### PR TITLE
chore: add license & missing license notices to source files

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
 # Copyright 2023 The StableHLO Authors. All Rights Reserved.
+# Copyright 2025 The ZKIR Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.bazelversion
+++ b/.bazelversion
@@ -1,14 +1,1 @@
 7.0.2
-# Copyright 2023 The StableHLO Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 config_setting(
     name = "linux_x86_64",
     constraint_values = [

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,4 +1,5 @@
 # Copyright 2023 The StableHLO Authors. All Rights Reserved.
+# Copyright 2025 The ZKIR Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 # Helper files for setting up the bazel workspace
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")

--- a/bazel/lit.bzl
+++ b/bazel/lit.bzl
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 """Macros for defining lit tests."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")

--- a/bazel/zkir_deps.bzl
+++ b/bazel/zkir_deps.bzl
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 """
 This module configures dependencies for the ZKIR project.
 """

--- a/benchmark/BUILD.bazel
+++ b/benchmark/BUILD.bazel
@@ -1,8 +1,22 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(
     default_visibility = ["//visibility:public"],
-    licenses = ["notice"],
 )
 
 cc_library(

--- a/benchmark/BenchmarkUtils.h
+++ b/benchmark/BenchmarkUtils.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef BENCHMARK_BENCHMARKUTILS_H_
 #define BENCHMARK_BENCHMARKUTILS_H_
 

--- a/benchmark/benchmark.bzl
+++ b/benchmark/benchmark.bzl
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 """A rule for running ZKIR benchmark"""
 
 load("@rules_cc//cc:defs.bzl", "cc_import", "cc_test")

--- a/benchmark/gpu/msm/BUILD.bazel
+++ b/benchmark/gpu/msm/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@rules_cuda//cuda:defs.bzl", "requires_cuda")
 load("//benchmark:benchmark.bzl", "zkir_benchmark", "zkir_mlir_cc_import")
 

--- a/benchmark/gpu/msm/msm_benchmark.cc
+++ b/benchmark/gpu/msm/msm_benchmark.cc
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include <climits>
 #include <random>
 

--- a/benchmark/gpu/msm/msm_cpu.mlir
+++ b/benchmark/gpu/msm/msm_cpu.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 !PFm = !field.pf<21888242871839275222246405745257275088696311157297823662689037894645226208583:i256, true>
 !SFm = !field.pf<21888242871839275222246405745257275088548364400416034343698204186575808495617:i256, true>
 

--- a/benchmark/gpu/msm/msm_gpu.mlir
+++ b/benchmark/gpu/msm/msm_gpu.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 !PFm = !field.pf<21888242871839275222246405745257275088696311157297823662689037894645226208583:i256, true>
 !SFm = !field.pf<21888242871839275222246405745257275088548364400416034343698204186575808495617:i256, true>
 

--- a/benchmark/gpu/ntt/BUILD.bazel
+++ b/benchmark/gpu/ntt/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@rules_cuda//cuda:defs.bzl", "requires_cuda")
 load("//benchmark:benchmark.bzl", "zkir_benchmark", "zkir_mlir_cc_import")
 

--- a/benchmark/gpu/ntt/ntt_benchmark.cc
+++ b/benchmark/gpu/ntt/ntt_benchmark.cc
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include <climits>
 #include <cstring>
 #include <random>

--- a/benchmark/gpu/ntt/ntt_cpu.mlir
+++ b/benchmark/gpu/ntt/ntt_cpu.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 !PF = !field.pf<21888242871839275222246405745257275088548364400416034343698204186575808495617 : i256>
 !PFm = !field.pf<21888242871839275222246405745257275088548364400416034343698204186575808495617 : i256, true>
 

--- a/benchmark/gpu/ntt/ntt_gpu.mlir
+++ b/benchmark/gpu/ntt/ntt_gpu.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 !PF = !field.pf<21888242871839275222246405745257275088548364400416034343698204186575808495617 : i256>
 !PFm = !field.pf<21888242871839275222246405745257275088548364400416034343698204186575808495617 : i256, true>
 

--- a/benchmark/gpu/vecops/BUILD.bazel
+++ b/benchmark/gpu/vecops/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@rules_cuda//cuda:defs.bzl", "requires_cuda")
 load("//benchmark:benchmark.bzl", "zkir_benchmark", "zkir_mlir_cc_import")
 

--- a/benchmark/gpu/vecops/vecops_benchmark.cc
+++ b/benchmark/gpu/vecops/vecops_benchmark.cc
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include <climits>
 #include <cstring>
 #include <random>

--- a/benchmark/gpu/vecops/vecops_cpu.mlir
+++ b/benchmark/gpu/vecops/vecops_cpu.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 !PF = !field.pf<9223372036836950017 : i64>
 
 func.func @matvec_cpu(%arg0: memref<1048576x100x!PF>, %arg1: memref<100x!PF>, %arg2: memref<1048576x!PF>) attributes {llvm.emit_c_interface}  {

--- a/benchmark/gpu/vecops/vecops_gpu.mlir
+++ b/benchmark/gpu/vecops/vecops_gpu.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 !PF = !field.pf<9223372036836950017 : i64>
 
 func.func @matvec_gpu(%arg0: memref<1048576x100x!PF>, %arg1: memref<100x!PF>, %arg2: memref<1048576x!PF>) attributes {llvm.emit_c_interface}  {

--- a/benchmark/mod_arith/BUILD.bazel
+++ b/benchmark/mod_arith/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("//benchmark:benchmark.bzl", "zkir_benchmark", "zkir_mlir_cc_import")
 
 zkir_mlir_cc_import(

--- a/benchmark/mod_arith/mul_benchmark.mlir
+++ b/benchmark/mod_arith/mul_benchmark.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 !mod = !mod_arith.int<21888242871839275222246405745257275088548364400416034343698204186575808495617 : i256>
 !modm = !mod_arith.int<21888242871839275222246405745257275088548364400416034343698204186575808495617 : i256, true>
 

--- a/benchmark/mod_arith/mul_benchmark_test.cc
+++ b/benchmark/mod_arith/mul_benchmark_test.cc
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "benchmark/BenchmarkUtils.h"
 #include "benchmark/benchmark.h"
 #include "mlir/ExecutionEngine/MemRefUtils.h"

--- a/benchmark/msm/BUILD.bazel
+++ b/benchmark/msm/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("//benchmark:benchmark.bzl", "zkir_benchmark", "zkir_mlir_cc_import")
 
 zkir_mlir_cc_import(

--- a/benchmark/msm/msm_benchmark.mlir
+++ b/benchmark/msm/msm_benchmark.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 !PFm = !field.pf<21888242871839275222246405745257275088696311157297823662689037894645226208583:i256, true>
 !SFm = !field.pf<21888242871839275222246405745257275088548364400416034343698204186575808495617:i256, true>
 

--- a/benchmark/msm/msm_benchmark_test.cc
+++ b/benchmark/msm/msm_benchmark_test.cc
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include <climits>
 #include <random>
 

--- a/benchmark/ntt/BUILD.bazel
+++ b/benchmark/ntt/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("//benchmark:benchmark.bzl", "zkir_benchmark", "zkir_mlir_cc_import")
 
 zkir_mlir_cc_import(

--- a/benchmark/ntt/ntt_benchmark.mlir
+++ b/benchmark/ntt/ntt_benchmark.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 !coeff_ty = !field.pf<21888242871839275222246405745257275088548364400416034343698204186575808495617 : i256>
 !coefft_ty = tensor<1048576x!coeff_ty>
 !memref_ty = memref<1048576x!coeff_ty>

--- a/benchmark/ntt/ntt_benchmark_test.cc
+++ b/benchmark/ntt/ntt_benchmark_test.cc
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include <climits>
 #include <random>
 

--- a/benchmark/poseidon2/BUILD.bazel
+++ b/benchmark/poseidon2/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("//benchmark:benchmark.bzl", "zkir_benchmark", "zkir_mlir_cc_import")
 
 zkir_mlir_cc_import(

--- a/benchmark/poseidon2/poseidon2.mlir
+++ b/benchmark/poseidon2/poseidon2.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // Poseidon2 utility functions for BabyBear field
 // Based on Plonky3 implementation: https://github.com/Plonky3/Plonky3
 

--- a/benchmark/poseidon2/poseidon2_benchmark.cc
+++ b/benchmark/poseidon2/poseidon2_benchmark.cc
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "benchmark/benchmark.h"
 #include "mlir/ExecutionEngine/MemRefUtils.h"
 #include "mlir/Support/LLVM.h"

--- a/benchmark/poseidon2/poseidon2_packed.mlir
+++ b/benchmark/poseidon2/poseidon2_packed.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // Poseidon2 utility functions for BabyBear field
 // Based on Plonky3 implementation: https://github.com/Plonky3/Plonky3
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,10 +1,24 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@rules_cuda//cuda:defs.bzl", "requires_cuda")
 load("//bazel:lit.bzl", "glob_lit_tests")
 
 package(
     default_visibility = ["//visibility:public"],
-    licenses = ["notice"],
 )
 
 cc_binary(

--- a/tests/Dialect/ArithExt/BUILD.bazel
+++ b/tests/Dialect/ArithExt/BUILD.bazel
@@ -1,8 +1,19 @@
-load("//bazel:lit.bzl", "glob_lit_tests")
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 
-package(
-    licenses = ["notice"],
-)
+load("//bazel:lit.bzl", "glob_lit_tests")
 
 glob_lit_tests(
     name = "all_tests",

--- a/tests/Dialect/ArithExt/packed_arith_runner.mlir
+++ b/tests/Dialect/ArithExt/packed_arith_runner.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt %s -specialize-arith-to-avx | FileCheck %s --check-prefix=CHECK-LOWERING
 
 // RUN: zkir-opt %s -specialize-arith-to-avx -convert-to-llvm \

--- a/tests/Dialect/EllipticCurve/BUILD.bazel
+++ b/tests/Dialect/EllipticCurve/BUILD.bazel
@@ -1,9 +1,20 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@rules_cuda//cuda:defs.bzl", "requires_cuda")
 load("//bazel:lit.bzl", "glob_lit_tests", "run_lit_tests")
-
-package(
-    licenses = ["notice"],
-)
 
 GPU_TESTS = [
     "bucket_acc_runner.mlir",

--- a/tests/Dialect/EllipticCurve/bucket_acc_runner.mlir
+++ b/tests/Dialect/EllipticCurve/bucket_acc_runner.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: cat %S/../../default_print_utils.mlir %S/../../bn254_field_defs.mlir %S/../../bn254_ec_mont_defs.mlir %S/../../bn254_ec_mont_utils.mlir %s \
 // RUN:   | zkir-opt -elliptic-curve-to-field -field-to-llvm \
 // RUN:   | mlir-runner -e test_bucket_acc -entry-point-result=void \

--- a/tests/Dialect/EllipticCurve/bucket_reduce_runner.mlir
+++ b/tests/Dialect/EllipticCurve/bucket_reduce_runner.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: cat %S/../../default_print_utils.mlir %S/../../bn254_field_defs.mlir %S/../../bn254_ec_mont_defs.mlir %S/../../bn254_ec_mont_utils.mlir %s \
 // RUN:   | zkir-opt -elliptic-curve-to-field -field-to-llvm \
 // RUN:   | mlir-runner -e test_bucket_reduce -entry-point-result=void \

--- a/tests/Dialect/EllipticCurve/canonicalize.mlir
+++ b/tests/Dialect/EllipticCurve/canonicalize.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: cat %S/../../bn254_field_defs.mlir %S/../../bn254_ec_defs.mlir %s \
 // RUN:   | zkir-opt -elliptic-curve-to-field -field-to-mod-arith -canonicalize \
 // RUN:   | FileCheck %s -enable-var-scope

--- a/tests/Dialect/EllipticCurve/elliptic_curve_msm_runner.mlir
+++ b/tests/Dialect/EllipticCurve/elliptic_curve_msm_runner.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: cat %S/../../default_print_utils.mlir %S/../../bn254_field_defs.mlir %S/../../bn254_ec_mont_defs.mlir %S/../../bn254_ec_mont_utils.mlir %s \
 // RUN:   | zkir-opt -elliptic-curve-to-field -field-to-llvm \
 // RUN:   | mlir-runner -e test_msm -entry-point-result=void \

--- a/tests/Dialect/EllipticCurve/elliptic_curve_to_field.mlir
+++ b/tests/Dialect/EllipticCurve/elliptic_curve_to_field.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: cat %S/../../bn254_field_defs.mlir %S/../../bn254_ec_mont_defs.mlir %s \
 // RUN:   | zkir-opt -elliptic-curve-to-field -split-input-file \
 // RUN:   | FileCheck %s -enable-var-scope

--- a/tests/Dialect/EllipticCurve/elliptic_curve_to_field_runner.mlir
+++ b/tests/Dialect/EllipticCurve/elliptic_curve_to_field_runner.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: cat %S/../../default_print_utils.mlir %S/../../bn254_field_defs.mlir %S/../../bn254_ec_mont_defs.mlir %S/../../bn254_ec_mont_utils.mlir %s \
 // RUN:   | zkir-opt -elliptic-curve-to-field -field-to-llvm \
 // RUN:   | mlir-runner -e test_ops_in_order -entry-point-result=void \

--- a/tests/Dialect/EllipticCurve/elliptic_curve_to_llvm.mlir
+++ b/tests/Dialect/EllipticCurve/elliptic_curve_to_llvm.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: cat %S/../../bn254_field_defs.mlir %S/../../bn254_ec_mont_defs.mlir %s \
 // RUN:   | zkir-opt -convert-to-llvm -split-input-file \
 // RUN:   | FileCheck %s -enable-var-scope

--- a/tests/Dialect/EllipticCurve/linalg.mlir
+++ b/tests/Dialect/EllipticCurve/linalg.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: cat %S/../../bn254_field_defs.mlir %S/../../bn254_ec_mont_defs.mlir %s \
 // RUN:   | zkir-opt -linalg-generalize-named-ops -split-input-file \
 // RUN:   | FileCheck %s -enable-var-scope

--- a/tests/Dialect/EllipticCurve/scalar_decomp_runner.mlir
+++ b/tests/Dialect/EllipticCurve/scalar_decomp_runner.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: cat %S/../../default_print_utils.mlir %S/../../bn254_field_defs.mlir %S/../../bn254_ec_mont_defs.mlir %S/../../bn254_ec_mont_utils.mlir %s \
 // RUN:   | zkir-opt -elliptic-curve-to-field -field-to-llvm \
 // RUN:   | mlir-runner -e test_scalar_decomp -entry-point-result=void \

--- a/tests/Dialect/EllipticCurve/sparse_tensor_runner.mlir
+++ b/tests/Dialect/EllipticCurve/sparse_tensor_runner.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: cat %S/../../default_print_utils.mlir %S/../../bn254_field_defs.mlir %S/../../bn254_ec_mont_defs.mlir %S/../../bn254_ec_mont_utils.mlir %s \
 // RUN:   | zkir-opt -convert-elementwise-to-linalg -sparsification-and-bufferization -elliptic-curve-to-field -field-to-llvm \
 // RUN:   | mlir-runner -e test_bucket_acc_csr -entry-point-result=void \

--- a/tests/Dialect/EllipticCurve/window_reduce_runner.mlir
+++ b/tests/Dialect/EllipticCurve/window_reduce_runner.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: cat %S/../../default_print_utils.mlir %S/../../bn254_field_defs.mlir %S/../../bn254_ec_mont_defs.mlir %S/../../bn254_ec_mont_utils.mlir %s \
 // RUN:   | zkir-opt -elliptic-curve-to-field -field-to-llvm \
 // RUN:   | mlir-runner -e test_window_reduce -entry-point-result=void \

--- a/tests/Dialect/Field/BUILD.bazel
+++ b/tests/Dialect/Field/BUILD.bazel
@@ -1,8 +1,19 @@
-load("//bazel:lit.bzl", "glob_lit_tests")
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 
-package(
-    licenses = ["notice"],
-)
+load("//bazel:lit.bzl", "glob_lit_tests")
 
 glob_lit_tests(
     name = "all_tests",

--- a/tests/Dialect/Field/affine.mlir
+++ b/tests/Dialect/Field/affine.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -field-to-mod-arith %s | FileCheck %s -enable-var-scope
 
 !PF = !field.pf<7:i32, true>

--- a/tests/Dialect/Field/bufferization.mlir
+++ b/tests/Dialect/Field/bufferization.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -field-to-mod-arith %s | FileCheck %s -enable-var-scope
 
 !PF = !field.pf<7:i32, true>

--- a/tests/Dialect/Field/canonicalize.mlir
+++ b/tests/Dialect/Field/canonicalize.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -field-to-mod-arith -canonicalize %s | FileCheck %s -enable-var-scope
 
 !PF = !field.pf<7:i32>

--- a/tests/Dialect/Field/ext_field_to_llvm.mlir
+++ b/tests/Dialect/Field/ext_field_to_llvm.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: cat %S/../../bn254_field_defs.mlir %S/../../bn254_ec_mont_defs.mlir %s \
 // RUN:   | zkir-opt -convert-to-llvm -split-input-file \
 // RUN:   | FileCheck %s -enable-var-scope

--- a/tests/Dialect/Field/field_canonicalization.mlir
+++ b/tests/Dialect/Field/field_canonicalization.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -canonicalize -field-to-mod-arith -mod-arith-to-arith -canonicalize %s | FileCheck %s -enable-var-scope
 
 !PF17 = !field.pf<17:i32>

--- a/tests/Dialect/Field/field_runner.mlir
+++ b/tests/Dialect/Field/field_runner.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt %s --field-to-llvm \
 // RUN:   | mlir-runner -e test_power -entry-point-result=void \
 // RUN:      --shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t

--- a/tests/Dialect/Field/field_to_gpu.mlir
+++ b/tests/Dialect/Field/field_to_gpu.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt %s -field-to-gpu="bufferize-function-boundaries target-format=llvm nvvm-use-bare-ptr-call-conv" | FileCheck %s
 
 !PF = !field.pf<21888242871839275222246405745257275088696311157297823662689037894645226208583:i256, true>

--- a/tests/Dialect/Field/linalg.mlir
+++ b/tests/Dialect/Field/linalg.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -field-to-mod-arith %s | FileCheck %s -enable-var-scope
 
 !PF = !field.pf<7:i32, true>

--- a/tests/Dialect/Field/memref.mlir
+++ b/tests/Dialect/Field/memref.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -field-to-mod-arith %s | FileCheck %s -enable-var-scope
 
 !PF = !field.pf<7:i32, true>

--- a/tests/Dialect/Field/poseidon2_unit_tests.mlir
+++ b/tests/Dialect/Field/poseidon2_unit_tests.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: cat %S/../../poseidon2.mlir %S/../../poseidon2_packed.mlir %s \
 // RUN:   | zkir-opt --field-to-llvm=bufferize-function-boundaries -convert-vector-to-llvm \
 // RUN:   | mlir-runner -e main -entry-point-result=void \

--- a/tests/Dialect/Field/prime_field_to_mod_arith.mlir
+++ b/tests/Dialect/Field/prime_field_to_mod_arith.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -field-to-mod-arith -split-input-file %s | FileCheck %s -enable-var-scope
 !PF1 = !field.pf<97:i32>
 !PF1m = !field.pf<97:i32, true>

--- a/tests/Dialect/Field/quadratic_ext_field_to_mod_arith.mlir
+++ b/tests/Dialect/Field/quadratic_ext_field_to_mod_arith.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -field-to-mod-arith -split-input-file %s | FileCheck %s -enable-var-scope
 #mont = #mod_arith.montgomery<7:i32>
 !PF = !field.pf<7:i32>

--- a/tests/Dialect/Field/sparse_tensor.mlir
+++ b/tests/Dialect/Field/sparse_tensor.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -sparsification-and-bufferization -split-input-file %s | FileCheck %s -enable-var-scope
 
 !PF = !field.pf<7:i32, true>

--- a/tests/Dialect/Field/tensor.mlir
+++ b/tests/Dialect/Field/tensor.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -field-to-mod-arith %s | FileCheck %s -enable-var-scope
 
 !PF = !field.pf<7:i32, true>

--- a/tests/Dialect/Field/vector.mlir
+++ b/tests/Dialect/Field/vector.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -field-to-mod-arith %s | FileCheck %s -enable-var-scope
 
 !PF = !field.pf<7:i32, true>

--- a/tests/Dialect/ModArith/BUILD.bazel
+++ b/tests/Dialect/ModArith/BUILD.bazel
@@ -1,8 +1,19 @@
-load("//bazel:lit.bzl", "glob_lit_tests")
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 
-package(
-    licenses = ["notice"],
-)
+load("//bazel:lit.bzl", "glob_lit_tests")
 
 glob_lit_tests(
     name = "all_tests",

--- a/tests/Dialect/ModArith/affine.mlir
+++ b/tests/Dialect/ModArith/affine.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -mod-arith-to-arith %s | FileCheck %s -enable-var-scope
 
 !Zp = !mod_arith.int<65537 : i32>

--- a/tests/Dialect/ModArith/bufferization.mlir
+++ b/tests/Dialect/ModArith/bufferization.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -mod-arith-to-arith %s | FileCheck %s -enable-var-scope
 
 !Zp = !mod_arith.int<65537 : i32>

--- a/tests/Dialect/ModArith/canonicalize.mlir
+++ b/tests/Dialect/ModArith/canonicalize.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -canonicalize %s | FileCheck %s
 
 !Zp = !mod_arith.int<37 : i32>

--- a/tests/Dialect/ModArith/linalg.mlir
+++ b/tests/Dialect/ModArith/linalg.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -mod-arith-to-arith %s | FileCheck %s -enable-var-scope
 
 !Zp = !mod_arith.int<65537 : i32>

--- a/tests/Dialect/ModArith/memref.mlir
+++ b/tests/Dialect/ModArith/memref.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -mod-arith-to-arith %s | FileCheck %s -enable-var-scope
 
 !Zp = !mod_arith.int<65537 : i32>

--- a/tests/Dialect/ModArith/mod_arith_bn254.mlir
+++ b/tests/Dialect/ModArith/mod_arith_bn254.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -mod-arith-to-arith -sccp -split-input-file %s | FileCheck %s -enable-var-scope
 
 !Zp = !mod_arith.int<21888242871839275222246405745257275088696311157297823662689037894645226208583 : i256>

--- a/tests/Dialect/ModArith/mod_arith_runner.mlir
+++ b/tests/Dialect/ModArith/mod_arith_runner.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt %s -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
 // RUN:   | mlir-runner -e test_lower_inverse -entry-point-result=void \
 // RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t

--- a/tests/Dialect/ModArith/mod_arith_to_arith.mlir
+++ b/tests/Dialect/ModArith/mod_arith_to_arith.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -mod-arith-to-arith -split-input-file %s | FileCheck %s -enable-var-scope
 
 !Zp = !mod_arith.int<65537 : i32>

--- a/tests/Dialect/ModArith/mul_by_inv_two_pow.mlir
+++ b/tests/Dialect/ModArith/mul_by_inv_two_pow.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -canonicalize -mod-arith-to-arith  -split-input-file %s | FileCheck %s --check-prefix=CHECK-LOWERING
 
 // RUN: zkir-opt %s -canonicalize -mod-arith-to-arith -convert-to-llvm \

--- a/tests/Dialect/ModArith/sparse_tensor.mlir
+++ b/tests/Dialect/ModArith/sparse_tensor.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -sparsification-and-bufferization -split-input-file %s | FileCheck %s -enable-var-scope
 
 !Zp = !mod_arith.int<65537 : i32>

--- a/tests/Dialect/ModArith/tensor.mlir
+++ b/tests/Dialect/ModArith/tensor.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -mod-arith-to-arith %s | FileCheck %s -enable-var-scope
 
 !Zp = !mod_arith.int<65537 : i32>

--- a/tests/Dialect/ModArith/vector.mlir
+++ b/tests/Dialect/ModArith/vector.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -mod-arith-to-arith %s | FileCheck %s -enable-var-scope
 
 !mod = !mod_arith.int<7:i32, true>

--- a/tests/Dialect/Poly/BUILD.bazel
+++ b/tests/Dialect/Poly/BUILD.bazel
@@ -1,8 +1,19 @@
-load("//bazel:lit.bzl", "glob_lit_tests")
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 
-package(
-    licenses = ["notice"],
-)
+load("//bazel:lit.bzl", "glob_lit_tests")
 
 glob_lit_tests(
     name = "all_tests",

--- a/tests/Dialect/Poly/bufferization.mlir
+++ b/tests/Dialect/Poly/bufferization.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -poly-to-field %s | FileCheck %s -enable-var-scope
 
 !PF = !field.pf<7:i32, true>

--- a/tests/Dialect/Poly/ntt_bufferization.mlir
+++ b/tests/Dialect/Poly/ntt_bufferization.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt %s -poly-to-field -field-to-mod-arith -mod-arith-to-arith -tensor-ext-to-tensor \
 // RUN:    -one-shot-bufferize="bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" -canonicalize | FileCheck %s
 

--- a/tests/Dialect/Poly/ntt_to_gpu.mlir
+++ b/tests/Dialect/Poly/ntt_to_gpu.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt %s -poly-to-field -field-to-gpu="bufferize-function-boundaries parallelize-affine target-format=llvm nvvm-use-bare-ptr-call-conv" | FileCheck %s
 
 !PF = !field.pf<7681:i32>

--- a/tests/Dialect/Poly/poly_canonicalization.mlir
+++ b/tests/Dialect/Poly/poly_canonicalization.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt %s -canonicalize | FileCheck %s
 
 !coeff_ty = !field.pf<7681:i32>

--- a/tests/Dialect/Poly/poly_ntt_runner.mlir
+++ b/tests/Dialect/Poly/poly_ntt_runner.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt %s -poly-to-field -field-to-llvm \
 // RUN:   | mlir-runner -e test_poly_ntt -entry-point-result=void \
 // RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t

--- a/tests/Dialect/Poly/poly_syntax.mlir
+++ b/tests/Dialect/Poly/poly_syntax.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -split-input-file %s | FileCheck %s -enable-var-scope
 
 !PF1 = !field.pf<7:i32>

--- a/tests/Dialect/Poly/poly_to_field.mlir
+++ b/tests/Dialect/Poly/poly_to_field.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -poly-to-field -split-input-file %s | FileCheck %s -enable-var-scope
 
 !PF1 = !field.pf<7:i255>

--- a/tests/Dialect/TensorExt/BUILD.bazel
+++ b/tests/Dialect/TensorExt/BUILD.bazel
@@ -1,8 +1,19 @@
-load("//bazel:lit.bzl", "glob_lit_tests")
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 
-package(
-    licenses = ["notice"],
-)
+load("//bazel:lit.bzl", "glob_lit_tests")
 
 glob_lit_tests(
     name = "all_tests",

--- a/tests/Dialect/TensorExt/tensor_ext_canonicalization.mlir
+++ b/tests/Dialect/TensorExt/tensor_ext_canonicalization.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: zkir-opt -canonicalize %s | FileCheck %s -enable-var-scope
 
 // CHECK-LABEL: @test_constant_folding

--- a/tests/Utils/sort_pairs_runner.mlir
+++ b/tests/Utils/sort_pairs_runner.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 // RUN: cat %S/../default_print_utils.mlir %s \
 // RUN:   | zkir-opt -field-to-gpu=parallelize-affine \
 // RUN:   | mlir-runner -e testSortPairs -entry-point-result=void \

--- a/tests/bn254_ec_defs.mlir
+++ b/tests/bn254_ec_defs.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 #a = #field.pf.elem<0:i256> : !PF
 #b = #field.pf.elem<3:i256> : !PF
 #1 = #field.pf.elem<1:i256> : !PF

--- a/tests/bn254_ec_mont_defs.mlir
+++ b/tests/bn254_ec_mont_defs.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 #a = #field.pf.elem<0:i256> : !PFm
 #b = #field.pf.elem<3:i256> : !PFm
 #1 = #field.pf.elem<1:i256> : !PFm

--- a/tests/bn254_ec_mont_utils.mlir
+++ b/tests/bn254_ec_mont_utils.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 func.func @printAffine(%affine: !affine) {
   %x, %y = elliptic_curve.extract %affine : !affine -> !PFm, !PFm
   %point = tensor.from_elements %x, %y : tensor<2x!PFm>

--- a/tests/bn254_ec_utils.mlir
+++ b/tests/bn254_ec_utils.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 func.func @printAffine(%affine: !affine) {
   %x, %y = elliptic_curve.extract %affine : !affine -> !PF, !PF
   %point = tensor.from_elements %x, %y : tensor<2x!PF>

--- a/tests/bn254_field_defs.mlir
+++ b/tests/bn254_field_defs.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 !PF = !field.pf<21888242871839275222246405745257275088696311157297823662689037894645226208583:i256>
 !SF = !field.pf<21888242871839275222246405745257275088548364400416034343698204186575808495617:i256>
 !PFm = !field.pf<21888242871839275222246405745257275088696311157297823662689037894645226208583:i256, true>

--- a/tests/default_print_utils.mlir
+++ b/tests/default_print_utils.mlir
@@ -1,3 +1,18 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
 func.func private @printMemrefI32(memref<*xi32>) attributes { llvm.emit_c_interface }
 func.func private @printMemrefI64(memref<*xi64>) attributes { llvm.emit_c_interface }
 func.func private @printMemrefI256(memref<*xi256>) attributes { llvm.emit_c_interface }

--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 import os
 from pathlib import Path
 

--- a/tests/printI256.cpp
+++ b/tests/printI256.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include <ostream>
 #include <string>
 

--- a/third_party/omp/omp.BUILD
+++ b/third_party/omp/omp.BUILD
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/omp/omp_configure.bzl
+++ b/third_party/omp/omp_configure.bzl
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 """
 This module configures OpenMP for use with Bazel.
 """

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 
 package(

--- a/tools/tools.bzl
+++ b/tools/tools.bzl
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 """A rule for running zkir-opt."""
 
 def executable_attr(label):

--- a/tools/zkir-lsp.cpp
+++ b/tools/zkir-lsp.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllExtensions.h"
 #include "mlir/InitAllPasses.h"

--- a/tools/zkir-opt.cpp
+++ b/tools/zkir-opt.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "llvm/Support/LogicalResult.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllExtensions.h"

--- a/utils/cuda/BUILD.bazel
+++ b/utils/cuda/BUILD.bazel
@@ -1,9 +1,23 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@rules_cuda//cuda:defs.bzl", "requires_cuda")
 
 package(
     default_visibility = ["//visibility:public"],
-    licenses = ["notice"],
 )
 
 cc_binary(

--- a/utils/cuda/CudaRuntimeUtils.cu
+++ b/utils/cuda/CudaRuntimeUtils.cu
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 // clang-format off
 #include <cub/device/device_radix_sort.cuh>
 // clang-format on

--- a/utils/cuda/CudaUtils.h
+++ b/utils/cuda/CudaUtils.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef UTILS_CUDA_CUDAUTILS_H_
 #define UTILS_CUDA_CUDAUTILS_H_
 

--- a/zkir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/BUILD.bazel
+++ b/zkir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 

--- a/zkir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/SpecializeArithToAVX.cpp
+++ b/zkir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/SpecializeArithToAVX.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/SpecializeArithToAVX.h"
 
 #include <optional>

--- a/zkir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/SpecializeArithToAVX.h
+++ b/zkir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/SpecializeArithToAVX.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ARITHEXT_CONVERSIONS_SPECIALIZEARITHTOAVX_SPECIALIZEARITHTOAVX_H_
 #define ZKIR_DIALECT_ARITHEXT_CONVERSIONS_SPECIALIZEARITHTOAVX_SPECIALIZEARITHTOAVX_H_
 

--- a/zkir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/SpecializeArithToAVX.td
+++ b/zkir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/SpecializeArithToAVX.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ARITHEXT_CONVERSIONS_SPECIALIZEARITHTOAVX_SPECIALIZEARITHTOAVX_TD_
 #define ZKIR_DIALECT_ARITHEXT_CONVERSIONS_SPECIALIZEARITHTOAVX_SPECIALIZEARITHTOAVX_TD_
 

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/BUILD.bazel
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.h"
 
 #include <utility>

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.h
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICCURVE_CONVERSIONS_ELLIPTICCURVETOFIELD_ELLIPTICCURVETOFIELD_H_
 #define ZKIR_DIALECT_ELLIPTICCURVE_CONVERSIONS_ELLIPTICCURVETOFIELD_ELLIPTICCURVETOFIELD_H_
 

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.td
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICURVE_CONVERSIONS_ELLIPTICCURVETOFIELD_ELLIPTICCURVETOFIELD_TD_
 #define ZKIR_DIALECT_ELLIPTICURVE_CONVERSIONS_ELLIPTICCURVETOFIELD_ELLIPTICCURVETOFIELD_TD_
 

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/BUILD.bazel
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/Generic.cpp
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/Generic.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/Generic.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/Generic.h
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/Generic.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICCURVE_CONVERSIONS_ELLIPTICCURVETOFIELD_MSM_PIPPENGERS_GENERIC_H_
 #define ZKIR_DIALECT_ELLIPTICCURVE_CONVERSIONS_ELLIPTICCURVETOFIELD_MSM_PIPPENGERS_GENERIC_H_
 

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/Pippengers.cpp
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/Pippengers.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/Pippengers.h"
 
 #include <cmath>

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/Pippengers.h
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/Pippengers.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICCURVE_CONVERSIONS_ELLIPTICCURVETOFIELD_MSM_PIPPENGERS_PIPPENGERS_H_
 #define ZKIR_DIALECT_ELLIPTICCURVE_CONVERSIONS_ELLIPTICCURVETOFIELD_MSM_PIPPENGERS_PIPPENGERS_H_
 

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/Jacobian/Add.cpp
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/Jacobian/Add.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/Jacobian/Add.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/Jacobian/Add.h
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/Jacobian/Add.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICCURVE_CONVERSIONS_ELLIPTICCURVETOFIELD_POINTOPERATIONS_JACOBIAN_ADD_H_
 #define ZKIR_DIALECT_ELLIPTICCURVE_CONVERSIONS_ELLIPTICCURVETOFIELD_POINTOPERATIONS_JACOBIAN_ADD_H_
 

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/Jacobian/BUILD.bazel
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/Jacobian/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/Jacobian/Double.cpp
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/Jacobian/Double.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/Jacobian/Double.h"
 
 #include "zkir/Dialect/Field/IR/FieldOps.h"

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/Jacobian/Double.h
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/Jacobian/Double.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICCURVE_CONVERSIONS_ELLIPTICCURVETOFIELD_POINTOPERATIONS_JACOBIAN_DOUBLE_H_
 #define ZKIR_DIALECT_ELLIPTICCURVE_CONVERSIONS_ELLIPTICCURVETOFIELD_POINTOPERATIONS_JACOBIAN_DOUBLE_H_
 

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/XYZZ/Add.cpp
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/XYZZ/Add.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/XYZZ/Add.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/XYZZ/Add.h
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/XYZZ/Add.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICCURVE_CONVERSIONS_ELLIPTICCURVETOFIELD_POINTOPERATIONS_XYZZ_ADD_H_
 #define ZKIR_DIALECT_ELLIPTICCURVE_CONVERSIONS_ELLIPTICCURVETOFIELD_POINTOPERATIONS_XYZZ_ADD_H_
 

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/XYZZ/BUILD.bazel
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/XYZZ/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/XYZZ/Double.cpp
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/XYZZ/Double.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/XYZZ/Double.h"
 
 #include "zkir/Dialect/Field/IR/FieldOps.h"

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/XYZZ/Double.h
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/XYZZ/Double.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICCURVE_CONVERSIONS_ELLIPTICCURVETOFIELD_POINTOPERATIONS_XYZZ_DOUBLE_H_
 #define ZKIR_DIALECT_ELLIPTICCURVE_CONVERSIONS_ELLIPTICCURVETOFIELD_POINTOPERATIONS_XYZZ_DOUBLE_H_
 

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToLLVM/BUILD.bazel
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToLLVM/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToLLVM/EllipticCurveToLLVM.cpp
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToLLVM/EllipticCurveToLLVM.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToLLVM/EllipticCurveToLLVM.h"
 
 #include "mlir/Conversion/ConvertToLLVM/ToLLVMInterface.h"

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToLLVM/EllipticCurveToLLVM.h
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToLLVM/EllipticCurveToLLVM.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICCURVE_CONVERSIONS_ELLIPTICCURVETOLLVM_ELLIPTICCURVETOLLVM_H_
 #define ZKIR_DIALECT_ELLIPTICCURVE_CONVERSIONS_ELLIPTICCURVETOLLVM_ELLIPTICCURVETOLLVM_H_
 

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToLLVM/EllipticCurveToLLVM.td
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToLLVM/EllipticCurveToLLVM.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICURVE_CONVERSIONS_ELLIPTICCURVETOLLVM_ELLIPTICCURVETOLLVM_TD_
 #define ZKIR_DIALECT_ELLIPTICURVE_CONVERSIONS_ELLIPTICCURVETOLLVM_ELLIPTICCURVETOLLVM_TD_
 

--- a/zkir/Dialect/EllipticCurve/IR/BUILD.bazel
+++ b/zkir/Dialect/EllipticCurve/IR/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 

--- a/zkir/Dialect/EllipticCurve/IR/EllipticCurveAttributes.h
+++ b/zkir/Dialect/EllipticCurve/IR/EllipticCurveAttributes.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVEATTRIBUTES_H_
 #define ZKIR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVEATTRIBUTES_H_
 

--- a/zkir/Dialect/EllipticCurve/IR/EllipticCurveAttributes.td
+++ b/zkir/Dialect/EllipticCurve/IR/EllipticCurveAttributes.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVEATTRIBUTES_TD_
 #define ZKIR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVEATTRIBUTES_TD_
 

--- a/zkir/Dialect/EllipticCurve/IR/EllipticCurveDialect.cpp
+++ b/zkir/Dialect/EllipticCurve/IR/EllipticCurveDialect.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/EllipticCurve/IR/EllipticCurveDialect.h"
 
 #include <cassert>

--- a/zkir/Dialect/EllipticCurve/IR/EllipticCurveDialect.h
+++ b/zkir/Dialect/EllipticCurve/IR/EllipticCurveDialect.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVEDIALECT_H_
 #define ZKIR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVEDIALECT_H_
 

--- a/zkir/Dialect/EllipticCurve/IR/EllipticCurveDialect.td
+++ b/zkir/Dialect/EllipticCurve/IR/EllipticCurveDialect.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVEDIALECT_TD_
 #define ZKIR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVEDIALECT_TD_
 

--- a/zkir/Dialect/EllipticCurve/IR/EllipticCurveOps.cpp
+++ b/zkir/Dialect/EllipticCurve/IR/EllipticCurveOps.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/EllipticCurve/IR/EllipticCurveOps.h"
 
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"

--- a/zkir/Dialect/EllipticCurve/IR/EllipticCurveOps.h
+++ b/zkir/Dialect/EllipticCurve/IR/EllipticCurveOps.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVEOPS_H_
 #define ZKIR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVEOPS_H_
 

--- a/zkir/Dialect/EllipticCurve/IR/EllipticCurveOps.td
+++ b/zkir/Dialect/EllipticCurve/IR/EllipticCurveOps.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVEOPS_TD_
 #define ZKIR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVEOPS_TD_
 

--- a/zkir/Dialect/EllipticCurve/IR/EllipticCurveTypes.h
+++ b/zkir/Dialect/EllipticCurve/IR/EllipticCurveTypes.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVETYPES_H_
 #define ZKIR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVETYPES_H_
 

--- a/zkir/Dialect/EllipticCurve/IR/EllipticCurveTypes.td
+++ b/zkir/Dialect/EllipticCurve/IR/EllipticCurveTypes.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVETYPES_TD_
 #define ZKIR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVETYPES_TD_
 

--- a/zkir/Dialect/Field/Conversions/ExtFieldToLLVM/BUILD.bazel
+++ b/zkir/Dialect/Field/Conversions/ExtFieldToLLVM/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 

--- a/zkir/Dialect/Field/Conversions/ExtFieldToLLVM/ExtFieldToLLVM.cpp
+++ b/zkir/Dialect/Field/Conversions/ExtFieldToLLVM/ExtFieldToLLVM.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/Field/Conversions/ExtFieldToLLVM/ExtFieldToLLVM.h"
 
 #include "mlir/Conversion/ConvertToLLVM/ToLLVMInterface.h"

--- a/zkir/Dialect/Field/Conversions/ExtFieldToLLVM/ExtFieldToLLVM.h
+++ b/zkir/Dialect/Field/Conversions/ExtFieldToLLVM/ExtFieldToLLVM.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_FIELD_CONVERSIONS_EXTFIELDTOLLVM_EXTFIELDTOLLVM_H_
 #define ZKIR_DIALECT_FIELD_CONVERSIONS_EXTFIELDTOLLVM_EXTFIELDTOLLVM_H_
 

--- a/zkir/Dialect/Field/Conversions/ExtFieldToLLVM/ExtFieldToLLVM.td
+++ b/zkir/Dialect/Field/Conversions/ExtFieldToLLVM/ExtFieldToLLVM.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_FIELD_CONVERSIONS_EXTFIELDTOLLVM_EXTFIELDTOLLVM_TD_
 #define ZKIR_DIALECT_FIELD_CONVERSIONS_EXTFIELDTOLLVM_EXTFIELDTOLLVM_TD_
 

--- a/zkir/Dialect/Field/Conversions/FieldToModArith/BUILD.bazel
+++ b/zkir/Dialect/Field/Conversions/FieldToModArith/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 

--- a/zkir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
+++ b/zkir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.h"
 
 #include <utility>

--- a/zkir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.h
+++ b/zkir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_FIELD_CONVERSIONS_FIELDTOMODARITH_FIELDTOMODARITH_H_
 #define ZKIR_DIALECT_FIELD_CONVERSIONS_FIELDTOMODARITH_FIELDTOMODARITH_H_
 

--- a/zkir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.td
+++ b/zkir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_FIELD_CONVERSIONS_FIELDTOMODARITH_FIELDTOMODARITH_TD_
 #define ZKIR_DIALECT_FIELD_CONVERSIONS_FIELDTOMODARITH_FIELDTOMODARITH_TD_
 

--- a/zkir/Dialect/Field/IR/BUILD.bazel
+++ b/zkir/Dialect/Field/IR/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 

--- a/zkir/Dialect/Field/IR/FieldAttributes.cpp
+++ b/zkir/Dialect/Field/IR/FieldAttributes.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/Field/IR/FieldAttributes.h"
 
 #include "mlir/IR/BuiltinAttributes.h"

--- a/zkir/Dialect/Field/IR/FieldAttributes.h
+++ b/zkir/Dialect/Field/IR/FieldAttributes.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_FIELD_IR_FIELDATTRIBUTES_H_
 #define ZKIR_DIALECT_FIELD_IR_FIELDATTRIBUTES_H_
 

--- a/zkir/Dialect/Field/IR/FieldAttributes.td
+++ b/zkir/Dialect/Field/IR/FieldAttributes.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_FIELD_IR_FIELDATTRS_TD_
 #define ZKIR_DIALECT_FIELD_IR_FIELDATTRS_TD_
 

--- a/zkir/Dialect/Field/IR/FieldCanonicalization.td
+++ b/zkir/Dialect/Field/IR/FieldCanonicalization.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_FIELD_IR_FIELD_CANONICALIZATION_TD
 #define ZKIR_FIELD_IR_FIELD_CANONICALIZATION_TD
 

--- a/zkir/Dialect/Field/IR/FieldDialect.cpp
+++ b/zkir/Dialect/Field/IR/FieldDialect.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/Field/IR/FieldDialect.h"
 
 #include <cassert>

--- a/zkir/Dialect/Field/IR/FieldDialect.h
+++ b/zkir/Dialect/Field/IR/FieldDialect.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_FIELD_IR_FIELDDIALECT_H_
 #define ZKIR_DIALECT_FIELD_IR_FIELDDIALECT_H_
 

--- a/zkir/Dialect/Field/IR/FieldDialect.td
+++ b/zkir/Dialect/Field/IR/FieldDialect.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_FIELD_IR_FIELDDIALECT_TD_
 #define ZKIR_DIALECT_FIELD_IR_FIELDDIALECT_TD_
 

--- a/zkir/Dialect/Field/IR/FieldOps.cpp
+++ b/zkir/Dialect/Field/IR/FieldOps.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/Field/IR/FieldOps.h"
 
 #include "mlir/IR/PatternMatch.h"

--- a/zkir/Dialect/Field/IR/FieldOps.h
+++ b/zkir/Dialect/Field/IR/FieldOps.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_FIELD_IR_FIELDOPS_H_
 #define ZKIR_DIALECT_FIELD_IR_FIELDOPS_H_
 

--- a/zkir/Dialect/Field/IR/FieldOps.td
+++ b/zkir/Dialect/Field/IR/FieldOps.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_FIELD_IR_FIELDOPS_TD_
 #define ZKIR_DIALECT_FIELD_IR_FIELDOPS_TD_
 

--- a/zkir/Dialect/Field/IR/FieldTypes.cpp
+++ b/zkir/Dialect/Field/IR/FieldTypes.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/Field/IR/FieldTypes.h"
 
 #include "mlir/IR/BuiltinTypes.h"

--- a/zkir/Dialect/Field/IR/FieldTypes.h
+++ b/zkir/Dialect/Field/IR/FieldTypes.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_FIELD_IR_FIELDTYPES_H_
 #define ZKIR_DIALECT_FIELD_IR_FIELDTYPES_H_
 

--- a/zkir/Dialect/Field/IR/FieldTypes.td
+++ b/zkir/Dialect/Field/IR/FieldTypes.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_FIELD_IR_FIELDTYPES_TD_
 #define ZKIR_DIALECT_FIELD_IR_FIELDTYPES_TD_
 

--- a/zkir/Dialect/Field/Pipelines/BUILD.bazel
+++ b/zkir/Dialect/Field/Pipelines/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(

--- a/zkir/Dialect/Field/Pipelines/Passes.cpp
+++ b/zkir/Dialect/Field/Pipelines/Passes.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/Field/Pipelines/Passes.h"
 
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"

--- a/zkir/Dialect/Field/Pipelines/Passes.h
+++ b/zkir/Dialect/Field/Pipelines/Passes.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_FIELD_PIPELINES_PASSES_H_
 #define ZKIR_DIALECT_FIELD_PIPELINES_PASSES_H_
 

--- a/zkir/Dialect/ModArith/Conversions/ModArithToArith/BUILD.bazel
+++ b/zkir/Dialect/ModArith/Conversions/ModArithToArith/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 

--- a/zkir/Dialect/ModArith/Conversions/ModArithToArith/Inverter/BUILD.bazel
+++ b/zkir/Dialect/ModArith/Conversions/ModArithToArith/Inverter/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(

--- a/zkir/Dialect/ModArith/Conversions/ModArithToArith/Inverter/BYInverter.cpp
+++ b/zkir/Dialect/ModArith/Conversions/ModArithToArith/Inverter/BYInverter.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/ModArith/Conversions/ModArithToArith/Inverter/BYInverter.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"

--- a/zkir/Dialect/ModArith/Conversions/ModArithToArith/Inverter/BYInverter.h
+++ b/zkir/Dialect/ModArith/Conversions/ModArithToArith/Inverter/BYInverter.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_MODARITH_CONVERSIONS_MODARITHTOARITH_INVERTER_BYINVERTER_H_
 #define ZKIR_DIALECT_MODARITH_CONVERSIONS_MODARITHTOARITH_INVERTER_BYINVERTER_H_
 

--- a/zkir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/zkir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.h"
 
 #include <utility>

--- a/zkir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.h
+++ b/zkir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_MODARITH_CONVERSIONS_MODARITHTOARITH_MODARITHTOARITH_H_
 #define ZKIR_DIALECT_MODARITH_CONVERSIONS_MODARITHTOARITH_MODARITHTOARITH_H_
 

--- a/zkir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.td
+++ b/zkir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_MODARITH_CONVERSIONS_MODARITHTOARITH_MODARITHTOARITH_TD_
 #define ZKIR_DIALECT_MODARITH_CONVERSIONS_MODARITHTOARITH_MODARITHTOARITH_TD_
 

--- a/zkir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BUILD.bazel
+++ b/zkir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(

--- a/zkir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.cpp
+++ b/zkir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"

--- a/zkir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.h
+++ b/zkir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_MODARITH_CONVERSIONS_MODARITHTOARITH_REDUCER_MONTREDUCER_H_
 #define ZKIR_DIALECT_MODARITH_CONVERSIONS_MODARITHTOARITH_REDUCER_MONTREDUCER_H_
 

--- a/zkir/Dialect/ModArith/IR/BUILD.bazel
+++ b/zkir/Dialect/ModArith/IR/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 

--- a/zkir/Dialect/ModArith/IR/ModArithAttributes.cpp
+++ b/zkir/Dialect/ModArith/IR/ModArithAttributes.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/ModArith/IR/ModArithAttributes.h"
 
 #include <utility>

--- a/zkir/Dialect/ModArith/IR/ModArithAttributes.h
+++ b/zkir/Dialect/ModArith/IR/ModArithAttributes.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_MODARITH_IR_MODARITHATTRIBUTES_H_
 #define ZKIR_DIALECT_MODARITH_IR_MODARITHATTRIBUTES_H_
 

--- a/zkir/Dialect/ModArith/IR/ModArithAttributes.td
+++ b/zkir/Dialect/ModArith/IR/ModArithAttributes.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_MODARITH_IR_MODARITHATTRS_TD_
 #define ZKIR_DIALECT_MODARITH_IR_MODARITHATTRS_TD_
 

--- a/zkir/Dialect/ModArith/IR/ModArithCanonicalization.td
+++ b/zkir/Dialect/ModArith/IR/ModArithCanonicalization.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_MODARITH_IR_MODARITH_CANONICALIZATION_TD
 #define ZKIR_MODARITH_IR_MODARITH_CANONICALIZATION_TD
 

--- a/zkir/Dialect/ModArith/IR/ModArithDialect.cpp
+++ b/zkir/Dialect/ModArith/IR/ModArithDialect.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/ModArith/IR/ModArithDialect.h"
 
 #include <cassert>

--- a/zkir/Dialect/ModArith/IR/ModArithDialect.h
+++ b/zkir/Dialect/ModArith/IR/ModArithDialect.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_MODARITH_IR_MODARITHDIALECT_H_
 #define ZKIR_DIALECT_MODARITH_IR_MODARITHDIALECT_H_
 

--- a/zkir/Dialect/ModArith/IR/ModArithDialect.td
+++ b/zkir/Dialect/ModArith/IR/ModArithDialect.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_MODARITH_IR_MODARITHDIALECT_TD_
 #define ZKIR_DIALECT_MODARITH_IR_MODARITHDIALECT_TD_
 

--- a/zkir/Dialect/ModArith/IR/ModArithOps.cpp
+++ b/zkir/Dialect/ModArith/IR/ModArithOps.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/ModArith/IR/ModArithOps.h"
 
 #include "mlir/IR/PatternMatch.h"

--- a/zkir/Dialect/ModArith/IR/ModArithOps.h
+++ b/zkir/Dialect/ModArith/IR/ModArithOps.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_MODARITH_IR_MODARITHOPS_H_
 #define ZKIR_DIALECT_MODARITH_IR_MODARITHOPS_H_
 

--- a/zkir/Dialect/ModArith/IR/ModArithOps.td
+++ b/zkir/Dialect/ModArith/IR/ModArithOps.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_MODARITH_IR_MODARITHOPS_TD_
 #define ZKIR_DIALECT_MODARITH_IR_MODARITHOPS_TD_
 

--- a/zkir/Dialect/ModArith/IR/ModArithTypes.h
+++ b/zkir/Dialect/ModArith/IR/ModArithTypes.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_MODARITH_IR_MODARITHTYPES_H_
 #define ZKIR_DIALECT_MODARITH_IR_MODARITHTYPES_H_
 

--- a/zkir/Dialect/ModArith/IR/ModArithTypes.td
+++ b/zkir/Dialect/ModArith/IR/ModArithTypes.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_MODARITH_IR_MODARITHTYPES_TD_
 #define ZKIR_DIALECT_MODARITH_IR_MODARITHTYPES_TD_
 

--- a/zkir/Dialect/Poly/Conversions/PolyToField/BUILD.bazel
+++ b/zkir/Dialect/Poly/Conversions/PolyToField/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 

--- a/zkir/Dialect/Poly/Conversions/PolyToField/PolyToField.cpp
+++ b/zkir/Dialect/Poly/Conversions/PolyToField/PolyToField.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/Poly/Conversions/PolyToField/PolyToField.h"
 
 #include <utility>

--- a/zkir/Dialect/Poly/Conversions/PolyToField/PolyToField.h
+++ b/zkir/Dialect/Poly/Conversions/PolyToField/PolyToField.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_POLY_CONVERSIONS_POLYTOFIELD_POLYTOFIELD_H_
 #define ZKIR_DIALECT_POLY_CONVERSIONS_POLYTOFIELD_POLYTOFIELD_H_
 

--- a/zkir/Dialect/Poly/Conversions/PolyToField/PolyToField.td
+++ b/zkir/Dialect/Poly/Conversions/PolyToField/PolyToField.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_POLY_CONVERSIONS_POLYTOFIELD_TD_
 #define ZKIR_DIALECT_POLY_CONVERSIONS_POLYTOFIELD_TD_
 

--- a/zkir/Dialect/Poly/IR/BUILD.bazel
+++ b/zkir/Dialect/Poly/IR/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 

--- a/zkir/Dialect/Poly/IR/PolyAttributes.cpp
+++ b/zkir/Dialect/Poly/IR/PolyAttributes.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/Poly/IR/PolyAttributes.h"
 
 #include <utility>

--- a/zkir/Dialect/Poly/IR/PolyAttributes.h
+++ b/zkir/Dialect/Poly/IR/PolyAttributes.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_POLY_IR_POLYATTRIBUTES_H_
 #define ZKIR_DIALECT_POLY_IR_POLYATTRIBUTES_H_
 

--- a/zkir/Dialect/Poly/IR/PolyAttributes.td
+++ b/zkir/Dialect/Poly/IR/PolyAttributes.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_POLY_IR_POLYATTRIBUTES_TD_
 #define ZKIR_DIALECT_POLY_IR_POLYATTRIBUTES_TD_
 

--- a/zkir/Dialect/Poly/IR/PolyCanonicalization.td
+++ b/zkir/Dialect/Poly/IR/PolyCanonicalization.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_POLY_IR_POLYCANONICALIZATION_TD_
 #define ZKIR_DIALECT_POLY_IR_POLYCANONICALIZATION_TD_
 

--- a/zkir/Dialect/Poly/IR/PolyDialect.cpp
+++ b/zkir/Dialect/Poly/IR/PolyDialect.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/Poly/IR/PolyDialect.h"
 
 #include "llvm/ADT/TypeSwitch.h"

--- a/zkir/Dialect/Poly/IR/PolyDialect.h
+++ b/zkir/Dialect/Poly/IR/PolyDialect.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_POLY_IR_POLYDIALECT_H_
 #define ZKIR_DIALECT_POLY_IR_POLYDIALECT_H_
 

--- a/zkir/Dialect/Poly/IR/PolyDialect.td
+++ b/zkir/Dialect/Poly/IR/PolyDialect.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_POLY_IR_POLYDIALECT_TD_
 #define ZKIR_DIALECT_POLY_IR_POLYDIALECT_TD_
 

--- a/zkir/Dialect/Poly/IR/PolyOps.cpp
+++ b/zkir/Dialect/Poly/IR/PolyOps.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/Poly/IR/PolyOps.h"
 
 #include "mlir/include/mlir/IR/PatternMatch.h"

--- a/zkir/Dialect/Poly/IR/PolyOps.h
+++ b/zkir/Dialect/Poly/IR/PolyOps.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_POLY_IR_POLYOPS_H_
 #define ZKIR_DIALECT_POLY_IR_POLYOPS_H_
 

--- a/zkir/Dialect/Poly/IR/PolyOps.td
+++ b/zkir/Dialect/Poly/IR/PolyOps.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_POLY_IR_POLYOPS_TD_
 #define ZKIR_DIALECT_POLY_IR_POLYOPS_TD_
 

--- a/zkir/Dialect/Poly/IR/PolyTypes.h
+++ b/zkir/Dialect/Poly/IR/PolyTypes.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_POLY_IR_POLYTYPES_H_
 #define ZKIR_DIALECT_POLY_IR_POLYTYPES_H_
 

--- a/zkir/Dialect/Poly/IR/PolyTypes.td
+++ b/zkir/Dialect/Poly/IR/PolyTypes.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_POLY_IR_POLYTYPES_TD_
 #define ZKIR_DIALECT_POLY_IR_POLYTYPES_TD_
 

--- a/zkir/Dialect/TensorExt/Conversions/TensorExtToTensor/BUILD.bazel
+++ b/zkir/Dialect/TensorExt/Conversions/TensorExtToTensor/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 

--- a/zkir/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.cpp
+++ b/zkir/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.h"
 
 #include <utility>

--- a/zkir/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.h
+++ b/zkir/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_TENSOREXT_CONVERSIONS_TENSOREXTTOTENSOR_TENSOREXTTOTENSOR_H_
 #define ZKIR_DIALECT_TENSOREXT_CONVERSIONS_TENSOREXTTOTENSOR_TENSOREXTTOTENSOR_H_
 

--- a/zkir/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.td
+++ b/zkir/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_TENSOREXT_CONVERSIONS_TENSOREXTTOTENSOR_TENSOREXTTOTENSOR_TD_
 #define ZKIR_DIALECT_TENSOREXT_CONVERSIONS_TENSOREXTTOTENSOR_TENSOREXTTOTENSOR_TD_
 

--- a/zkir/Dialect/TensorExt/IR/BUILD.bazel
+++ b/zkir/Dialect/TensorExt/IR/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 

--- a/zkir/Dialect/TensorExt/IR/TensorExtCanonicalization.td
+++ b/zkir/Dialect/TensorExt/IR/TensorExtCanonicalization.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_TENSOREXT_IR_TENSOREXT_CANONICALIZATION_TD
 #define ZKIR_TENSOREXT_IR_TENSOREXT_CANONICALIZATION_TD
 

--- a/zkir/Dialect/TensorExt/IR/TensorExtDialect.cpp
+++ b/zkir/Dialect/TensorExt/IR/TensorExtDialect.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/TensorExt/IR/TensorExtDialect.h"
 
 // IWYU pragma: begin_keep

--- a/zkir/Dialect/TensorExt/IR/TensorExtDialect.h
+++ b/zkir/Dialect/TensorExt/IR/TensorExtDialect.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_TENSOREXT_IR_TENSOREXTDIALECT_H_
 #define ZKIR_DIALECT_TENSOREXT_IR_TENSOREXTDIALECT_H_
 

--- a/zkir/Dialect/TensorExt/IR/TensorExtDialect.td
+++ b/zkir/Dialect/TensorExt/IR/TensorExtDialect.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_TENSOREXT_IR_TENSOREXTDIALECT_TD_
 #define ZKIR_DIALECT_TENSOREXT_IR_TENSOREXTDIALECT_TD_
 

--- a/zkir/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/zkir/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Dialect/TensorExt/IR/TensorExtOps.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"

--- a/zkir/Dialect/TensorExt/IR/TensorExtOps.h
+++ b/zkir/Dialect/TensorExt/IR/TensorExtOps.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_TENSOREXT_IR_TENSOREXTOPS_H_
 #define ZKIR_DIALECT_TENSOREXT_IR_TENSOREXTOPS_H_
 

--- a/zkir/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/zkir/Dialect/TensorExt/IR/TensorExtOps.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_DIALECT_TENSOREXT_IR_TENSOREXTOPS_TD_
 #define ZKIR_DIALECT_TENSOREXT_IR_TENSOREXTOPS_TD_
 

--- a/zkir/Utils/APIntUtils.cpp
+++ b/zkir/Utils/APIntUtils.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Utils/APIntUtils.h"
 
 #include <utility>

--- a/zkir/Utils/APIntUtils.h
+++ b/zkir/Utils/APIntUtils.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_UTILS_APINTUTILS_H_
 #define ZKIR_UTILS_APINTUTILS_H_
 

--- a/zkir/Utils/BUILD.bazel
+++ b/zkir/Utils/BUILD.bazel
@@ -1,3 +1,18 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@llvm-project//mlir:tblgen.bzl", "td_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 

--- a/zkir/Utils/CommonTraits.td
+++ b/zkir/Utils/CommonTraits.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_UTILS_COMMONTRAITS_TD_
 #define ZKIR_UTILS_COMMONTRAITS_TD_
 

--- a/zkir/Utils/CommonTypeConstraints.td
+++ b/zkir/Utils/CommonTypeConstraints.td
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_UTILS_COMMONTYPECONSTRAINTS_TD_
 #define ZKIR_UTILS_COMMONTYPECONSTRAINTS_TD_
 

--- a/zkir/Utils/ConversionUtils.cpp
+++ b/zkir/Utils/ConversionUtils.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Utils/ConversionUtils.h"
 
 #include <algorithm>

--- a/zkir/Utils/ConversionUtils.h
+++ b/zkir/Utils/ConversionUtils.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_UTILS_CONVERSIONUTILS_H_
 #define ZKIR_UTILS_CONVERSIONUTILS_H_
 

--- a/zkir/Utils/OpUtils.cpp
+++ b/zkir/Utils/OpUtils.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Utils/OpUtils.h"
 
 #include "mlir/IR/BuiltinTypes.h"

--- a/zkir/Utils/OpUtils.h
+++ b/zkir/Utils/OpUtils.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_UTILS_OPUTILS_H_
 #define ZKIR_UTILS_OPUTILS_H_
 

--- a/zkir/Utils/ShapedTypeConverter.cpp
+++ b/zkir/Utils/ShapedTypeConverter.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Utils/ShapedTypeConverter.h"
 
 #include <assert.h>

--- a/zkir/Utils/ShapedTypeConverter.h
+++ b/zkir/Utils/ShapedTypeConverter.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_UTILS_SHAPEDTYPECONVERTER_H_
 #define ZKIR_UTILS_SHAPEDTYPECONVERTER_H_
 

--- a/zkir/Utils/SimpleStructBuilder.cpp
+++ b/zkir/Utils/SimpleStructBuilder.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "zkir/Utils/SimpleStructBuilder.h"
 
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"

--- a/zkir/Utils/SimpleStructBuilder.h
+++ b/zkir/Utils/SimpleStructBuilder.h
@@ -1,3 +1,18 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef ZKIR_UTILS_SIMPLESTRUCTBUILDER_H_
 #define ZKIR_UTILS_SIMPLESTRUCTBUILDER_H_
 


### PR DESCRIPTION
## Description

This PR adds the Apache License, Version 2.0 license header notice to all source files within the ZKIR repository.

The Bazel `licenses = ["notice"]` attribute was also removed, as it's primarily used when incorporating files from other projects and is unnecessary for our own source code.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
