### PR TITLE
feat(field): support zk_dtypes Karatsuba operation

### DIFF
--- a/third_party/zk_dtypes/workspace.bzl
+++ b/third_party/zk_dtypes/workspace.bzl
@@ -17,8 +17,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def repo():
-    ZK_DTYPES_COMMIT = "99ffae4d3b121b4983c553589cef536c120c5e86"
-    ZK_DTYPES_SHA256 = "9c3477f988163f07c213efc0c12cc30f1882891f6376e1621a6e2383a7eeb701"
+    ZK_DTYPES_COMMIT = "50951b9e83ae78c99ed88b3cbf466da5cc17b951"
+    ZK_DTYPES_SHA256 = "23bb47fb4ab5a0e47995d8994b03e4619e5ed7a1547f65edd3c2e3d2865e828f"
     http_archive(
         name = "zk_dtypes",
         sha256 = ZK_DTYPES_SHA256,

--- a/zkir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.cpp
+++ b/zkir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.cpp
@@ -25,16 +25,34 @@ PrimeFieldCodeGen::operator+(const PrimeFieldCodeGen &other) const {
       b, b->create<mod_arith::AddOp>(value, other.value).getOutput());
 }
 
+PrimeFieldCodeGen &
+PrimeFieldCodeGen::operator+=(const PrimeFieldCodeGen &other) {
+  value = b->create<mod_arith::AddOp>(value, other.value).getOutput();
+  return *this;
+}
+
 PrimeFieldCodeGen
 PrimeFieldCodeGen::operator-(const PrimeFieldCodeGen &other) const {
   return PrimeFieldCodeGen(
       b, b->create<mod_arith::SubOp>(value, other.value).getOutput());
 }
 
+PrimeFieldCodeGen &
+PrimeFieldCodeGen::operator-=(const PrimeFieldCodeGen &other) {
+  value = b->create<mod_arith::SubOp>(value, other.value).getOutput();
+  return *this;
+}
+
 PrimeFieldCodeGen
 PrimeFieldCodeGen::operator*(const PrimeFieldCodeGen &other) const {
   return PrimeFieldCodeGen(
       b, b->create<mod_arith::MulOp>(value, other.value).getOutput());
+}
+
+PrimeFieldCodeGen &
+PrimeFieldCodeGen::operator*=(const PrimeFieldCodeGen &other) {
+  value = b->create<mod_arith::MulOp>(value, other.value).getOutput();
+  return *this;
 }
 
 PrimeFieldCodeGen PrimeFieldCodeGen::operator-() const {

--- a/zkir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.h
+++ b/zkir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.h
@@ -32,8 +32,11 @@ public:
   operator Value() const { return value; }
 
   PrimeFieldCodeGen operator+(const PrimeFieldCodeGen &other) const;
+  PrimeFieldCodeGen &operator+=(const PrimeFieldCodeGen &other);
   PrimeFieldCodeGen operator-(const PrimeFieldCodeGen &other) const;
+  PrimeFieldCodeGen &operator-=(const PrimeFieldCodeGen &other);
   PrimeFieldCodeGen operator*(const PrimeFieldCodeGen &other) const;
+  PrimeFieldCodeGen &operator*=(const PrimeFieldCodeGen &other);
   PrimeFieldCodeGen operator-() const;
   PrimeFieldCodeGen Double() const;
   PrimeFieldCodeGen Square() const;


### PR DESCRIPTION
## Description
Add GetSquareAlgorithm() and CreateZeroBaseField() methods to ExtensionFieldCodeGen.
Also add operator+=, operator-=, and operator*= to PrimeFieldCodeGen.

## Related Issues/PRs
- https://github.com/fractalyze/zk_dtypes/pull/34

## Checklist
- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline