### PR TITLE
refactor(field): rename `ToBaseField()` to `ToBaseFields()`

### DIFF
--- a/third_party/zk_dtypes/workspace.bzl
+++ b/third_party/zk_dtypes/workspace.bzl
@@ -17,8 +17,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def repo():
-    ZK_DTYPES_COMMIT = "a6b5fb7e046594a45b5981e67271b0b7c2394c71"
-    ZK_DTYPES_SHA256 = "20aecb7cff60ede1a37ef3bb48352308f05c4feb07b8c04fa1304a4b0bfd1c57"
+    ZK_DTYPES_COMMIT = "54fa64bd1ee2ac32e8c54800f569a4e0ae1ed9d5"
+    ZK_DTYPES_SHA256 = "cb8986fcb38547999b4abe85320c80ee79755c3c8a78db9da0b5eb8eac4ebdc6"
     http_archive(
         name = "zk_dtypes",
         sha256 = ZK_DTYPES_SHA256,

--- a/zkir/Dialect/Field/Conversions/FieldToModArith/ExtensionFieldCodeGen.h
+++ b/zkir/Dialect/Field/Conversions/FieldToModArith/ExtensionFieldCodeGen.h
@@ -110,7 +110,7 @@ public:
   Type getType() const { return type; }
 
   ExtensionFieldCodeGen operator*(const PrimeFieldCodeGen &scalar) const {
-    std::array<PrimeFieldCodeGen, N> coeffs = ToBaseField();
+    std::array<PrimeFieldCodeGen, N> coeffs = ToBaseFields();
     for (size_t i = 0; i < N; ++i) {
       coeffs[i] = coeffs[i] * scalar;
     }
@@ -118,7 +118,7 @@ public:
   }
 
   // zk_dtypes ExtensionFieldOperation methods
-  std::array<PrimeFieldCodeGen, N> ToBaseField() const {
+  std::array<PrimeFieldCodeGen, N> ToBaseFields() const {
     Operation::result_range coeffs = toCoeffs(*b, value);
     std::array<PrimeFieldCodeGen, N> ret;
     for (size_t i = 0; i < N; ++i) {


### PR DESCRIPTION
## Description

This PR renames the method name.

## Related Issues/PRs

See https://github.com/fractalyze/zk_dtypes/pull/62

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
