### PR TITLE
feat: mark all `Field` and `ModArith` ops as inlinable

### DIFF
--- a/tests/Dialect/Field/inline.mlir
+++ b/tests/Dialect/Field/inline.mlir
@@ -1,0 +1,70 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// RUN: zkir-opt -inline %s | FileCheck %s
+
+!PF17 = !field.pf<17:i32>
+
+//===----------------------------------------------------------------------===//
+// Inline with multiple operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @test_inline_multiple_ops
+// CHECK-SAME: (%[[ARG0:.*]]: [[T:.*]], %[[ARG1:.*]]: [[T]]) -> [[T]]
+func.func @test_inline_multiple_ops(%arg0: !PF17, %arg1: !PF17) -> !PF17 {
+  // CHECK-NOT: func.call @helper_complex
+  // CHECK: %[[C3:.*]] = field.constant #field<pf.elem<3 : i32>
+  // CHECK: %[[MUL:.*]] = field.mul %[[ARG0]], %[[C3]] : [[T]]
+  // CHECK: %[[ADD:.*]] = field.add %[[MUL]], %[[ARG1]] : [[T]]
+  // CHECK: %[[RES:.*]] = field.square %[[ADD]] : [[T]]
+  // CHECK: return %[[RES]] : [[T]]
+  %0 = func.call @helper_complex(%arg0, %arg1) : (!PF17, !PF17) -> (!PF17)
+  return %0 : !PF17
+}
+
+func.func private @helper_complex(%x: !PF17, %y: !PF17) -> !PF17 {
+  %c3 = field.constant 3 : !PF17
+  %mul = field.mul %x, %c3 : !PF17
+  %add = field.add %mul, %y : !PF17
+  %square = field.square %add : !PF17
+  return %square : !PF17
+}
+
+//===----------------------------------------------------------------------===//
+// Inline with nested calls
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @test_inline_nested
+// CHECK-SAME: (%[[ARG0:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_inline_nested(%arg0: !PF17) -> !PF17 {
+  // CHECK-NOT: func.call @helper_nested
+  // CHECK-NOT: func.call @helper_complex
+  // CHECK: %[[C5:.*]] = field.constant #field<pf.elem<5 : i32>
+  // CHECK: %[[C3:.*]] = field.constant #field<pf.elem<3 : i32>
+  // CHECK: %[[MUL:.*]] = field.mul %[[ARG0]], %[[C3]] : [[T]]
+  // CHECK: %[[ADD:.*]] = field.add %[[MUL]], %[[ARG0]] : [[T]]
+  // CHECK: %[[SQUARE:.*]] = field.square %[[ADD]] : [[T]]
+  // CHECK: %[[ADD2:.*]] = field.add %[[SQUARE]], %[[C5]] : [[T]]
+  // CHECK: return %[[ADD2]] : [[T]]
+  %0 = func.call @helper_nested(%arg0) : (!PF17) -> (!PF17)
+  return %0 : !PF17
+}
+
+func.func private @helper_nested(%x: !PF17) -> !PF17 {
+  %0 = func.call @helper_complex(%x, %x) : (!PF17, !PF17) -> (!PF17)
+  %c5 = field.constant 5 : !PF17
+  %1 = field.add %0, %c5 : !PF17
+  return %1 : !PF17
+}

