### PR TITLE
chore: remove unneeded Cpplint styling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,11 @@ repos:
       - id: cpplint
         args:
           # NOTE(chokobole): Disabled rules that conflict with LLVM style.
-          # -whitespace/comments, -whitespace/indent are explicitly disabled
+          # -build/include_what_you_use, -whitespace/comments,
+          # -whitespace/indent are explicitly disabled
           # because LLVM formatting is not compatible with Google style.
           - --filter=
+            -build/include_what_you_use,
             -build/namespaces,
             -legal/copyright,
             -runtime/references,


### PR DESCRIPTION
## Description

Previously, we were using the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html), but now we follow the [LLVM Coding Standard](https://llvm.org/docs/CodingStandards.html). The Cpplint rule `build/include_what_you_use` follows the Google C++ Style guide [preventing the use of transitive headers](https://google.github.io/styleguide/cppguide.html#Include_What_You_Use), yet the LLVM Coding Standard urges users to [#include as little as possible](https://llvm.org/docs/CodingStandards.html#id37). As such it has been removed from the Cpplint checks.

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/zk-rabbit/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/zk-rabbit/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/zk-rabbit/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
