### PR TITLE
fix: disable running unittests using avx 512 on non x86_64 arch

### DIFF
--- a/.bazelrc.ci
+++ b/.bazelrc.ci
@@ -1,2 +1,3 @@
 build:ci --remote_cache=grpc://127.0.0.1:9092
 test:ci --test_output=errors
+test:ci --//:has_avx512

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -13,6 +13,13 @@
 # limitations under the License.
 # ==============================================================================
 
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+bool_flag(
+    name = "has_avx512",
+    build_setting_default = False,
+)
+
 config_setting(
     name = "linux_x86_64",
     constraint_values = [
@@ -43,4 +50,10 @@ config_setting(
         "@platforms//os:macos",
         "@platforms//cpu:aarch64",
     ],
+)
+
+config_setting(
+    name = "zkir_has_avx512",
+    constraint_values = ["@platforms//cpu:x86_64"],
+    flag_values = {":has_avx512": "true"},
 )

--- a/benchmark/poseidon2/BUILD.bazel
+++ b/benchmark/poseidon2/BUILD.bazel
@@ -29,8 +29,10 @@ zkir_mlir_cc_import(
         "-mcpu=native",
     ],
     mlir_src = "poseidon2_packed.mlir",
-    zkir_opt_flags = [
-        "-field-to-llvm=specialize-avx",
+    zkir_opt_flags = select({
+        "//:zkir_has_avx512": ["-field-to-llvm=specialize-avx"],
+        "//conditions:default": ["-field-to-llvm"],
+    }) + [
         "-convert-vector-to-llvm",
     ],
 )

--- a/tests/Dialect/ArithExt/BUILD.bazel
+++ b/tests/Dialect/ArithExt/BUILD.bazel
@@ -13,11 +13,39 @@
 # limitations under the License.
 # ==============================================================================
 
+load("@rules_python//python:defs.bzl", "py_test")
 load("//bazel:lit.bzl", "glob_lit_tests")
+
+AVX512_TESTS = [
+    "packed_arith_runner.mlir",
+]
 
 glob_lit_tests(
     name = "all_tests",
     data = ["//tests:test_utilities"],
     driver = "//tests:run_lit.sh",
+    exclude = AVX512_TESTS,
     test_file_exts = ["mlir"],
 )
+
+[
+    py_test(
+        name = f.replace(".mlir", ""),
+        srcs = ["@llvm-project//llvm:lit"],
+        args = select({
+            "//:zkir_has_avx512": [
+                "-v",
+                "tests/Dialect/ArithExt/" + f,
+            ],
+            # TODO(chokobole): This is a hack to prevent the test from running if AVX512 is not supported.
+            "//conditions:default": ["-h"],
+        }),
+        data = [
+            "//tests:test_utilities",
+            f,
+        ],
+        main = "lit.py",
+        deps = ["@pypi//lit"],
+    )
+    for f in AVX512_TESTS
+]


### PR DESCRIPTION
## Description

N/A

## Related Issues/PRs

#112

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
