### PR TITLE
build: use dict syntax for tbl_outs

### DIFF
--- a/zkir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/BUILD.bazel
+++ b/zkir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/BUILD.bazel
@@ -39,23 +39,14 @@ cc_library(
 
 gentbl_cc_library(
     name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=SpecializeArithToAVX",
-            ],
-            "SpecializeArithToAVX.h.inc",
-        ),
-        (
-            ["-gen-rewriters"],
-            "SpecializeArithToAVX.cpp.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "SpecializeArithToAVX.md",
-        ),
-    ],
+    tbl_outs = {
+        "SpecializeArithToAVX.h.inc": [
+            "-gen-pass-decls",
+            "-name=SpecializeArithToAVX",
+        ],
+        "SpecializeArithToAVX.cpp.inc": ["-gen-rewriters"],
+        "SpecializeArithToAVX.md": ["-gen-pass-doc"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "SpecializeArithToAVX.td",
     deps = [

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/BUILD.bazel
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/BUILD.bazel
@@ -51,23 +51,14 @@ cc_library(
 
 gentbl_cc_library(
     name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=EllipticCurveToField",
-            ],
-            "EllipticCurveToField.h.inc",
-        ),
-        (
-            ["-gen-rewriters"],
-            "EllipticCurveToField.cpp.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "EllipticCurveToField.md",
-        ),
-    ],
+    tbl_outs = {
+        "EllipticCurveToField.h.inc": [
+            "-gen-pass-decls",
+            "-name=EllipticCurveToField",
+        ],
+        "EllipticCurveToField.cpp.inc": ["-gen-rewriters"],
+        "EllipticCurveToField.md": ["-gen-pass-doc"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "EllipticCurveToField.td",
     deps = [

--- a/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToLLVM/BUILD.bazel
+++ b/zkir/Dialect/EllipticCurve/Conversions/EllipticCurveToLLVM/BUILD.bazel
@@ -45,23 +45,14 @@ cc_library(
 
 gentbl_cc_library(
     name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=EllipticCurveToLLVM",
-            ],
-            "EllipticCurveToLLVM.h.inc",
-        ),
-        (
-            ["-gen-rewriters"],
-            "EllipticCurveToLLVM.cpp.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "EllipticCurveToLLVM.md",
-        ),
-    ],
+    tbl_outs = {
+        "EllipticCurveToLLVM.h.inc": [
+            "-gen-pass-decls",
+            "-name=EllipticCurveToLLVM",
+        ],
+        "EllipticCurveToLLVM.cpp.inc": ["-gen-rewriters"],
+        "EllipticCurveToLLVM.md": ["-gen-pass-doc"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "EllipticCurveToLLVM.td",
     deps = [

--- a/zkir/Dialect/EllipticCurve/IR/BUILD.bazel
+++ b/zkir/Dialect/EllipticCurve/IR/BUILD.bazel
@@ -73,16 +73,10 @@ td_library(
 
 gentbl_cc_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-dialect-decls"],
-            "EllipticCurveDialect.h.inc",
-        ),
-        (
-            ["-gen-dialect-defs"],
-            "EllipticCurveDialect.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "EllipticCurveDialect.h.inc": ["-gen-dialect-decls"],
+        "EllipticCurveDialect.cpp.inc": ["-gen-dialect-defs"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "EllipticCurveDialect.td",
     deps = [
@@ -93,22 +87,16 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "attributes_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-attrdef-decls",
-                "--attrdefs-dialect=elliptic_curve",
-            ],
-            "EllipticCurveAttributes.h.inc",
-        ),
-        (
-            [
-                "-gen-attrdef-defs",
-                "--attrdefs-dialect=elliptic_curve",
-            ],
-            "EllipticCurveAttributes.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "EllipticCurveAttributes.h.inc": [
+            "-gen-attrdef-decls",
+            "--attrdefs-dialect=elliptic_curve",
+        ],
+        "EllipticCurveAttributes.cpp.inc": [
+            "-gen-attrdef-defs",
+            "--attrdefs-dialect=elliptic_curve",
+        ],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "EllipticCurveAttributes.td",
     deps = [
@@ -119,22 +107,16 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "types_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-typedef-decls",
-                "--typedefs-dialect=elliptic_curve",
-            ],
-            "EllipticCurveTypes.h.inc",
-        ),
-        (
-            [
-                "-gen-typedef-defs",
-                "--typedefs-dialect=elliptic_curve",
-            ],
-            "EllipticCurveTypes.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "EllipticCurveTypes.h.inc": [
+            "-gen-typedef-decls",
+            "--typedefs-dialect=elliptic_curve",
+        ],
+        "EllipticCurveTypes.cpp.inc": [
+            "-gen-typedef-defs",
+            "--typedefs-dialect=elliptic_curve",
+        ],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "EllipticCurveTypes.td",
     deps = [
@@ -144,16 +126,10 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "EllipticCurveOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "EllipticCurveOps.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "EllipticCurveOps.h.inc": ["-gen-op-decls"],
+        "EllipticCurveOps.cpp.inc": ["-gen-op-defs"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "EllipticCurveOps.td",
     deps = [

--- a/zkir/Dialect/Field/Conversions/ExtFieldToLLVM/BUILD.bazel
+++ b/zkir/Dialect/Field/Conversions/ExtFieldToLLVM/BUILD.bazel
@@ -43,23 +43,14 @@ cc_library(
 
 gentbl_cc_library(
     name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=ExtFieldToLLVM",
-            ],
-            "ExtFieldToLLVM.h.inc",
-        ),
-        (
-            ["-gen-rewriters"],
-            "ExtFieldToLLVM.cpp.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "ExtFieldToLLVM.md",
-        ),
-    ],
+    tbl_outs = {
+        "ExtFieldToLLVM.h.inc": [
+            "-gen-pass-decls",
+            "-name=ExtFieldToLLVM",
+        ],
+        "ExtFieldToLLVM.cpp.inc": ["-gen-rewriters"],
+        "ExtFieldToLLVM.md": ["-gen-pass-doc"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "ExtFieldToLLVM.td",
     deps = [

--- a/zkir/Dialect/Field/Conversions/FieldToModArith/BUILD.bazel
+++ b/zkir/Dialect/Field/Conversions/FieldToModArith/BUILD.bazel
@@ -54,23 +54,14 @@ cc_library(
 
 gentbl_cc_library(
     name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=FieldToModArith",
-            ],
-            "FieldToModArith.h.inc",
-        ),
-        (
-            ["-gen-rewriters"],
-            "FieldToModArith.cpp.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "FieldToModArith.md",
-        ),
-    ],
+    tbl_outs = {
+        "FieldToModArith.h.inc": [
+            "-gen-pass-decls",
+            "-name=FieldToModArith",
+        ],
+        "FieldToModArith.cpp.inc": ["-gen-rewriters"],
+        "FieldToModArith.md": ["-gen-pass-doc"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "FieldToModArith.td",
     deps = [

--- a/zkir/Dialect/Field/IR/BUILD.bazel
+++ b/zkir/Dialect/Field/IR/BUILD.bazel
@@ -77,24 +77,12 @@ td_library(
 
 gentbl_cc_library(
     name = "attributes_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-attrdef-decls"],
-            "FieldAttributes.h.inc",
-        ),
-        (
-            ["-gen-attrdef-defs"],
-            "FieldAttributes.cpp.inc",
-        ),
-        (
-            ["-gen-attr-interface-decls"],
-            "FieldAttributesInterfaces.h.inc",
-        ),
-        (
-            ["-gen-attr-interface-defs"],
-            "FieldAttributesInterfaces.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "FieldAttributes.h.inc": ["-gen-attrdef-decls"],
+        "FieldAttributes.cpp.inc": ["-gen-attrdef-defs"],
+        "FieldAttributesInterfaces.h.inc": ["-gen-attr-interface-decls"],
+        "FieldAttributesInterfaces.cpp.inc": ["-gen-attr-interface-defs"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "FieldAttributes.td",
     deps = [
@@ -104,12 +92,9 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "canonicalization_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-rewriters"],
-            "FieldCanonicalization.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "FieldCanonicalization.cpp.inc": ["-gen-rewriters"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "FieldCanonicalization.td",
     deps = [
@@ -119,16 +104,10 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-dialect-decls"],
-            "FieldDialect.h.inc",
-        ),
-        (
-            ["-gen-dialect-defs"],
-            "FieldDialect.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "FieldDialect.h.inc": ["-gen-dialect-decls"],
+        "FieldDialect.cpp.inc": ["-gen-dialect-defs"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "FieldDialect.td",
     deps = [
@@ -138,24 +117,12 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "types_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-typedef-decls"],
-            "FieldTypes.h.inc",
-        ),
-        (
-            ["-gen-typedef-defs"],
-            "FieldTypes.cpp.inc",
-        ),
-        (
-            ["-gen-type-interface-decls"],
-            "FieldTypesInterfaces.h.inc",
-        ),
-        (
-            ["-gen-type-interface-defs"],
-            "FieldTypesInterfaces.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "FieldTypes.h.inc": ["-gen-typedef-decls"],
+        "FieldTypes.cpp.inc": ["-gen-typedef-defs"],
+        "FieldTypesInterfaces.h.inc": ["-gen-type-interface-decls"],
+        "FieldTypesInterfaces.cpp.inc": ["-gen-type-interface-defs"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "FieldTypes.td",
     deps = [
@@ -165,16 +132,10 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "FieldOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "FieldOps.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "FieldOps.h.inc": ["-gen-op-decls"],
+        "FieldOps.cpp.inc": ["-gen-op-defs"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "FieldOps.td",
     deps = [

--- a/zkir/Dialect/ModArith/Conversions/ModArithToArith/BUILD.bazel
+++ b/zkir/Dialect/ModArith/Conversions/ModArithToArith/BUILD.bazel
@@ -58,23 +58,14 @@ cc_library(
 
 gentbl_cc_library(
     name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=ModArithToArith",
-            ],
-            "ModArithToArith.h.inc",
-        ),
-        (
-            ["-gen-rewriters"],
-            "ModArithToArith.cpp.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "ModArithToArith.md",
-        ),
-    ],
+    tbl_outs = {
+        "ModArithToArith.h.inc": [
+            "-gen-pass-decls",
+            "-name=ModArithToArith",
+        ],
+        "ModArithToArith.cpp.inc": ["-gen-rewriters"],
+        "ModArithToArith.md": ["-gen-pass-doc"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "ModArithToArith.td",
     deps = [

--- a/zkir/Dialect/ModArith/IR/BUILD.bazel
+++ b/zkir/Dialect/ModArith/IR/BUILD.bazel
@@ -74,16 +74,10 @@ td_library(
 
 gentbl_cc_library(
     name = "attributes_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-attrdef-decls"],
-            "ModArithAttributes.h.inc",
-        ),
-        (
-            ["-gen-attrdef-defs"],
-            "ModArithAttributes.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "ModArithAttributes.h.inc": ["-gen-attrdef-decls"],
+        "ModArithAttributes.cpp.inc": ["-gen-attrdef-defs"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "ModArithAttributes.td",
     deps = [
@@ -93,12 +87,9 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "canonicalization_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-rewriters"],
-            "ModArithCanonicalization.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "ModArithCanonicalization.cpp.inc": ["-gen-rewriters"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "ModArithCanonicalization.td",
     deps = [
@@ -108,16 +99,10 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-dialect-decls"],
-            "ModArithDialect.h.inc",
-        ),
-        (
-            ["-gen-dialect-defs"],
-            "ModArithDialect.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "ModArithDialect.h.inc": ["-gen-dialect-decls"],
+        "ModArithDialect.cpp.inc": ["-gen-dialect-defs"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "ModArithDialect.td",
     deps = [
@@ -127,16 +112,10 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "types_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-typedef-decls"],
-            "ModArithTypes.h.inc",
-        ),
-        (
-            ["-gen-typedef-defs"],
-            "ModArithTypes.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "ModArithTypes.h.inc": ["-gen-typedef-decls"],
+        "ModArithTypes.cpp.inc": ["-gen-typedef-defs"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "ModArithTypes.td",
     deps = [
@@ -146,16 +125,10 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "ModArithOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "ModArithOps.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "ModArithOps.h.inc": ["-gen-op-decls"],
+        "ModArithOps.cpp.inc": ["-gen-op-defs"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "ModArithOps.td",
     deps = [

--- a/zkir/Dialect/Poly/Conversions/PolyToField/BUILD.bazel
+++ b/zkir/Dialect/Poly/Conversions/PolyToField/BUILD.bazel
@@ -48,23 +48,14 @@ cc_library(
 
 gentbl_cc_library(
     name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=PolyToField",
-            ],
-            "PolyToField.h.inc",
-        ),
-        (
-            ["-gen-rewriters"],
-            "PolyToField.cpp.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "PolyToField.md",
-        ),
-    ],
+    tbl_outs = {
+        "PolyToField.h.inc": [
+            "-gen-pass-decls",
+            "-name=PolyToField",
+        ],
+        "PolyToField.cpp.inc": ["-gen-rewriters"],
+        "PolyToField.md": ["-gen-pass-doc"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "PolyToField.td",
     deps = [

--- a/zkir/Dialect/Poly/IR/BUILD.bazel
+++ b/zkir/Dialect/Poly/IR/BUILD.bazel
@@ -71,22 +71,16 @@ td_library(
 
 gentbl_cc_library(
     name = "attributes_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-attrdef-decls",
-                "--attrdefs-dialect=poly",
-            ],
-            "PolyAttributes.h.inc",
-        ),
-        (
-            [
-                "-gen-attrdef-defs",
-                "--attrdefs-dialect=poly",
-            ],
-            "PolyAttributes.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "PolyAttributes.h.inc": [
+            "-gen-attrdef-decls",
+            "--attrdefs-dialect=poly",
+        ],
+        "PolyAttributes.cpp.inc": [
+            "-gen-attrdef-defs",
+            "--attrdefs-dialect=poly",
+        ],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "PolyAttributes.td",
     deps = [
@@ -97,12 +91,9 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "canonicalization_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-rewriters"],
-            "PolyCanonicalization.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "PolyCanonicalization.cpp.inc": ["-gen-rewriters"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "PolyCanonicalization.td",
     deps = [
@@ -113,16 +104,10 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-dialect-decls"],
-            "PolyDialect.h.inc",
-        ),
-        (
-            ["-gen-dialect-defs"],
-            "PolyDialect.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "PolyDialect.h.inc": ["-gen-dialect-decls"],
+        "PolyDialect.cpp.inc": ["-gen-dialect-defs"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "PolyDialect.td",
     deps = [
@@ -132,22 +117,16 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "types_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-typedef-decls",
-                "--typedefs-dialect=poly",
-            ],
-            "PolyTypes.h.inc",
-        ),
-        (
-            [
-                "-gen-typedef-defs",
-                "--typedefs-dialect=poly",
-            ],
-            "PolyTypes.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "PolyTypes.h.inc": [
+            "-gen-typedef-decls",
+            "--typedefs-dialect=poly",
+        ],
+        "PolyTypes.cpp.inc": [
+            "-gen-typedef-defs",
+            "--typedefs-dialect=poly",
+        ],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "PolyTypes.td",
     deps = [
@@ -158,16 +137,10 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "PolyOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "PolyOps.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "PolyOps.h.inc": ["-gen-op-decls"],
+        "PolyOps.cpp.inc": ["-gen-op-defs"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "PolyOps.td",
     deps = [

--- a/zkir/Dialect/TensorExt/Conversions/TensorExtToTensor/BUILD.bazel
+++ b/zkir/Dialect/TensorExt/Conversions/TensorExtToTensor/BUILD.bazel
@@ -42,23 +42,14 @@ cc_library(
 
 gentbl_cc_library(
     name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=TensorExtToTensor",
-            ],
-            "TensorExtToTensor.h.inc",
-        ),
-        (
-            ["-gen-rewriters"],
-            "TensorExtToTensor.cpp.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "TensorExtToTensor.md",
-        ),
-    ],
+    tbl_outs = {
+        "TensorExtToTensor.h.inc": [
+            "-gen-pass-decls",
+            "-name=TensorExtToTensor",
+        ],
+        "TensorExtToTensor.cpp.inc": ["-gen-rewriters"],
+        "TensorExtToTensor.md": ["-gen-pass-doc"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "TensorExtToTensor.td",
     deps = [

--- a/zkir/Dialect/TensorExt/IR/BUILD.bazel
+++ b/zkir/Dialect/TensorExt/IR/BUILD.bazel
@@ -62,12 +62,9 @@ td_library(
 
 gentbl_cc_library(
     name = "canonicalization_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-rewriters"],
-            "TensorExtCanonicalization.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "TensorExtCanonicalization.cpp.inc": ["-gen-rewriters"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "TensorExtCanonicalization.td",
     deps = [":td_files"],
@@ -75,16 +72,10 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-dialect-decls"],
-            "TensorExtDialect.h.inc",
-        ),
-        (
-            ["-gen-dialect-defs"],
-            "TensorExtDialect.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "TensorExtDialect.h.inc": ["-gen-dialect-decls"],
+        "TensorExtDialect.cpp.inc": ["-gen-dialect-defs"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "TensorExtDialect.td",
     deps = [":td_files"],
@@ -92,16 +83,10 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "TensorExtOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "TensorExtOps.cpp.inc",
-        ),
-    ],
+    tbl_outs = {
+        "TensorExtOps.h.inc": ["-gen-op-decls"],
+        "TensorExtOps.cpp.inc": ["-gen-op-defs"],
+    },
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "TensorExtOps.td",
     deps = [":td_files"],


### PR DESCRIPTION
## Description

This PR applies the recently introduced dict (dictionary) syntax to `tbl_outs` to make the MLIR TableGen code cleaner.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
