### PR TITLE
feat: legalize `tensor::PadOp` and `tensor::YieldOp`

### DIFF
--- a/tests/Dialect/Field/tensor.mlir
+++ b/tests/Dialect/Field/tensor.mlir
@@ -92,6 +92,19 @@ func.func @test_tensor_insert_slice(%input : tensor<4x!PF>, %update : tensor<2x!
   return %insert_slice : tensor<4x!PF>
 }
 
+// CHECK-LABEL: @test_tensor_pad
+// CHECK-SAME: (%[[INPUT:.*]]: [[INPUT_TYPE:.*]]) -> [[T:.*]] {
+func.func @test_tensor_pad(%input : tensor<4x!PF>) -> tensor<6x!PF> {
+  %c0 = field.constant 0 : !PF
+  // CHECK: %[[PAD:.*]] = tensor.pad %[[INPUT]] low[1] high[1] {
+  %pad = tensor.pad %input low[1] high[1] {
+    ^bb0(%arg: index):
+      tensor.yield %c0 : !PF
+  } : tensor<4x!PF> to tensor<6x!PF>
+  // CHECK: return %[[PAD]] : [[T]]
+  return %pad : tensor<6x!PF>
+}
+
 // CHECK-LABEL: @test_tensor_reshape
 // CHECK-SAME: (%[[INPUT:.*]]: [[INPUT_TYPE:.*]], %[[SHAPE:.*]]: [[SHAPE_TYPE:.*]]) -> [[T:.*]] {
 func.func @test_tensor_reshape(%input : tensor<4x!PF>, %shape: tensor<2xi32>) -> tensor<2x2x!PF> {

--- a/tests/Dialect/ModArith/tensor.mlir
+++ b/tests/Dialect/ModArith/tensor.mlir
@@ -92,6 +92,19 @@ func.func @test_tensor_insert_slice(%input : tensor<4x!Zp>, %update : tensor<2x!
   return %insert_slice : tensor<4x!Zp>
 }
 
+// CHECK-LABEL: @test_tensor_pad
+// CHECK-SAME: (%[[INPUT:.*]]: [[INPUT_TYPE:.*]]) -> [[T:.*]] {
+func.func @test_tensor_pad(%input : tensor<4x!Zp>) -> tensor<6x!Zp> {
+  %c0 = mod_arith.constant 0 : !Zp
+  // CHECK: %[[PAD:.*]] = tensor.pad %[[INPUT]] low[1] high[1] {
+  %pad = tensor.pad %input low[1] high[1] {
+    ^bb0(%arg: index):
+      tensor.yield %c0 : !Zp
+  } : tensor<4x!Zp> to tensor<6x!Zp>
+  // CHECK: return %[[PAD]] : [[T]]
+  return %pad : tensor<6x!Zp>
+}
+
 // CHECK-LABEL: @test_tensor_reshape
 // CHECK-SAME: (%[[INPUT:.*]]: [[INPUT_TYPE:.*]], %[[SHAPE:.*]]: [[SHAPE_TYPE:.*]]) -> [[T:.*]] {
 func.func @test_tensor_reshape(%input : tensor<4x!Zp>, %shape: tensor<2xi32>) -> tensor<2x2x!Zp> {

--- a/zkir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
+++ b/zkir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
@@ -774,7 +774,9 @@ void FieldToModArith::runOnOperation() {
       ConvertAny<tensor::FromElementsOp>,
       ConvertAny<tensor::InsertOp>,
       ConvertAny<tensor::InsertSliceOp>,
+      ConvertAny<tensor::PadOp>,
       ConvertAny<tensor::ReshapeOp>,
+      ConvertAny<tensor::YieldOp>,
       ConvertAny<tensor_ext::BitReverseOp>
       // clang-format on
       >(typeConverter, context);
@@ -821,7 +823,9 @@ void FieldToModArith::runOnOperation() {
       tensor::FromElementsOp,
       tensor::InsertOp,
       tensor::InsertSliceOp,
+      tensor::PadOp,
       tensor::ReshapeOp,
+      tensor::YieldOp,
       tensor_ext::BitReverseOp
       // clang-format on
       >([&](auto op) { return typeConverter.isLegal(op); });

--- a/zkir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/zkir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -929,7 +929,9 @@ void ModArithToArith::runOnOperation() {
       ConvertAny<tensor::FromElementsOp>,
       ConvertAny<tensor::InsertOp>,
       ConvertAny<tensor::InsertSliceOp>,
+      ConvertAny<tensor::PadOp>,
       ConvertAny<tensor::ReshapeOp>,
+      ConvertAny<tensor::YieldOp>,
       ConvertAny<tensor_ext::BitReverseOp>
       // clang-format on
       >(typeConverter, context);
@@ -977,7 +979,9 @@ void ModArithToArith::runOnOperation() {
       tensor::FromElementsOp,
       tensor::InsertOp,
       tensor::InsertSliceOp,
+      tensor::PadOp,
       tensor::ReshapeOp,
+      tensor::YieldOp,
       tensor_ext::BitReverseOp
       // clang-format on
       >([&](auto op) { return typeConverter.isLegal(op); });


### PR DESCRIPTION
## Description

This PR legalizes `tensor::PadOp` and `tensor::YieldOp` for `mod_arith` and `field` dialects which is needed by zkx pad opcode.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/zk-rabbit/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/zk-rabbit/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/zk-rabbit/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
