### PR TITLE
build: expose LLVM patches and standardize on `-p1` strip level

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,11 +32,10 @@ refresh the patches we carry in this repository.
    are extending an existing patch).
 
 1. Produce an updated patch and copy it back under `third_party/llvm-project/`.
-   Using `--no-prefix` is required so `tools/setup_llvm_clone.sh` can apply the
-   patch without stripping path components:
+   To generate the patch, run this:
 
    ```sh
-   git show HEAD --no-prefix > /path/to/zkir/repo/third_party/llvm-project/<descriptive_name>.patch
+   git show HEAD > /path/to/zkir/repo/third_party/llvm-project/<descriptive_name>.patch
    ```
 
 ### Managing multiple patches
@@ -50,4 +49,4 @@ refresh the patches we carry in this repository.
     `git commit -m "whatever"`.
   - Fold it back into the original commit
     (`git rebase -i <applying-patch-commit>^` and choose `fixup`).
-  - Regenerate the patch: `git show HEAD --no-prefix`.
+  - Regenerate the patch: `git show HEAD`.

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -61,34 +61,13 @@ load("//bazel:zkir_deps.bzl", "zkir_deps")
 zkir_deps()
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//third_party/llvm-project:workspace.bzl", "LLVM_COMMIT", "LLVM_PATCHES", "LLVM_SHA256")
 