--- a/tests/Dialect/ModArith/inline.mlir
+++ b/tests/Dialect/ModArith/inline.mlir
@@ -1,0 +1,70 @@
+// Copyright 2025 The ZKIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// RUN: zkir-opt -inline %s | FileCheck %s
+
+!Zp = !mod_arith.int<37 : i32>
+
+//===----------------------------------------------------------------------===//
+// Inline with multiple operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @test_inline_multiple_ops
+// CHECK-SAME: (%[[ARG0:.*]]: [[T:.*]], %[[ARG1:.*]]: [[T]]) -> [[T]]
+func.func @test_inline_multiple_ops(%arg0: !Zp, %arg1: !Zp) -> !Zp {
+  // CHECK-NOT: func.call @helper_complex
+  // CHECK: %[[C3:.*]] = mod_arith.constant 3 : [[T]]
+  // CHECK: %[[MUL:.*]] = mod_arith.mul %[[ARG0]], %[[C3]] : [[T]]
+  // CHECK: %[[ADD:.*]] = mod_arith.add %[[MUL]], %[[ARG1]] : [[T]]
+  // CHECK: %[[RES:.*]] = mod_arith.square %[[ADD]] : [[T]]
+  // CHECK: return %[[RES]] : [[T]]
+  %0 = func.call @helper_complex(%arg0, %arg1) : (!Zp, !Zp) -> (!Zp)
+  return %0 : !Zp
+}
+
+func.func private @helper_complex(%x: !Zp, %y: !Zp) -> !Zp {
+  %c3 = mod_arith.constant 3 : !Zp
+  %mul = mod_arith.mul %x, %c3 : !Zp
+  %add = mod_arith.add %mul, %y : !Zp
+  %square = mod_arith.square %add : !Zp
+  return %square : !Zp
+}
+
+//===----------------------------------------------------------------------===//
+// Inline with nested calls
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @test_inline_nested
+// CHECK-SAME: (%[[ARG0:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_inline_nested(%arg0: !Zp) -> !Zp {
+  // CHECK-NOT: func.call @helper_nested
+  // CHECK-NOT: func.call @helper_complex
+  // CHECK: %[[C5:.*]] = mod_arith.constant 5 : [[T]]
+  // CHECK: %[[C3:.*]] = mod_arith.constant 3 : [[T]]
+  // CHECK: %[[MUL:.*]] = mod_arith.mul %[[ARG0]], %[[C3]] : [[T]]
+  // CHECK: %[[ADD:.*]] = mod_arith.add %[[MUL]], %[[ARG0]] : [[T]]
+  // CHECK: %[[SQUARE:.*]] = mod_arith.square %[[ADD]] : [[T]]
+  // CHECK: %[[ADD2:.*]] = mod_arith.add %[[SQUARE]], %[[C5]] : [[T]]
+  // CHECK: return %[[ADD2]] : [[T]]
+  %0 = func.call @helper_nested(%arg0) : (!Zp) -> (!Zp)
+  return %0 : !Zp
+}
+
+func.func private @helper_nested(%x: !Zp) -> !Zp {
+  %0 = func.call @helper_complex(%x, %x) : (!Zp, !Zp) -> (!Zp)
+  %c5 = mod_arith.constant 5 : !Zp
+  %1 = mod_arith.add %0, %c5 : !Zp
+  return %1 : !Zp
+}

--- a/zkir/Dialect/Field/IR/BUILD.bazel
+++ b/zkir/Dialect/Field/IR/BUILD.bazel
@@ -49,6 +49,7 @@ cc_library(
         "@llvm-project//mlir:DataLayoutInterfaces",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
+        "@llvm-project//mlir:InliningUtils",
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:Support",
     ],

--- a/zkir/Dialect/Field/IR/FieldDialect.cpp
+++ b/zkir/Dialect/Field/IR/FieldDialect.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/InliningUtils.h"
 #include "zkir/Dialect/Field/IR/FieldTypes.h"
 
 // IWYU pragma: begin_keep
@@ -57,6 +58,15 @@ limitations under the License.
 
 namespace mlir::zkir::field {
 
+struct FieldInlinerInterface : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+
+  // All field dialect ops can be inlined.
+  bool isLegalToInline(Operation *, Region *, bool, IRMapping &) const final {
+    return true;
+  }
+};
+
 class FieldOpAsmDialectInterface : public OpAsmDialectInterface {
 public:
   using OpAsmDialectInterface::OpAsmDialectInterface;
@@ -87,6 +97,7 @@ void FieldDialect::initialize() {
 #include "zkir/Dialect/Field/IR/FieldOps.cpp.inc" // NOLINT(build/include)
       >();
 
+  addInterface<FieldInlinerInterface>();
   addInterface<FieldOpAsmDialectInterface>();
 }
 

--- a/zkir/Dialect/ModArith/IR/BUILD.bazel
+++ b/zkir/Dialect/ModArith/IR/BUILD.bazel
@@ -47,6 +47,7 @@ cc_library(
         "@llvm-project//mlir:DataLayoutInterfaces",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
+        "@llvm-project//mlir:InliningUtils",
         "@llvm-project//mlir:Support",
     ],
 )

--- a/zkir/Dialect/ModArith/IR/ModArithDialect.cpp
+++ b/zkir/Dialect/ModArith/IR/ModArithDialect.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/InliningUtils.h"
 #include "zkir/Dialect/ModArith/IR/ModArithTypes.h"
 
 // IWYU pragma: begin_keep
@@ -51,6 +52,15 @@ limitations under the License.
 #include "zkir/Dialect/ModArith/IR/ModArithOps.cpp.inc"
 
 namespace mlir::zkir::mod_arith {
+
+struct ModArithInlinerInterface : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+
+  // All ModArith dialect ops can be inlined.
+  bool isLegalToInline(Operation *, Region *, bool, IRMapping &) const final {
+    return true;
+  }
+};
 
 class ModArithOpAsmDialectInterface : public OpAsmDialectInterface {
 public:
@@ -84,6 +94,7 @@ void ModArithDialect::initialize() {
 #include "zkir/Dialect/ModArith/IR/ModArithOps.cpp.inc" // NOLINT(build/include)
       >();
 
+  addInterface<ModArithInlinerInterface>();
   addInterface<ModArithOpAsmDialectInterface>();
 }
 


### PR DESCRIPTION
## Description

This PR legalizes `Field` and `ModArith` ops to be inlinable. Previously, the `inline` pass didn't work with these ops even if the functions are small. With this change, inline pass works as expected with these dialects.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
