### PR TITLE
build: add `includes=[]` to `td_library()`

### DIFF
--- a/zkir/Dialect/EllipticCurve/IR/BUILD.bazel
+++ b/zkir/Dialect/EllipticCurve/IR/BUILD.bazel
@@ -65,6 +65,7 @@ td_library(
         "EllipticCurveOps.td",
         "EllipticCurveTypes.td",
     ],
+    includes = ["../../../.."],
     deps = [
         "//zkir/Dialect/Field/IR:td_files",
         "//zkir/Utils:CommonTraits",

--- a/zkir/Dialect/Field/IR/BUILD.bazel
+++ b/zkir/Dialect/Field/IR/BUILD.bazel
@@ -65,6 +65,7 @@ td_library(
         "FieldOps.td",
         "FieldTypes.td",
     ],
+    includes = ["../../../.."],
     deps = [
         "//zkir/Dialect/ModArith/IR:td_files",
         "@llvm-project//mlir:ArithOpsTdFiles",

--- a/zkir/Dialect/ModArith/IR/BUILD.bazel
+++ b/zkir/Dialect/ModArith/IR/BUILD.bazel
@@ -66,6 +66,7 @@ td_library(
         "ModArithOps.td",
         "ModArithTypes.td",
     ],
+    includes = ["../../../.."],
     deps = [
         "//zkir/Utils:CommonTraits",
         "@llvm-project//mlir:ArithOpsTdFiles",

--- a/zkir/Dialect/Poly/IR/BUILD.bazel
+++ b/zkir/Dialect/Poly/IR/BUILD.bazel
@@ -60,6 +60,7 @@ td_library(
         "PolyOps.td",
         "PolyTypes.td",
     ],
+    includes = ["../../../.."],
     deps = [
         "@llvm-project//mlir:BuiltinDialectTdFiles",
         "@llvm-project//mlir:DestinationStyleOpInterfaceTdFiles",

--- a/zkir/Dialect/TensorExt/IR/BUILD.bazel
+++ b/zkir/Dialect/TensorExt/IR/BUILD.bazel
@@ -51,6 +51,7 @@ td_library(
         "TensorExtDialect.td",
         "TensorExtOps.td",
     ],
+    includes = ["../../../.."],
     deps = [
         "@llvm-project//mlir:BuiltinDialectTdFiles",
         "@llvm-project//mlir:DestinationStyleOpInterfaceTdFiles",

--- a/zkir/Utils/BUILD.bazel
+++ b/zkir/Utils/BUILD.bazel
@@ -43,12 +43,14 @@ cc_library(
 td_library(
     name = "CommonTraits",
     srcs = ["CommonTraits.td"],
+    includes = ["../.."],
     deps = ["@llvm-project//mlir:OpBaseTdFiles"],
 )
 
 td_library(
     name = "CommonTypeConstraints",
     srcs = ["CommonTypeConstraints.td"],
+    includes = ["../.."],
     deps = ["@llvm-project//mlir:BuiltinDialectTdFiles"],
 )
 


### PR DESCRIPTION
## Description

This PR adds a proper` includes = []` to `td_library()` thanks to @batzor (Originally, i moved all the `td_library()` into project root, but there's a more elegant solution, so I adopt this!)

This change is necessary to allow external repositories (like ZKX) to correctly consume ZKIR's TD files (e.g., `zkir/Dialect/Field/IR/FieldTypes.td`).

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
