### PR TITLE
refactor(field): expose `parseFieldConstant()` for cross-dialect compatibility

### DIFF
--- a/zkir/Dialect/Field/IR/FieldOps.h
+++ b/zkir/Dialect/Field/IR/FieldOps.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef ZKIR_DIALECT_FIELD_IR_FIELDOPS_H_
 #define ZKIR_DIALECT_FIELD_IR_FIELDOPS_H_
 
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/OperationSupport.h"
 #include "zkir/Dialect/Field/IR/FieldAttributes.h"
 #include "zkir/Dialect/Field/IR/FieldTypes.h"
 
@@ -37,6 +39,8 @@ PrimeFieldType getResultPrimeFieldType(OpType op) {
 
 Type getStandardFormType(Type type);
 Type getMontgomeryFormType(Type type);
+
+ParseResult parseFieldConstant(OpAsmParser &parser, OperationState &result);
 
 } // namespace mlir::zkir::field
 


### PR DESCRIPTION
## Description

This PR refactors the constant parsing logic to expose `parseFieldConstant()`, allowing other dialects to parse field-based constant attributes.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
