### PR TITLE
fix(utils): resolve field alias collision between standard and Montgomery forms

### DIFF
--- a/zkir/Utils/KnownModulus.cpp
+++ b/zkir/Utils/KnownModulus.cpp
@@ -29,6 +29,10 @@ namespace {
 template <typename T>
 void registerKnownModulusAliases(DenseMap<APInt, std::string> &map,
                                  std::string_view name) {
+  if (name.size() >= 4 && name.substr(name.size() - 4) == "_std") {
+    return;
+  }
+
   APInt modulus;
   modulus = convertToAPInt(T::Config::kModulus, T::Config::kModulusBits);
   map[modulus] = name;


### PR DESCRIPTION
## Description

This PR fixes an issue where prime field attributes were incorrectly aliased, causing Montgomery forms to be printed as standard forms.

**Example output before fix:**

```mlir
!pf_babybear_std = !field.pf<2013265921 : i32, true>
```


## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
