### PR TITLE
fix(elliptic_curve): support element-wise operations with proper type…

### DIFF
--- a/zkir/Dialect/EllipticCurve/IR/EllipticCurveOps.cpp
+++ b/zkir/Dialect/EllipticCurve/IR/EllipticCurveOps.cpp
@@ -109,6 +109,7 @@ LogicalResult IsZeroOp::verify() {
   return emitError() << "invalid input type";
 }
 
+namespace {
 template <typename OpType>
 LogicalResult verifyBinaryOp(OpType op) {
   Type lhsType = getElementTypeOrSelf(op.getLhs().getType());
@@ -134,6 +135,7 @@ LogicalResult verifyBinaryOp(OpType op) {
   // TODO(ashjeong): check the curves of given types are the same
   return op->emitError() << "input or output types are wrong";
 }
+} // namespace
 
 LogicalResult AddOp::verify() { return verifyBinaryOp(*this); }
 


### PR DESCRIPTION
## Description

Elementwise ops on elliptic curves failed verification because type checking did not handle shaped types correctly. Updated the verifier to use `getElementTypeOrSelf`, allowing `-convert-elementwise-to-linalg` to lower these ops as expected.

## Related Issues/PRs

#81

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/zk-rabbit/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/zk-rabbit/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/zk-rabbit/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
