### PR TITLE
refactor: update type after domain conversion

### DIFF
--- a/zkir/Dialect/Field/IR/FieldOperation.h
+++ b/zkir/Dialect/Field/IR/FieldOperation.h
@@ -113,10 +113,16 @@ public:
     return PrimeFieldOperation::fromUnchecked(op.inverse(), type);
   }
   PrimeFieldOperation fromMont() const {
-    return PrimeFieldOperation::fromUnchecked(op.fromMont(), type);
+    assert(type.isMontgomery());
+    auto stdType =
+        PrimeFieldType::get(type.getContext(), type.getModulus(), false);
+    return PrimeFieldOperation::fromUnchecked(op.fromMont(), stdType);
   }
   PrimeFieldOperation toMont() const {
-    return PrimeFieldOperation::fromUnchecked(op.toMont(), type);
+    assert(!type.isMontgomery());
+    auto montType =
+        PrimeFieldType::get(type.getContext(), type.getModulus(), true);
+    return PrimeFieldOperation::fromUnchecked(op.toMont(), montType);
   }
   bool isOne() const { return op.isOne(); }
   bool isZero() const { return op.isZero(); }

--- a/zkir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/zkir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -516,13 +516,6 @@ struct ConvertMul : public OpConversionPattern<MulOp> {
           auto rhsStdOp =
               ModArithOperation::fromUnchecked(rhsInt.getValue(), modType);
           if (modType.isMontgomery()) {
-            // NOTE(chokobole): Ideally, we should convert the underlying
-            // 'modType' to standard form here. Normalizing to standard form
-            // would improve performance by allowing us to bypass redundant
-            // Montgomery reductions during comparisons.
-            //
-            // For now, we perform a local 'fromMont()' conversion to extract
-            // the values only.
             rhsStdOp = rhsStdOp.fromMont();
           }
           rhsStd = rhsStdOp.getIntegerAttr();

--- a/zkir/Dialect/ModArith/IR/ModArithOps.cpp
+++ b/zkir/Dialect/ModArith/IR/ModArithOps.cpp
@@ -228,7 +228,9 @@ public:
   using UnaryModArithConstantFolder::UnaryModArithConstantFolder;
 
   APInt operate(const APInt &value) const final {
-    return ModArithOperation::fromUnchecked(value, modArithType).toMont();
+    auto stdType = cast<ModArithType>(
+        getElementTypeOrSelf(getStandardFormType(modArithType)));
+    return ModArithOperation::fromUnchecked(value, stdType).toMont();
   }
 };
 
@@ -246,7 +248,9 @@ public:
   using UnaryModArithConstantFolder::UnaryModArithConstantFolder;
 
   APInt operate(const APInt &value) const final {
-    return ModArithOperation::fromUnchecked(value, modArithType).fromMont();
+    auto montType = cast<ModArithType>(
+        getElementTypeOrSelf(getMontgomeryFormType(modArithType)));
+    return ModArithOperation::fromUnchecked(value, montType).fromMont();
   }
 };
 
@@ -594,7 +598,7 @@ bool isNegativeOf(Attribute attr, Value val, uint32_t offset) {
     ModArithType stdType = modArithType;
     if (modArithType.isMontgomery()) {
       stdType = cast<ModArithType>(getStandardFormType(modArithType));
-      valueOp = ModArithOperation(valueOp.fromMont(), stdType);
+      valueOp = valueOp.fromMont();
     }
     ModArithOperation offsetOp(APInt(intAttr.getValue().getBitWidth(), offset),
                                stdType);

--- a/zkir/Dialect/ModArith/IR/ModArithTypes.cpp
+++ b/zkir/Dialect/ModArith/IR/ModArithTypes.cpp
@@ -41,20 +41,20 @@ ModArithType::getABIAlignment(DataLayout const &dataLayout,
 }
 
 IntegerAttr getAttrAsStandardForm(IntegerAttr modulusAttr, IntegerAttr attr) {
-  auto modArithType = ModArithType::get(attr.getContext(), modulusAttr);
+  auto modArithType = ModArithType::get(attr.getContext(), modulusAttr, true);
   auto value = ModArithOperation::fromUnchecked(attr.getValue(), modArithType);
   return value.fromMont().getIntegerAttr();
 }
 
 IntegerAttr getAttrAsMontgomeryForm(IntegerAttr modulusAttr, IntegerAttr attr) {
-  auto modArithType = ModArithType::get(attr.getContext(), modulusAttr);
+  auto modArithType = ModArithType::get(attr.getContext(), modulusAttr, false);
   auto value = ModArithOperation::fromUnchecked(attr.getValue(), modArithType);
   return value.toMont().getIntegerAttr();
 }
 
 DenseElementsAttr getAttrAsStandardForm(IntegerAttr modulusAttr,
                                         DenseElementsAttr attr) {
-  auto modArithType = ModArithType::get(attr.getContext(), modulusAttr);
+  auto modArithType = ModArithType::get(attr.getContext(), modulusAttr, true);
   return attr.mapValues(attr.getElementType(), [&](APInt value) -> APInt {
     auto valueOp = ModArithOperation::fromUnchecked(value, modArithType);
     return valueOp.fromMont();
@@ -63,7 +63,7 @@ DenseElementsAttr getAttrAsStandardForm(IntegerAttr modulusAttr,
 
 DenseElementsAttr getAttrAsMontgomeryForm(IntegerAttr modulusAttr,
                                           DenseElementsAttr attr) {
-  auto modArithType = ModArithType::get(attr.getContext(), modulusAttr);
+  auto modArithType = ModArithType::get(attr.getContext(), modulusAttr, false);
   return attr.mapValues(attr.getElementType(), [&](APInt value) -> APInt {
     auto valueOp = ModArithOperation::fromUnchecked(value, modArithType);
     return valueOp.toMont();


### PR DESCRIPTION
## Description

Ensures that `fromMont()` and `toMont()` explicitly update the underlying `ModArithType` or `PrimeFieldType` of the resulting operation.

**Benefits:**
- Prevents mathematical errors caused by domain/type mismatches.
- Makes intent explicit: a Standard form value is now always paired with a Standard form type.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
