### PR TITLE
refactor: update `zk_dtypes` and migrate to `kStorageBits` in KnownModulus

### DIFF
--- a/third_party/zk_dtypes/workspace.bzl
+++ b/third_party/zk_dtypes/workspace.bzl
@@ -17,8 +17,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def repo():
-    ZK_DTYPES_COMMIT = "242f9c5190cf02dfbe21deef26a8f0dd2c6330a0"
-    ZK_DTYPES_SHA256 = "124a43b5e390d15af2f88f38946c66aa1f5c34d4b941b4d031db017ebe3cb1cb"
+    ZK_DTYPES_COMMIT = "f45a18c9297da1e9235c0488a5a19034536e3cd2"
+    ZK_DTYPES_SHA256 = "31e750a60c27b0f48179869917d5eaa3385d61aa9f76b16f374012a3d133dee8"
     http_archive(
         name = "zk_dtypes",
         sha256 = ZK_DTYPES_SHA256,

--- a/zkir/Utils/KnownModulus.cpp
+++ b/zkir/Utils/KnownModulus.cpp
@@ -34,10 +34,10 @@ void registerKnownModulusAliases(DenseMap<APInt, std::string> &map,
   }
 
   APInt modulus;
-  modulus = convertToAPInt(T::Config::kModulus, T::Config::kModulusBits);
+  modulus = convertToAPInt(T::Config::kModulus, T::Config::kStorageBits);
   map[modulus] = name;
-  if constexpr (!isPowerOfTwo(T::Config::kModulusBits)) {
-    map[modulus.zext(llvm::bit_ceil(T::Config::kModulusBits))] = name;
+  if constexpr (!isPowerOfTwo(T::Config::kStorageBits)) {
+    map[modulus.zext(llvm::bit_ceil(T::Config::kStorageBits))] = name;
   }
 }
 


### PR DESCRIPTION
## Description

This updates the `zk_dtypes` dependency to a newer commit and refactors the modulus alias registration logic to use `kStorageBits` instead of `kModulusBits`.

## Related Issues/PRs

https://github.com/fractalyze/zk_dtypes/pull/49(Should be merged after this)

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
