### PR TITLE
test(field): fix tests for lowering inversion over cubic and quartic extension field

### DIFF
--- a/tests/Dialect/Field/cubic_ext_field_to_mod_arith.mlir
+++ b/tests/Dialect/Field/cubic_ext_field_to_mod_arith.mlir
@@ -62,43 +62,31 @@ func.func @test_lower_square(%arg0: !CF) -> !CF {
 
 // CHECK-LABEL: @test_lower_inverse
 func.func @test_lower_inverse(%arg0: !CF) -> !CF {
-    // TODO(junbeomlee): After canonicalization, this should be optimized to:
+    // CHECK: mod_arith.constant 2 : !z7_i32
+    // CHECK: field.ext_to_coeffs
     //   t₀ = x₀² - ξ * x₁ * x₂
+    // CHECK: mod_arith.square
+    // CHECK: mod_arith.mul
+    // CHECK: mod_arith.mul
+    // CHECK: mod_arith.sub
     //   t₁ = ξ * x₂² - x₀ * x₁
+    // CHECK: mod_arith.square
+    // CHECK: mod_arith.mul
+    // CHECK: mod_arith.mul
+    // CHECK: mod_arith.sub
     //   t₂ = x₁² - x₀ * x₂
+    // CHECK: mod_arith.square
+    // CHECK: mod_arith.mul
+    // CHECK: mod_arith.sub
     //   t₃ = x₀ * t₀ + ξ * (x₂ * t₁ + x₁ * t₂)
+    // CHECK: mod_arith.mul
+    // CHECK: mod_arith.mul
+    // CHECK: mod_arith.mul
+    // CHECK: mod_arith.add
+    // CHECK: mod_arith.mul
+    // CHECK: mod_arith.add
     //   (y₀, y₁, y₂) = (t₀, t₁, t₂) * t₃⁻¹
-    // (3 squares + 12 muls + 1 inverse)
-    //
-    // Frobenius-based inverse: x⁻¹ = Frobenius_product(x) * Norm(x)⁻¹
-    // Frobenius_product = φ¹(x) * φ²(x)
-    //
-    // Frobenius φ¹(x): coeffs scaled by ξ^(i * (p - 1) / 3)
-    // CHECK: field.ext_to_coeffs
-    // CHECK-COUNT-2: mod_arith.mul
-    // CHECK: field.ext_from_coeffs
-    //
-    // Frobenius φ²(x): coeffs scaled by ξ^(i * (p² - 1) / 3)
-    // CHECK: field.ext_to_coeffs
-    // CHECK-COUNT-2: mod_arith.mul
-    // CHECK: field.ext_from_coeffs
-    //
-    // Karatsuba mul: φ¹(x) * φ²(x)
-    // CHECK-COUNT-2: field.ext_to_coeffs
-    // CHECK-COUNT-6: mod_arith.mul
-    // CHECK: field.ext_from_coeffs
-    //
-    // Direct mul: x * frob_product (for norm)
-    // CHECK-COUNT-2: mod_arith.mul
-    // CHECK: mod_arith.add
-    // CHECK-COUNT-2: mod_arith.mul
-    // CHECK: mod_arith.add
-    //
-    // Norm inverse:
     // CHECK: mod_arith.inverse
-    //
-    // Final scaling: frob_product * norm⁻¹
-    // CHECK: field.ext_to_coeffs
     // CHECK-COUNT-3: mod_arith.mul
     // CHECK: field.ext_from_coeffs
     %inv = field.inverse %arg0 : !CF

--- a/third_party/zk_dtypes/workspace.bzl
+++ b/third_party/zk_dtypes/workspace.bzl
@@ -17,8 +17,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def repo():
-    ZK_DTYPES_COMMIT = "970b24cb594b32c6439b284264491d207b7048ab"
-    ZK_DTYPES_SHA256 = "bcb8117f7cdc44f47f2dbbb2d7c76e217d38fe7927356514b5a8a47b06c64e8e"
+    ZK_DTYPES_COMMIT = "a6b5fb7e046594a45b5981e67271b0b7c2394c71"
+    ZK_DTYPES_SHA256 = "20aecb7cff60ede1a37ef3bb48352308f05c4feb07b8c04fa1304a4b0bfd1c57"
     http_archive(
         name = "zk_dtypes",
         sha256 = ZK_DTYPES_SHA256,


### PR DESCRIPTION
## Description

Due to change of inverse algorithms in `zk_dtypes` for cubic and quartic extension field, this PR fixes tests for lowering inversion.

## Related Issues/PRs

- https://github.com/fractalyze/zk_dtypes/pull/57

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
