### PR TITLE
build: comment out source file validation assert

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -115,6 +115,8 @@ llvm_configure(name = "llvm-project")
 # https://github.com/hedronvision/bazel-compile-commands-extractor
 http_archive(
     name = "hedron_compile_commands",
+    patch_args = ["-p1"],
+    patches = ["@zk_dtypes//third_party/bazel-compile-commands-extractor:allow_header_as_a_source_file.patch"],
     strip_prefix = "bazel-compile-commands-extractor-ed994039a951b736091776d677f324b3903ef939",
     url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/ed994039a951b736091776d677f324b3903ef939.tar.gz",
 )


### PR DESCRIPTION
## Description

Comments out the source file validation `assert` in the `refresh_compile_commands.py` script to fix an `AssertionError`.

The issue was caused by the script's inability to correctly handle C++ header compilation commands (those using `-xc++-header -fsyntax-only`), leading it to incorrectly identify a header file (e.g., `check.h`) as a source file, which failed the extension validation assert.

## Related Issues/PRs

https://github.com/fractalyze/zk_dtypes/commit/0d54bdf

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)