### PR TITLE
ci: move common build options to `.bazelrc.ci` and use `--bazelrc`

### DIFF
--- a/.bazelrc.ci
+++ b/.bazelrc.ci
@@ -1,0 +1,2 @@
+build:ci --remote_cache=grpc://127.0.0.1:9092
+test:ci --test_output=errors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,15 @@ jobs:
 
       - name: Run `bazel build`
         run: |
-          bazel build --remote_cache=grpc://127.0.0.1:9092 --test_output=errors //...
+          bazel --bazelrc=.bazelrc.ci build \
+            --config ci \
+            //...
 
       - name: Run `bazel test`
         run: |
-          bazel test --config ci --remote_cache=grpc://127.0.0.1:9092 --test_output=errors //...
+          bazel --bazelrc=.bazelrc.ci test \
+            --config ci \
+            //...
 
   pre-commit-style:
     runs-on: [self-hosted, zkir]


### PR DESCRIPTION
## Description

CI builds previously duplicated options like `--remote_cache` and `--test_output` across every build step. Centralized these options into `.bazelrc.ci` and loaded them via `--bazelrc` to simplify maintenance and ensure consistency.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/zk-rabbit/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/zk-rabbit/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/zk-rabbit/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