-LLVM_COMMIT = "5ed852f7f72855710eeff53179e6a6f2271a3c2a"
-
-LLVM_SHA256 = "95792e50d5f84847721545b645a6ca2c2b3b7610d02e3de07d65a6148e68508c"
-
-# TODO(chokobole): The 'llvm-raw' definition here is not identical to the one used
-# in the ZKX project. We must review the applied patches below and remove any that
-# are not strictly necessary for this project.
 http_archive(
     name = "llvm-raw",
     build_file_content = "# empty",
-    patches = [
-        # TODO(chokobole): Remove once the issues are resolved upstream.
-        "//third_party/llvm-project:cuda_runtime.patch",
-        "//third_party/llvm-project:kernel_outlining.patch",
-        "//third_party/llvm-project:nvptx_lowering.patch",
-        # TODO(chokobole): Remove owning_memref_free.patch once we upgrade the version of LLVM.
-        # See https://github.com/llvm/llvm-project/pull/153133
-        "//third_party/llvm-project:owning_memref_free.patch",
-        # TODO(chokobole): Remove owning_memref_memset.patch once we upgrade the version of LLVM.
-        # See https://github.com/llvm/llvm-project/pull/158200
-        "//third_party/llvm-project:owning_memref_memset.patch",
-        # NOTE(chokobole): Patches for supporting ZKIR Dialects.
-        "//third_party/llvm-project:linalg_type_support.patch",
-        "//third_party/llvm-project:tensor_type_support.patch",
-        "//third_party/llvm-project:vector_type_support.patch",
-        "//third_party/llvm-project:memref_folding.patch",
-    ],
+    patch_args = ["-p1"],
+    patches = LLVM_PATCHES,
     sha256 = LLVM_SHA256,
     strip_prefix = "llvm-project-" + LLVM_COMMIT,
     urls = ["https://github.com/llvm/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT)],

--- a/third_party/llvm-project/cuda_runtime.patch
+++ b/third_party/llvm-project/cuda_runtime.patch
@@ -1,17 +1,21 @@
 diff --git a/mlir/lib/Target/LLVM/NVVM/Target.cpp b/mlir/lib/Target/LLVM/NVVM/Target.cpp
 index 565f153b50c4..839e3284e5b4 100644
---- mlir/lib/Target/LLVM/NVVM/Target.cpp
-+++ mlir/lib/Target/LLVM/NVVM/Target.cpp
-@@ -49,3 +49,3 @@ using namespace mlir;
+--- a/mlir/lib/Target/LLVM/NVVM/Target.cpp
++++ b/mlir/lib/Target/LLVM/NVVM/Target.cpp
+@@ -47,7 +47,7 @@ using namespace mlir;
+ using namespace mlir::NVVM;
+ 
  #ifndef __DEFAULT_CUDATOOLKIT_PATH__
 -#define __DEFAULT_CUDATOOLKIT_PATH__ ""
 +#define __DEFAULT_CUDATOOLKIT_PATH__ "/usr/local/cuda"
  #endif
+ 
+ extern "C" const unsigned char _mlir_embedded_libdevice[];
 diff --git a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
-index 05c2fb481980..9a3d4a534569 100644
---- utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
-+++ utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
-@@ -9243,7 +9243,7 @@ cc_library(
+index cc266c2fe3a7..7543739b3a44 100644
+--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
++++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+@@ -9434,8 +9434,8 @@ cc_library(
          ":LLVMSupportHeaders",
          ":mlir_c_runner_utils_hdrs",
          "@cuda//:cuda_headers",
@@ -21,3 +25,4 @@ index 05c2fb481980..9a3d4a534569 100644
 +        "@cuda//:cusparse_so",
      ],
  )
+ 

--- a/third_party/llvm-project/kernel_outlining.patch
+++ b/third_party/llvm-project/kernel_outlining.patch
@@ -1,7 +1,7 @@
-diff --git i/mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp w/mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp
-index a64ec8d52daf..9a29005e0591 100644
---- mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp
-+++ mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp
+diff --git a/mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp b/mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp
+index a64ec8d52daf..85a41e136f74 100644
+--- a/mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp
++++ b/mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp
 @@ -19,6 +19,7 @@
  #include "mlir/Dialect/Func/IR/FuncOps.h"
  #include "mlir/Dialect/GPU/IR/GPUDialect.h"

--- a/third_party/llvm-project/linalg_type_support.patch
+++ b/third_party/llvm-project/linalg_type_support.patch
@@ -1,7 +1,7 @@
-diff --git mlir/lib/Dialect/Linalg/IR/LinalgInterfaces.cpp w/mlir/lib/Dialect/Linalg/IR/LinalgInterfaces.cpp
+diff --git a/mlir/lib/Dialect/Linalg/IR/LinalgInterfaces.cpp b/mlir/lib/Dialect/Linalg/IR/LinalgInterfaces.cpp
 index ca7f31dd6b51..5b0e32f98e8e 100644
---- mlir/lib/Dialect/Linalg/IR/LinalgInterfaces.cpp
-+++ mlir/lib/Dialect/Linalg/IR/LinalgInterfaces.cpp
+--- a/mlir/lib/Dialect/Linalg/IR/LinalgInterfaces.cpp
++++ b/mlir/lib/Dialect/Linalg/IR/LinalgInterfaces.cpp
 @@ -25,12 +25,18 @@
  #include "llvm/ADT/SmallVector.h"
  #include "llvm/Support/Casting.h"
@@ -14,11 +14,11 @@ index ca7f31dd6b51..5b0e32f98e8e 100644
  #include <algorithm>
  #include <numeric>
  #include <optional>
-
+ 
  using namespace mlir;
  using namespace mlir::linalg;
 +using namespace mlir::zkir;
-
+ 
  /// Include the definitions of the copy operation interface.
  #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.cpp.inc"
 @@ -525,6 +531,9 @@ mlir::linalg::detail::isContractionInterfaceImpl(
@@ -31,10 +31,10 @@ index ca7f31dd6b51..5b0e32f98e8e 100644
          arith::MulFOp, arith::AddFOp,
          arith::MulIOp, arith::AddIOp,
          complex::MulOp, complex::AddOp,
-diff --git mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp w/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
-index 8075df730ccc..0da75c4c81cc 100644
---- mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
-+++ mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+diff --git a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+index 8075df730ccc..5989b699fcfa 100644
+--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
++++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
 @@ -51,6 +51,14 @@
  #include "llvm/Support/LogicalResult.h"
  #include "llvm/Support/MathExtras.h"
@@ -49,11 +49,11 @@ index 8075df730ccc..0da75c4c81cc 100644
 +
  #include <cassert>
  #include <optional>
-
+ 
 @@ -439,8 +447,16 @@ static void printNamedStructuredOp(OpAsmPrinter &p, Operation *op,
-
+ 
  namespace {
-
+ 
 +using namespace ::mlir::zkir;
  class RegionBuilderHelper {
  public:
@@ -66,7 +66,7 @@ index 8075df730ccc..0da75c4c81cc 100644
 +
    RegionBuilderHelper(OpBuilder &builder, Block &block)
        : builder(builder), block(block) {}
-
+ 
 @@ -506,11 +522,20 @@ public:
      bool allInteger = isInteger(arg0) && isInteger(arg1);
      bool allBool = allInteger && arg0.getType().getIntOrFloatBitWidth() == 1 &&
@@ -271,13 +271,13 @@ index 8075df730ccc..0da75c4c81cc 100644
 +           llvm::isa<JacobianType>(value.getType()) ||
 +           llvm::isa<XYZZType>(value.getType());
 +  }
-
+ 
    OpBuilder &builder;
    Block &block;
-diff --git utils/bazel/llvm-project-overlay/mlir/BUILD.bazel w/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
-index cc266c2fe3a7..13b7e256ea64 100644
---- utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
-+++ utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+index 7543739b3a44..4fc82f6c1d27 100644
+--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
++++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
 @@ -10544,6 +10544,9 @@ cc_library(
          ":ValueBoundsOpInterface",
          ":ViewLikeInterface",
@@ -287,4 +287,4 @@ index cc266c2fe3a7..13b7e256ea64 100644
 +        "@zkir//zkir/Dialect/ModArith/IR:ModArith",
      ],
  )
-
+ 

--- a/third_party/llvm-project/memref_folding.patch
+++ b/third_party/llvm-project/memref_folding.patch
@@ -1,7 +1,7 @@
-diff --git mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp
+diff --git a/mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp b/mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp
 index 9bd87d66c7d3..0d0b41f51926 100644
---- mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp
-+++ mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp
+--- a/mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp
++++ b/mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp
 @@ -835,7 +835,7 @@ struct LoadOfToBuffer : public OpRewritePattern<memref::LoadOp> {
    LogicalResult matchAndRewrite(memref::LoadOp load,
                                  PatternRewriter &rewriter) const override {
@@ -9,5 +9,5 @@ index 9bd87d66c7d3..0d0b41f51926 100644
 -    if (!toBuffer)
 +    if (!toBuffer || !toBuffer.getReadOnly())
        return failure();
-
+ 
      rewriter.replaceOpWithNewOp<tensor::ExtractOp>(load, toBuffer.getTensor(),

--- a/third_party/llvm-project/nvptx_lowering.patch
+++ b/third_party/llvm-project/nvptx_lowering.patch
@@ -1,7 +1,7 @@
-diff --git i/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp w/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+diff --git a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
 index d817a3c6a877..480e1c676dc1 100644
---- llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
-+++ llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
++++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
 @@ -308,6 +308,17 @@ static void ComputePTXValueVTs(const TargetLowering &TLI, const DataLayout &DL,
      return;
    }

--- a/third_party/llvm-project/owning_memref_free.patch
+++ b/third_party/llvm-project/owning_memref_free.patch
@@ -1,8 +1,8 @@
 diff --git a/mlir/include/mlir/ExecutionEngine/MemRefUtils.h b/mlir/include/mlir/ExecutionEngine/MemRefUtils.h
-index 918647d9feac..be12881883ad 100644
---- mlir/include/mlir/ExecutionEngine/MemRefUtils.h
-+++ mlir/include/mlir/ExecutionEngine/MemRefUtils.h
-@@ -150,7 +150,7 @@ public:
+index f355dfb8648e..34e69c95fda7 100644
+--- a/mlir/include/mlir/ExecutionEngine/MemRefUtils.h
++++ b/mlir/include/mlir/ExecutionEngine/MemRefUtils.h
+@@ -151,7 +151,7 @@ public:
        AllocFunType allocFun = &::malloc,
        std::function<void(StridedMemRefType<T, Rank>)> freeFun =
            [](StridedMemRefType<T, Rank> descriptor) {

--- a/third_party/llvm-project/owning_memref_memset.patch
+++ b/third_party/llvm-project/owning_memref_memset.patch
@@ -1,7 +1,7 @@
 diff --git a/mlir/include/mlir/ExecutionEngine/MemRefUtils.h b/mlir/include/mlir/ExecutionEngine/MemRefUtils.h
-index f355dfb8648e..1b2cd162ff5d 100644
---- mlir/include/mlir/ExecutionEngine/MemRefUtils.h
-+++ mlir/include/mlir/ExecutionEngine/MemRefUtils.h
+index 34e69c95fda7..8e0d1e6bae83 100644
+--- a/mlir/include/mlir/ExecutionEngine/MemRefUtils.h
++++ b/mlir/include/mlir/ExecutionEngine/MemRefUtils.h
 @@ -174,9 +174,7 @@ public:
             it != end; ++it)
          init(*it, it.getIndices());

--- a/third_party/llvm-project/tensor_type_support.patch
+++ b/third_party/llvm-project/tensor_type_support.patch
@@ -1,7 +1,7 @@
-diff --git mlir/lib/Dialect/Tensor/IR/TensorOps.cpp mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+diff --git a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
 index 22a25fd1a5af..1832036990e4 100644
---- mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
-+++ mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+--- a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
++++ b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
 @@ -41,6 +41,10 @@
  #include <optional>
  #include <vector>
@@ -49,10 +49,10 @@ index 22a25fd1a5af..1832036990e4 100644
  }
  
  //===----------------------------------------------------------------------===//
-diff --git utils/bazel/llvm-project-overlay/mlir/BUILD.bazel utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
 index 4fc82f6c1d27..f7722951646c 100644
---- utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
-+++ utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
++++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
 @@ -7134,6 +7134,9 @@ cc_library(
          ":ValueBoundsOpInterface",
          ":ViewLikeInterface",

--- a/third_party/llvm-project/vector_type_support.patch
+++ b/third_party/llvm-project/vector_type_support.patch
@@ -1,7 +1,7 @@
-diff --git mlir/lib/Dialect/Vector/IR/VectorOps.cpp mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+diff --git a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
 index 1fb8c7a928e0..bce5fd54a14d 100644
---- mlir/lib/Dialect/Vector/IR/VectorOps.cpp
-+++ mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
++++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
 @@ -38,6 +38,9 @@
  #include "mlir/Interfaces/ValueBoundsOpInterface.h"
  #include "mlir/Support/LLVM.h"
@@ -173,10 +173,10 @@ index 1fb8c7a928e0..bce5fd54a14d 100644
  }
  
  void SplatOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
-diff --git utils/bazel/llvm-project-overlay/mlir/BUILD.bazel utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
 index f7722951646c..008946b81e69 100644
---- utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
-+++ utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
++++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
 @@ -4713,6 +4713,9 @@ cc_library(
          ":VectorOpsIncGen",
          ":ViewLikeInterface",

--- a/third_party/llvm-project/workspace.bzl
+++ b/third_party/llvm-project/workspace.bzl
@@ -1,0 +1,38 @@
+# Copyright 2025 The ZKIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# buildifier: disable=module-docstring
+LLVM_COMMIT = "5ed852f7f72855710eeff53179e6a6f2271a3c2a"
+
+LLVM_SHA256 = "95792e50d5f84847721545b645a6ca2c2b3b7610d02e3de07d65a6148e68508c"
+
+# TODO(chokobole): We must review the applied patches below and remove any that
+# are not strictly necessary for this project.
+LLVM_PATCHES = [
+    # TODO(chokobole): Remove once the issues are resolved upstream.
+    "@zkir//third_party/llvm-project:cuda_runtime.patch",
+    "@zkir//third_party/llvm-project:kernel_outlining.patch",
+    "@zkir//third_party/llvm-project:nvptx_lowering.patch",
+    # TODO(chokobole): Remove owning_memref_free.patch once we upgrade the version of LLVM.
+    # See https://github.com/llvm/llvm-project/pull/153133
+    "@zkir//third_party/llvm-project:owning_memref_free.patch",
+    # TODO(chokobole): Remove owning_memref_memset.patch once we upgrade the version of LLVM.
+    # See https://github.com/llvm/llvm-project/pull/158200
+    "@zkir//third_party/llvm-project:owning_memref_memset.patch",
+    # NOTE(chokobole): Patches for supporting ZKIR Dialects.
+    "@zkir//third_party/llvm-project:linalg_type_support.patch",
+    "@zkir//third_party/llvm-project:tensor_type_support.patch",
+    "@zkir//third_party/llvm-project:vector_type_support.patch",
+    "@zkir//third_party/llvm-project:memref_folding.patch",
+]

--- a/tools/setup_llvm_clone.sh
+++ b/tools/setup_llvm_clone.sh
@@ -30,10 +30,10 @@ if [[ ! -d "$dest_dir/.git" ]]; then
     git clone https://github.com/llvm/llvm-project.git "$dest_dir"
 fi
 
-llvm_commit=$(awk -F'"' '/LLVM_COMMIT/ {print $2; exit}' "$repo_root/WORKSPACE.bazel")
+llvm_commit=$(awk -F'"' '/LLVM_COMMIT/ {print $2; exit}' "$repo_root/third_party/llvm-project/workspace.bzl")
 
 if [[ -z $llvm_commit ]]; then
-    echo "error: unable to locate LLVM_COMMIT in WORKSPACE.bazel" >&2
+    echo "error: unable to locate LLVM_COMMIT in third_party/llvm-project/workspace.bzl" >&2
     exit 1
 fi
 
@@ -60,11 +60,11 @@ fi
     cd "$dest_dir"
     for patch in "${patches[@]}"; do
         patch_name=$(basename "$patch")
-        if git apply --check -p0 "$patch" >/dev/null 2>&1; then
-            git apply --verbose -p0 "$patch"
-        else
-            git apply --verbose "$patch"
+        if ! git apply --check -p1 "$patch" >/dev/null 2>&1; then
+            echo "error: patch '$patch_name' cannot be applied with -p1." >&2
+            exit 1
         fi
+        git apply --verbose -p1 "$patch"
         if [[ -n $(git status --porcelain) ]]; then
             git add -A
             git commit -m "Apply $patch_name"


### PR DESCRIPTION
## Description

This PR exposes LLVM patches and version metadata to external repositories and standardizes the patch format to use the default git `a/b` prefix (`-p1`).

**Rationale:**
Internal ZKIR LLVM patches were previously applied using `strip=0` (no prefix). However, external projects (like ZKX) typically expect `strip=1` by default. To prevent "mismatched LLVM" errors in external builds and to align with standard `git diff` output, all patches have been regenerated to include the `a/` and `b/` virtual directory prefixes.

**Key Changes:**
1.  **Metadata Extraction:** Moved `LLVM_COMMIT`, `LLVM_SHA256`, and `LLVM_PATCHES` from `WORKSPACE.bazel` to a new shared file: `third_party/llvm-project/workspace.bzl`.
2.  **Patch Standardization:** Regenerated all `.patch` files in `third_party/llvm-project/` to use the standard git prefix format.
3.  **Build Configuration:** Updated `http_archive` in `WORKSPACE.bazel` to use `patch_args = ["-p1"]`.
4.  **Tooling Update:** Modified `tools/setup_llvm_clone.sh` and `CONTRIBUTING.md` to remove the `--no-prefix` requirement, simplifying the patch regeneration workflow.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
