### PR TITLE
refactor(field): reuse quadratic extension field algorithm for code generation

### DIFF
--- a/tests/Dialect/Field/canonicalize.mlir
+++ b/tests/Dialect/Field/canonicalize.mlir
@@ -45,8 +45,8 @@ func.func @test_mul(%a: !QF, %b: !QF) -> !QF {
 func.func @test_square(%a: !QF) -> !QF {
   // CHECK: %[[COEFFS:.*]]:2 = field.ext_to_coeffs %[[ARG0]] : ([[T]]) -> (!z7_i32, !z7_i32)
   // CHECK: %[[SUB:.*]] = mod_arith.sub %[[COEFFS]]#0, %[[COEFFS]]#1 : !z7_i32
-  // CHECK: %[[ADD:.*]] = mod_arith.add %[[COEFFS]]#0, %[[COEFFS]]#1 : !z7_i32
   // CHECK: %[[MUL:.*]] = mod_arith.mul %[[COEFFS]]#0, %[[COEFFS]]#1 : !z7_i32
+  // CHECK: %[[ADD:.*]] = mod_arith.add %[[COEFFS]]#0, %[[COEFFS]]#1 : !z7_i32
   // CHECK: %[[MUL2:.*]] = mod_arith.mul %[[SUB]], %[[ADD]] : !z7_i32
   // CHECK: %[[DOUBLE:.*]] = mod_arith.double %[[MUL]] : !z7_i32
   // CHECK: %[[RESULT:.*]] = field.ext_from_coeffs %[[MUL2]], %[[DOUBLE]] : (!z7_i32, !z7_i32) -> [[T]]
@@ -59,9 +59,9 @@ func.func @test_square(%a: !QF) -> !QF {
 // CHECK-SAME: (%[[ARG0:.*]]: [[T:.*]]) -> [[T]]
 func.func @test_inverse(%a: !QF) -> !QF {
   // CHECK: %[[COEFFS:.*]]:2 = field.ext_to_coeffs %[[ARG0]] : ([[T]]) -> (!z7_i32, !z7_i32)
-  // CHECK: %[[SQUARE0:.*]] = mod_arith.square %[[COEFFS]]#0 : !z7_i32
-  // CHECK: %[[SQUARE1:.*]] = mod_arith.square %[[COEFFS]]#1 : !z7_i32
-  // CHECK: %[[ADD:.*]] = mod_arith.add %[[SQUARE0]], %[[SQUARE1]] : !z7_i32
+  // CHECK: %[[SQUARE:.*]] = mod_arith.square %[[COEFFS]]#1 : !z7_i32
+  // CHECK: %[[SQUARE2:.*]] = mod_arith.square %[[COEFFS]]#0 : !z7_i32
+  // CHECK: %[[ADD:.*]] = mod_arith.add %[[SQUARE2]], %[[SQUARE]] : !z7_i32
   // CHECK: %[[INV:.*]] = mod_arith.inverse %[[ADD]] : !z7_i32
   // CHECK: %[[MUL:.*]] = mod_arith.mul %[[COEFFS]]#0, %[[INV]] : !z7_i32
   // CHECK: %[[NEG:.*]] = mod_arith.negate %[[COEFFS]]#1 : !z7_i32

--- a/third_party/zk_dtypes/workspace.bzl
+++ b/third_party/zk_dtypes/workspace.bzl
@@ -17,8 +17,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def repo():
-    ZK_DTYPES_COMMIT = "66743801229c6d41e2a38a81f65d521c4bb3e4ea"
-    ZK_DTYPES_SHA256 = "e977c7a248ac81020fd327b78f3df6b8bcf930e6a697c48a79232fd43bd5f8ae"
+    ZK_DTYPES_COMMIT = "c1ccdc3aa30665c1847578c6938255b597c65e8b"
+    ZK_DTYPES_SHA256 = "e2680dff0ffc7b9c44992b7c2d637603e77a93a49aa60c312d63af47abeac6e0"
     http_archive(
         name = "zk_dtypes",
         sha256 = ZK_DTYPES_SHA256,

--- a/zkir/Dialect/Field/Conversions/FieldToModArith/BUILD.bazel
+++ b/zkir/Dialect/Field/Conversions/FieldToModArith/BUILD.bazel
@@ -35,6 +35,18 @@ cc_library(
 )
 
 cc_library(
+    name = "ExtensionFieldCodeGen",
+    hdrs = ["ExtensionFieldCodeGen.h"],
+    deps = [
+        ":ConversionUtils",
+        ":PrimeFieldCodeGen",
+        "//zkir/Dialect/Field/IR:Field",
+        "@llvm-project//mlir:IR",
+        "@zk_dtypes//zk_dtypes:extension_field_operations",
+    ],
+)
+
+cc_library(
     name = "FieldToModArith",
     srcs = ["FieldToModArith.cpp"],
     hdrs = [
@@ -85,5 +97,15 @@ gentbl_cc_library(
         "//zkir/Dialect/ModArith/IR:td_files",
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)
+
+cc_library(
+    name = "PrimeFieldCodeGen",
+    srcs = ["PrimeFieldCodeGen.cpp"],
+    hdrs = ["PrimeFieldCodeGen.h"],
+    deps = [
+        "//zkir/Dialect/ModArith/IR:ModArith",
+        "@llvm-project//mlir:IR",
     ],
 )

--- a/zkir/Dialect/Field/Conversions/FieldToModArith/Extension/BUILD.bazel
+++ b/zkir/Dialect/Field/Conversions/FieldToModArith/Extension/BUILD.bazel
@@ -33,6 +33,7 @@ cc_library(
     hdrs = ["ExtensionField.h"],
     deps = [
         "//zkir/Dialect/Field/Conversions/FieldToModArith:ConversionUtils",
+        "//zkir/Dialect/Field/Conversions/FieldToModArith:ExtensionFieldCodeGen",
         "//zkir/Dialect/Field/IR:Field",
         "//zkir/Dialect/ModArith/IR:ModArith",
         "//zkir/Utils:APIntUtils",

--- a/zkir/Dialect/Field/Conversions/FieldToModArith/Extension/QuadraticExtensionField.cpp
+++ b/zkir/Dialect/Field/Conversions/FieldToModArith/Extension/QuadraticExtensionField.cpp
@@ -15,89 +15,24 @@ limitations under the License.
 
 #include "zkir/Dialect/Field/Conversions/FieldToModArith/Extension/QuadraticExtensionField.h"
 
-#include "zkir/Dialect/Field/Conversions/FieldToModArith/ConversionUtils.h"
-#include "zkir/Dialect/ModArith/IR/ModArithOps.h"
+#include "zkir/Dialect/Field/Conversions/FieldToModArith/ExtensionFieldCodeGen.h"
 
 namespace mlir::zkir::field {
 
 Value QuadraticExtensionField::square(Value x) {
-  // For x = x₀ + x₁ * u where u² = β:
-
-  auto coeffs = toCoeffs(b, x);
-  auto x0 = coeffs[0];
-  auto x1 = coeffs[1];
-
-  // v₀ = x₀ - x₁
-  auto v0 = b.create<mod_arith::SubOp>(x0, x1);
-
-  // v₁ = x₀ - βx₁
-  auto betaTimesX1 = b.create<mod_arith::MulOp>(nonResidue, x1);
-  auto v1 = b.create<mod_arith::SubOp>(x0, betaTimesX1);
-
-  // v₂ = x₀ * x₁
-  auto v2 = b.create<mod_arith::MulOp>(x0, x1);
-
-  // v₃ = v₀ * v₁ + v₂
-  auto v0TimesV1 = b.create<mod_arith::MulOp>(v0, v1);
-  auto v3 = b.create<mod_arith::AddOp>(v0TimesV1, v2);
-
-  // y₁ = 2 * v₂
-  auto y1 = b.create<mod_arith::DoubleOp>(v2);
-  // y₀ = v₃ + βv₂
-  auto betaTimesV2 = b.create<mod_arith::MulOp>(nonResidue, v2);
-  auto y0 = b.create<mod_arith::AddOp>(v3, betaTimesV2);
-  return fromCoeffs(b, type, {y0, y1});
+  ExtensionFieldCodeGen<2> xGen(&b, x.getType(), x, nonResidue);
+  return xGen.Square().getValue();
 }
 
 Value QuadraticExtensionField::mul(Value x, Value y) {
-  // For x = x₀ + x₁ * u and y = y₀ + y₁ * u where u² = β:
-
-  auto xCoeffs = toCoeffs(b, x);
-  auto x0 = xCoeffs[0];
-  auto x1 = xCoeffs[1];
-  auto yCoeffs = toCoeffs(b, y);
-  auto y0 = yCoeffs[0];
-  auto y1 = yCoeffs[1];
-
-  // v₀ = x₀ * y₀
-  // v₁ = x₁ * y₁
-  auto v0 = b.create<mod_arith::MulOp>(x0, y0);
-  auto v1 = b.create<mod_arith::MulOp>(x1, y1);
-
-  // z₀ = v₀ + βv₁
-  auto betaTimesV1 = b.create<mod_arith::MulOp>(nonResidue, v1);
-  auto z0 = b.create<mod_arith::AddOp>(v0, betaTimesV1);
-
-  // z₁ = (x₀ + x₁)(y₀ + y₁) - v₀ - v₁
-  auto sumX = b.create<mod_arith::AddOp>(x0, x1);
-  auto sumY = b.create<mod_arith::AddOp>(y0, y1);
-  auto sumProduct = b.create<mod_arith::MulOp>(sumX, sumY);
-  auto z1 = b.create<mod_arith::SubOp>(sumProduct, v0);
-  z1 = b.create<mod_arith::SubOp>(z1, v1);
-
-  return fromCoeffs(b, type, {z0, z1});
+  ExtensionFieldCodeGen<2> xGen(&b, x.getType(), x, nonResidue);
+  ExtensionFieldCodeGen<2> yGen(&b, y.getType(), y, nonResidue);
+  return (xGen * yGen).getValue();
 }
 
 Value QuadraticExtensionField::inverse(Value x) {
-  // For x = x₀ + x₁ * u where u² = β:
-
-  auto coeffs = toCoeffs(b, x);
-  auto x0 = coeffs[0];
-  auto x1 = coeffs[1];
-
-  // denominator = x₀² - x₁²β
-  auto x0Squared = b.create<mod_arith::SquareOp>(x0);
-  auto x1Squared = b.create<mod_arith::SquareOp>(x1);
-  auto betaTimesX1Squared = b.create<mod_arith::MulOp>(nonResidue, x1Squared);
-  auto denominator = b.create<mod_arith::SubOp>(x0Squared, betaTimesX1Squared);
-  auto denominatorInv = b.create<mod_arith::InverseOp>(denominator);
-
-  // y₀ = x₀ / denominator
-  auto y0 = b.create<mod_arith::MulOp>(x0, denominatorInv);
-  // y₁ = -x₁ / denominator
-  auto x1Negated = b.create<mod_arith::NegateOp>(x1);
-  auto y1 = b.create<mod_arith::MulOp>(x1Negated, denominatorInv);
-  return fromCoeffs(b, type, {y0, y1});
+  ExtensionFieldCodeGen<2> xGen(&b, x.getType(), x, nonResidue);
+  return xGen.Inverse().getValue();
 }
 
 } // namespace mlir::zkir::field

--- a/zkir/Dialect/Field/Conversions/FieldToModArith/ExtensionFieldCodeGen.h
+++ b/zkir/Dialect/Field/Conversions/FieldToModArith/ExtensionFieldCodeGen.h
@@ -1,0 +1,93 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZKIR_DIALECT_FIELD_CONVERSIONS_FIELDTOMODARITH_EXTENSIONFIELDCODEGEN_H_
+#define ZKIR_DIALECT_FIELD_CONVERSIONS_FIELDTOMODARITH_EXTENSIONFIELDCODEGEN_H_
+
+#include <cstddef>
+
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
+#include "zk_dtypes/include/field/quadratic_extension_field_operation.h"
+#include "zkir/Dialect/Field/Conversions/FieldToModArith/ConversionUtils.h"
+#include "zkir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.h"
+#include "zkir/Dialect/Field/IR/FieldTypes.h"
+
+namespace mlir::zkir::field {
+
+template <size_t N>
+class ExtensionFieldCodeGen
+    : public zk_dtypes::QuadraticExtensionFieldOperation<
+          ExtensionFieldCodeGen<N>> {
+public:
+  ExtensionFieldCodeGen(ImplicitLocOpBuilder *b, Type type, Value value,
+                        Value nonResidue)
+      : b(b), type(type), value(value), nonResidue(nonResidue) {}
+  ~ExtensionFieldCodeGen() = default;
+
+  Value getValue() const { return value; }
+
+  // zk_dtypes::QuadraticExtensionFieldOperation methods
+  std::array<PrimeFieldCodeGen, N> ToBaseField() const {
+    Operation::result_range coeffs = toCoeffs(*b, value);
+    std::array<PrimeFieldCodeGen, N> ret;
+    for (size_t i = 0; i < N; ++i) {
+      ret[i] = PrimeFieldCodeGen(b, coeffs[i]);
+    }
+    return ret;
+  }
+  ExtensionFieldCodeGen
+  FromBaseFields(const std::array<PrimeFieldCodeGen, N> &values) const {
+    SmallVector<Value, N> coeffs;
+    for (size_t i = 0; i < N; ++i) {
+      coeffs.push_back(values[i].getValue());
+    }
+    return {b, type, fromCoeffs(*b, type, coeffs), nonResidue};
+  }
+  size_t DegreeOverBasePrimeField() const {
+    assert(isa<ExtensionFieldTypeInterface>(type));
+    return N * cast<ExtensionFieldTypeInterface>(type).getDegreeOverBase();
+  }
+  PrimeFieldCodeGen NonResidue() const {
+    return PrimeFieldCodeGen(b, nonResidue);
+  }
+
+private:
+  ImplicitLocOpBuilder *b = nullptr; // not owned
+  Type type;
+  Value value;
+  Value nonResidue;
+};
+
+} // namespace mlir::zkir::field
+
+namespace zk_dtypes {
+
+template <size_t N>
+class ExtensionFieldOperationTraits<
+    mlir::zkir::field::ExtensionFieldCodeGen<N>> {
+public:
+  // TODO(chokobole): Support towers of extension field.
+  using BaseField = mlir::zkir::field::PrimeFieldCodeGen;
+  static constexpr size_t kDegree = N;
+
+  constexpr static bool kHasHint = false;
+};
+
+} // namespace zk_dtypes
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#endif // ZKIR_DIALECT_FIELD_CONVERSIONS_FIELDTOMODARITH_EXTENSIONFIELDCODEGEN_H_

--- a/zkir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.cpp
+++ b/zkir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.cpp
@@ -1,0 +1,60 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "zkir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.h"
+
+#include "zkir/Dialect/ModArith/IR/ModArithOps.h"
+
+namespace mlir::zkir::field {
+
+PrimeFieldCodeGen
+PrimeFieldCodeGen::operator+(const PrimeFieldCodeGen &other) const {
+  return PrimeFieldCodeGen(
+      b, b->create<mod_arith::AddOp>(value, other.value).getOutput());
+}
+
+PrimeFieldCodeGen
+PrimeFieldCodeGen::operator-(const PrimeFieldCodeGen &other) const {
+  return PrimeFieldCodeGen(
+      b, b->create<mod_arith::SubOp>(value, other.value).getOutput());
+}
+
+PrimeFieldCodeGen
+PrimeFieldCodeGen::operator*(const PrimeFieldCodeGen &other) const {
+  return PrimeFieldCodeGen(
+      b, b->create<mod_arith::MulOp>(value, other.value).getOutput());
+}
+
+PrimeFieldCodeGen PrimeFieldCodeGen::operator-() const {
+  return PrimeFieldCodeGen(b,
+                           b->create<mod_arith::NegateOp>(value).getOutput());
+}
+
+PrimeFieldCodeGen PrimeFieldCodeGen::Double() const {
+  return PrimeFieldCodeGen(b,
+                           b->create<mod_arith::DoubleOp>(value).getOutput());
+}
+
+PrimeFieldCodeGen PrimeFieldCodeGen::Square() const {
+  return PrimeFieldCodeGen(b,
+                           b->create<mod_arith::SquareOp>(value).getOutput());
+}
+
+PrimeFieldCodeGen PrimeFieldCodeGen::Inverse() const {
+  return PrimeFieldCodeGen(b,
+                           b->create<mod_arith::InverseOp>(value).getOutput());
+}
+
+} // namespace mlir::zkir::field

--- a/zkir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.h
+++ b/zkir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.h
@@ -1,0 +1,48 @@
+/* Copyright 2025 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZKIR_DIALECT_FIELD_CONVERSIONS_FIELDTOMODARITH_PRIMEFIELDCODEGEN_H_
+#define ZKIR_DIALECT_FIELD_CONVERSIONS_FIELDTOMODARITH_PRIMEFIELDCODEGEN_H_
+
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Value.h"
+
+namespace mlir::zkir::field {
+
+class PrimeFieldCodeGen {
+public:
+  PrimeFieldCodeGen() = default;
+  PrimeFieldCodeGen(ImplicitLocOpBuilder *b, Value value)
+      : b(b), value(value) {}
+  ~PrimeFieldCodeGen() = default;
+
+  Value getValue() const { return value; }
+
+  PrimeFieldCodeGen operator+(const PrimeFieldCodeGen &other) const;
+  PrimeFieldCodeGen operator-(const PrimeFieldCodeGen &other) const;
+  PrimeFieldCodeGen operator*(const PrimeFieldCodeGen &other) const;
+  PrimeFieldCodeGen operator-() const;
+  PrimeFieldCodeGen Double() const;
+  PrimeFieldCodeGen Square() const;
+  PrimeFieldCodeGen Inverse() const;
+
+private:
+  ImplicitLocOpBuilder *b = nullptr; // not owned
+  Value value;
+};
+
+} // namespace mlir::zkir::field
+
+#endif // ZKIR_DIALECT_FIELD_CONVERSIONS_FIELDTOMODARITH_PRIMEFIELDCODEGEN_H_


### PR DESCRIPTION
## Description

ZKIR now utilizes the quadratic extension field algorithm framework provided by `zk_dtypes` to eliminate code duplication in the code generation path.

## Related Issues/PRs

Should be merged after https://github.com/fractalyze/zk_dtypes/pull/9

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
