### PR TITLE
feat(field): add `PowPFOp` to support prime field exponent 

### DIFF
--- a/tests/Dialect/Field/field_runner.mlir
+++ b/tests/Dialect/Field/field_runner.mlir
@@ -6,6 +6,7 @@
 #mont = #mod_arith.montgomery<7:i32>
 !PF = !field.pf<7:i32>
 !PFm = !field.pf<7:i32, true>
+!PF_exp = !field.pf<7:i64>
 
 #beta = #field.pf.elem<6:i32> : !PF
 #beta_mont = #field.pf.elem<3:i32> : !PFm
@@ -17,6 +18,7 @@ func.func private @printMemrefI32(memref<*xi32>) attributes { llvm.emit_c_interf
 
 func.func @test_power() {
   %exp = arith.constant 51 : i64
+  %exp_pf = field.encapsulate %exp : i64 -> !PF_exp
   %base = arith.constant 3 : i32
   %base_pf = field.encapsulate %base: i32 -> !PF
 
@@ -53,10 +55,27 @@ func.func @test_power() {
   %U4 = memref.cast %16 : memref<2xi32> to memref<*xi32>
   func.call @printMemrefI32(%U4) : (memref<*xi32>) -> ()
 
+  %res1_pf = field.powpf %base_pf, %exp_pf : !PF, !PF_exp
+  %17 = field.extract %res1_pf : !PF -> i32
+  %18 = tensor.from_elements %17 : tensor<1xi32>
+  %19 = bufferization.to_buffer %18 : tensor<1xi32> to memref<1xi32>
+  %U5 = memref.cast %19 : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U5) : (memref<*xi32>) -> ()
+
+  %res2_pf_mont = field.powpf %base_f2_mont, %exp_pf : !QFm, !PF_exp
+  %res2_pf_standard = field.from_mont %res2_pf_mont : !QF
+  %20, %21 = field.extract %res2_pf_standard : !QF -> i32, i32
+  %22 = tensor.from_elements %20, %21 : tensor<2xi32>
+  %23 = bufferization.to_buffer %22 : tensor<2xi32> to memref<2xi32>
+  %U6 = memref.cast %23 : memref<2xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U6) : (memref<*xi32>) -> ()
+
   return
 }
 
 // CHECK_TEST_POWER: [6]
 // CHECK_TEST_POWER: [6]
 // CHECK_TEST_POWER: [2, 5]
+// CHECK_TEST_POWER: [2, 5]
+// CHECK_TEST_POWER: [6]
 // CHECK_TEST_POWER: [2, 5]

--- a/zkir/Dialect/Field/IR/FieldOps.cpp
+++ b/zkir/Dialect/Field/IR/FieldOps.cpp
@@ -202,6 +202,7 @@ LogicalResult AddOp::verify() { return disallowShapedTypeOfExtField(*this); }
 LogicalResult SubOp::verify() { return disallowShapedTypeOfExtField(*this); }
 LogicalResult MulOp::verify() { return disallowShapedTypeOfExtField(*this); }
 LogicalResult PowUIOp::verify() { return disallowShapedTypeOfExtField(*this); }
+LogicalResult PowPFOp::verify() { return disallowShapedTypeOfExtField(*this); }
 LogicalResult InverseOp::verify() {
   return disallowShapedTypeOfExtField(*this);
 }

--- a/zkir/Dialect/Field/IR/FieldOps.td
+++ b/zkir/Dialect/Field/IR/FieldOps.td
@@ -308,7 +308,7 @@ def Field_MulOp : Field_BinaryOp<"mul", [Commutative]> {
   let hasCanonicalizer = 1;
 }
 
-// Field power.
+// Field power with unsigned integer exponent.
 def Field_PowUIOp : Field_Op<"powui", [TypesMatchWith<
   "base and output must have same type", "base", "output", "$_self">]> {
   let summary = "Field power with unsigned integer exponent";
@@ -321,6 +321,24 @@ def Field_PowUIOp : Field_Op<"powui", [TypesMatchWith<
     ```
   }];
   let arguments = (ins FieldLike:$base, SignlessIntegerLike:$exp);
+  let results = (outs FieldLike:$output);
+  let assemblyFormat = "operands attr-dict `:` type($base) `,` type($exp)";
+  let hasVerifier = 1;
+}
+
+// Field power with prime field exponent.
+def Field_PowPFOp : Field_Op<"powpf", [TypesMatchWith<
+  "base and output must have same type", "base", "output", "$_self">]> {
+  let summary = "Field power with prime field exponent";
+  let description = [{
+    Computes the field element a raised to the power of prime field b.
+
+    Example:
+    ```
+    %power = field.powpf %a, %b : field.pf<primeModulus>, field.pf<primeModulus>
+    ```
+  }];
+  let arguments = (ins FieldLike:$base, Field_PrimeFieldType:$exp);
   let results = (outs FieldLike:$output);
   let assemblyFormat = "operands attr-dict `:` type($base) `,` type($exp)";
   let hasVerifier = 1;


### PR DESCRIPTION
## Description

This PR introduces `PowPFOp` which can take prime field element as an exponent so that HLO power operation can handle both scalar field type and primitive unsigned integer type as an exponent. 

## Related Issues/PRs

- #61

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/zk-rabbit/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/zk-rabbit/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/zk-rabbit/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
