### PR TITLE
docs: improve contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,25 +28,55 @@ refresh the patches we carry in this repository.
      )
      ```
 
-1. Implement and test your LLVM changes (see “Managing multiple patches” if you
-   are extending an existing patch).
+1. Implement and test your changes within the LLVM source tree.
 
-1. Produce an updated patch and copy it back under `third_party/llvm-project/`.
-   To generate the patch, run this:
+1. Produce a patch file using your preferred method:
 
-   ```sh
-   git show HEAD > /path/to/zkir/repo/third_party/llvm-project/<descriptive_name>.patch
-   ```
+   - `git diff` (Unstaged changes)
+   - `git diff --cached` (Staged changes)
+   - `git show HEAD --pretty=""` (The most recent commit)
 
-### Managing multiple patches
+1. Copy the generated patch file into `third_party/llvm-project/`.
+
+### Extending patches
 
 - Keep a dedicated local branch (created automatically by the helper script) so
   each patch remains its own commit and can be edited independently.
+
 - When work must happen “within” an existing patch:
-  - Reset to the commit that represents the patch:
-    `git reset --hard <applying-patch-commit>`.
-  - Implement your changes and create a temporary commit:
-    `git commit -m "whatever"`.
-  - Fold it back into the original commit
-    (`git rebase -i <applying-patch-commit>^` and choose `fixup`).
-  - Regenerate the patch: `git show HEAD`.
+
+  1. **Enter Edit Mode:** Locate the commit for the specific patch you want to
+     update. Use interactive rebase:
+
+     ```shell
+     git rebase -i <target-patch-commit>^
+     ```
+
+     Then, mark the target commit as `edit`.
+
+  1. **Apply Changes:** Make the necessary code modifications.
+
+  1. **Stage Changes:**
+
+     ```shell
+     git add --update
+     ```
+
+  1. **Amend the Commit:**
+
+     ```shell
+     git commit --amend
+     ```
+
+  1. **Regenerate the Patch:** Overwrite the existing patch file in your project
+     directory:
+
+     ```shell
+     git show HEAD --pretty="" > /path/to/zkir/third_party/llvm-project/<patch_name>.patch
+     ```
+
+  1. **Finalize Rebase:** Return to the current `HEAD`:
+
+     ```shell
+     git rebase --continue
+     ```


### PR DESCRIPTION
## Description

Updates the guidelines for managing and extending LLVM patches to ensure cleaner patch files and a more robust git history.

**Key Changes:**
1.  **Cleaner Patch Generation:** Added `--pretty=""` to the `git show` command to exclude commit metadata (author, date, SHA) from generated `.patch` files, ensuring they only contain the relevant diff.
2.  **Expanded Patch Methods:** Documented various ways to produce a patch, including `git diff` (unstaged), `git diff --cached` (staged), and `git show HEAD` (committed).
3.  **Improved Extension Workflow:** Replaced the `git reset --hard` method for updating patches with a `git rebase -i` (interactive rebase) workflow. This prevents losing the current `HEAD` and provides a safer way to amend specific patches within a multi-commit local branch.

## Related Issues/PRs

https://github.com/fractalyze/zkir/pull/141#discussion_r2633795142

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
