### PR TITLE
Add Fp3 (cubic extension field) type support

### DIFF
--- a/zkir/Dialect/Field/IR/FieldAttributes.td
+++ b/zkir/Dialect/Field/IR/FieldAttributes.td
@@ -46,6 +46,15 @@ def Field_QuadraticExtFieldAttr : Field_Attr<"QuadraticExtField", "f2.elem", [Ty
   }];
 }
 
+def Field_CubicExtFieldAttr : Field_Attr<"CubicExtField", "f3.elem", [TypedAttrInterface]> {
+  let summary = "An attribute representing a cubic extension field element";
+  let parameters = (ins "CubicExtFieldType":$type, Field_PrimeFieldAttr:$low, Field_PrimeFieldAttr:$mid, Field_PrimeFieldAttr:$high);
+  let assemblyFormat = "`<` $low `,` $mid `,` $high `>` `:` $type";
+  let extraClassDeclaration = [{
+    using ValueType = Attribute;
+  }];
+}
+
 def Field_RootOfUnityAttr : Field_Attr<"RootOfUnity", "root_of_unity", [TypedAttrInterface]> {
   let summary = "An attribute representing a root of unity in a prime field";
   let parameters = (ins Field_PrimeFieldAttr:$root, "IntegerAttr":$degree);
@@ -58,7 +67,7 @@ def Field_RootOfUnityAttr : Field_Attr<"RootOfUnity", "root_of_unity", [TypedAtt
   let genVerifyDecl = 1;
 }
 
-def Field_AnyFieldAttr : AnyAttrOf<[Field_PrimeFieldAttr, Field_QuadraticExtFieldAttr]> {
+def Field_AnyFieldAttr : AnyAttrOf<[Field_PrimeFieldAttr, Field_QuadraticExtFieldAttr, Field_CubicExtFieldAttr]> {
   string cppType = "::mlir::TypedAttr";
 }
 

--- a/zkir/Dialect/Field/IR/FieldOps.td
+++ b/zkir/Dialect/Field/IR/FieldOps.td
@@ -100,6 +100,23 @@ def Field_F2ConstantOp : Op<Field_Dialect, "f2.constant", [Pure, TypesMatchWith<
   let assemblyFormat = "$low `,` $high attr-dict `:` type($output)";
 }
 
+def Field_F3ConstantOp : Op<Field_Dialect, "f3.constant", [Pure, TypesMatchWith<
+  "result type is the same as the operand type", "output", "low", "cast<CubicExtFieldType>($_self).getBaseField()">,
+  TypesMatchWith< "result type is the same as the operand type", "output", "mid", "cast<CubicExtFieldType>($_self).getBaseField()">,
+  TypesMatchWith< "result type is the same as the operand type", "output", "high", "cast<CubicExtFieldType>($_self).getBaseField()">]> {
+  let summary = "Define a constant cubic extension field element";
+  let description = [{
+    Example:
+    ```
+    !CF = !field.f3<!PF, #xi>
+    %0 = field.f3.constant %low, %mid, %high : !CF
+    ```
+  }];
+  let arguments = (ins Field_PrimeFieldType:$low, Field_PrimeFieldType:$mid, Field_PrimeFieldType:$high);
+  let results = (outs Field_CubicExtFieldType:$output);
+  let assemblyFormat = "$low `,` $mid `,` $high attr-dict `:` type($output)";
+}
+
 def Field_BitcastOp : Op<Field_Dialect, "bitcast", [Pure,
  SameOperandsAndResultShape, AllSameTensorDims<["input", "output"]>,
  DeclareOpInterfaceMethods<CastOpInterface>]> {

--- a/zkir/Dialect/Field/IR/FieldTypes.td
+++ b/zkir/Dialect/Field/IR/FieldTypes.td
@@ -81,10 +81,43 @@ def Field_QuadraticExtFieldType : Field_Type<"QuadraticExtField", "f2", [
   }];
 }
 
-def Field_AnyFieldType : AnyTypeOf<[Field_PrimeFieldType, Field_QuadraticExtFieldType], "any-field-type">;
+// Cubic extension field type definition.
+// This type represents an element in a cubic extension field parameterized by the underlying field.
+// Currently, it is only defined for prime fields.
+def Field_CubicExtFieldType : Field_Type<"CubicExtField", "f3", [
+  MemRefElementTypeInterface]> {
+  let summary = "Cubic extension field element type";
+  let description = [{
+    Represents an element in a cubic extension field defined by the given
+    prime field `baseField` and the irreducible binomial `xi`.
+
+    An element is represented as a₀ + a₁v + a₂v² where v³ = ξ.
+
+    Example:
+    ```
+    !PF = !field.pf<7:i32>
+    #xi = #field.pf.elem<6:i32> : !PF
+    !CF = !field.f3<!PF, #xi>
+    ```
+  }];
+  let parameters = (ins
+   Field_PrimeFieldType: $baseField,
+   "PrimeFieldAttr": $xi
+  );
+  let assemblyFormat = "`<` $baseField `,` $xi `>`";
+  let extraClassDeclaration = [{
+    // Check if the field is in Montgomery form.
+    bool isMontgomery() {
+      return getBaseField().getIsMontgomery();
+    }
+  }];
+}
+
+def Field_AnyFieldType : AnyTypeOf<[Field_PrimeFieldType, Field_QuadraticExtFieldType, Field_CubicExtFieldType], "any-field-type">;
 
 def PrimeFieldLike: TypeOrValueSemanticsContainer<Field_PrimeFieldType, "prime-field-like">;
 def QuadraticExtFieldLike: TypeOrValueSemanticsContainer<Field_QuadraticExtFieldType, "quadratic-ext-field-like">;
-def FieldLike : TypeConstraint<Or<[PrimeFieldLike.predicate, QuadraticExtFieldLike.predicate]>, "field-like">;
+def CubicExtFieldLike: TypeOrValueSemanticsContainer<Field_CubicExtFieldType, "cubic-ext-field-like">;
+def FieldLike : TypeConstraint<Or<[PrimeFieldLike.predicate, QuadraticExtFieldLike.predicate, CubicExtFieldLike.predicate]>, "field-like">;
 
 #endif  // ZKIR_DIALECT_FIELD_IR_FIELDTYPES_TD_


### PR DESCRIPTION
This implements basic Fp3. Additional field arithmetic operations (add, mul, etc.) will be added after confirming that this approach is correct.

- Add CubicExtFieldType definition in FieldTypes.td
- Add CubicExtFieldAttr for Fp3 constants
- Add field.f3.constant operation
- Add Fp3 to LLVM struct lowering in ExtFieldToLLVM
- Update type constraints (CubicExtFieldLike, FieldLike)

## Description

<!-- Why is this change being made? Provide context and background -->

## Related Issues/PRs

<!-- Link related GitHub issues or PRs -->

## Checklist

- [ ] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [ ] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [ ] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
