### PR TITLE
docs: update README.md

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -170,6 +170,6 @@ ______________________________________________________________________
 
 [.clang-format]: /.clang-format
 [angular commit convention]: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
-[commit message guideline]: https://github.com/zk-rabbit/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md
+[commit message guideline]: https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md
 [llvm coding standard]: https://llvm.org/docs/CodingStandards.html
-[pull request guideline]: https://github.com/zk-rabbit/.github/blob/main/PULL_REQUEST_GUIDELINE.md
+[pull request guideline]: https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install cpplint
         run: pip install cpplint
 
-      # FIXME(ashjeong): clang-tidy currently fails on CI. See https://github.com/zk-rabbit/zkir/actions/runs/16904324348/job/47890440254 for more details.
+      # FIXME(ashjeong): clang-tidy currently fails on CI. See https://github.com/fractalyze/zkir/actions/runs/16904324348/job/47890440254 for more details.
       # - name: Refresh compile commands
       #   run: |
       #     bazel run --remote_cache=grpc://127.0.0.1:9092 @hedron_compile_commands//:refresh_all

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
             -whitespace/indent,
             -whitespace/indent_namespace
 
-  # FIXME(ashjeong): clang-tidy currently fails on CI. See https://github.com/zk-rabbit/zkir/actions/runs/16904324348/job/47890440254 for more details.
+  # FIXME(ashjeong): clang-tidy currently fails on CI. See https://github.com/fractalyze/zkir/actions/runs/16904324348/job/47890440254 for more details.
   # This hook now relies on a local shell script.
   # - repo: local
   #   hooks:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ performance and correctness across a wide range of devices.
 1. Clone the ZKIR repo
 
    ```sh
-   git clone https://github.com/zk-rabbit/zkir
+   git clone https://github.com/fractalyze/zkir
    ```
 
 1. Build ZKIR
@@ -153,4 +153,4 @@ for more details.
 
 We use GitHub Issues and Pull Requests to coordinate development, and
 longer-form discussions take place in the
-[zkir-discuss](https://github.com/zk-rabbit/zkir/discussions).
+[zkir-discuss](https://github.com/fractalyze/zkir/discussions).


### PR DESCRIPTION
## Description

Revised documentation to clarify that StableHLO serves as the frontend of ZKX, while ZKIR defines ZK-specific semantics.

- Removed “Why not use LLVM IR”.
- Improved the “Vision” section with a clearer visualization of ZKIR’s current operation coverage instead of a vague subset description.
- Performed minor tone and phrasing refinements across the document.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/zk-rabbit/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/zk-rabbit/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/zk-rabbit/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
