### PR TITLE
ci: add license notice guide to gemini styleguide

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -186,6 +186,13 @@ ______________________________________________________________________
 - **Pre-commit hooks:** Recommended for enforcing format and lint locally.
 - **CI:** All PRs must pass lint, format, and tests before merge.
 
+______________________________________________________________________
+
+## License
+
+Every file (that could be exceptional case, such as empty BUILD.bazel) should
+have license notice in the top.
+
 [.clang-format]: /.clang-format
 [angular commit convention]: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
 [commit message guideline]: https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md


### PR DESCRIPTION
## Description

This PR adss license notice guide to `.gemini/styleguide.md`

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
