### PR TITLE
feat(field): add constant folding for extension field unary ops

### DIFF
--- a/tests/Dialect/Field/field_canonicalize.mlir
+++ b/tests/Dialect/Field/field_canonicalize.mlir
@@ -186,3 +186,58 @@ func.func @test_mul_self_is_square(%arg0: !PF17) -> !PF17 {
   // CHECK: return %[[RES]] : [[T]]
   return %mul : !PF17
 }
+
+//===----------------------------------------------------------------------===//
+// Tensor operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @test_tensor_from_elements
+// CHECK-SAME: () -> [[T:.*]] {
+func.func @test_tensor_from_elements() -> tensor<2x!PF17> {
+  %0 = field.constant 1 : !PF17
+  %1 = field.constant 2 : !PF17
+  %2 = tensor.from_elements %0, %1 : tensor<2x!PF17>
+  // CHECK: %[[C:.*]] = field.constant dense<[1, 2]> : [[T]]
+  // CHECK-NOT: tensor.from_elements
+  // CHECK: return %[[C:.*]] : [[T]]
+  return %2 : tensor<2x!PF17>
+}
+
+// CHECK-LABEL: @test_tensor_extract
+// CHECK-SAME: () -> [[T:.*]] {
+func.func @test_tensor_extract() -> !PF17 {
+  // CHECK: %[[C:.*]] = field.constant 3 : [[T]]
+  // CHECK-NOT: tensor.extract
+  // CHECK: return %[[C]] : [[T]]
+  %c1 = arith.constant 1: index
+  %0 = field.constant dense<[2, 3]> : tensor<2x!PF17>
+  %1 = tensor.extract %0[%c1] : tensor<2x!PF17>
+  return %1 : !PF17
+}
+
+//===----------------------------------------------------------------------===//
+// Vector operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @test_vector_from_elements
+// CHECK-SAME: () -> [[T:.*]] {
+func.func @test_vector_from_elements() -> vector<2x!PF17> {
+  %0 = field.constant 1 : !PF17
+  %1 = field.constant 2 : !PF17
+  %2 = vector.from_elements %0, %1 : vector<2x!PF17>
+  // CHECK: %[[FROM_ELEMENTS:.*]] = field.constant dense<[1, 2]> : [[T]]
+  // CHECK-NOT: vector.from_elements
+  // CHECK: return %[[FROM_ELEMENTS:.*]] : [[T]]
+  return %2 : vector<2x!PF17>
+}
+
+// CHECK-LABEL: @test_vector_extract
+// CHECK-SAME: () -> [[T:.*]] {
+func.func @test_vector_extract() -> !PF17 {
+  // CHECK: %[[C:.*]] = field.constant 3 : [[T]]
+  // CHECK-NOT: vector.extract
+  // CHECK: return %[[C]] : [[T]]
+  %0 = field.constant dense<[2, 3]> : vector<2x!PF17>
+  %1 = vector.extract %0[1] : !PF17 from vector<2x!PF17>
+  return %1 : !PF17
+}

--- a/zkir/Dialect/Field/IR/BUILD.bazel
+++ b/zkir/Dialect/Field/IR/BUILD.bazel
@@ -65,9 +65,11 @@ cc_library(
         "//zkir/Dialect/ModArith/IR:ModArith",
         "//zkir/Utils:AssemblyFormatUtils",
         "//zkir/Utils:CanonicalizationPatterns",
+        "//zkir/Utils:ConstantFolder",
         "//zkir/Utils:KnownModulus",
         "//zkir/Utils:OpUtils",
         "//zkir/Utils:SimpleStructBuilder",
+        "@com_google_absl//absl/status:statusor",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:DataLayoutInterfaces",
@@ -75,6 +77,7 @@ cc_library(
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:InliningUtils",
         "@llvm-project//mlir:Support",
+        "@zk_dtypes//zk_dtypes:extension_field_operations",
     ],
 )
 

--- a/zkir/Dialect/Field/IR/FieldOperation.h
+++ b/zkir/Dialect/Field/IR/FieldOperation.h
@@ -16,13 +16,20 @@
 #ifndef ZKIR_DIALECT_FIELD_IR_FIELDOPERATION_H_
 #define ZKIR_DIALECT_FIELD_IR_FIELDOPERATION_H_
 
+#include <array>
 #include <cassert>
 
+#include "absl/status/statusor.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "zk_dtypes/include/field/cubic_extension_field_operation.h"
+#include "zk_dtypes/include/field/quadratic_extension_field_operation.h"
+#include "zk_dtypes/include/field/quartic_extension_field_operation.h"
 #include "zkir/Dialect/Field/IR/FieldTypes.h"
 #include "zkir/Dialect/ModArith/IR/ModArithOperation.h"
 
 namespace mlir::zkir::field {
 
+// PrimeFieldOperation wraps ModArithOperation for prime field arithmetic.
 class PrimeFieldOperation {
 public:
   PrimeFieldOperation() = default;
@@ -100,6 +107,7 @@ public:
   PrimeFieldOperation operator-() const {
     return PrimeFieldOperation::fromUnchecked(-op, type);
   }
+
   PrimeFieldOperation dbl() const {
     return PrimeFieldOperation::fromUnchecked(op.dbl(), type);
   }
@@ -124,6 +132,7 @@ public:
         PrimeFieldType::get(type.getContext(), type.getModulus(), true);
     return PrimeFieldOperation::fromUnchecked(op.toMont(), montType);
   }
+
   bool isOne() const { return op.isOne(); }
   bool isZero() const { return op.isZero(); }
   bool operator==(const PrimeFieldOperation &other) const {
@@ -153,6 +162,32 @@ public:
   llvm::SmallString<40> toString() const { return op.toString(); }
 
 private:
+  // PascalCase methods (zk_dtypes compatible)
+  template <size_t>
+  friend class ExtensionFieldOperation;
+  template <typename>
+  friend class zk_dtypes::QuadraticExtensionFieldOperation;
+  template <typename>
+  friend class zk_dtypes::CubicExtensionFieldOperation;
+  template <typename>
+  friend class zk_dtypes::QuarticExtensionFieldOperation;
+  template <typename>
+  friend class zk_dtypes::KaratsubaOperation;
+  template <typename>
+  friend class zk_dtypes::ToomCookOperation;
+  template <typename>
+  friend class zk_dtypes::ExtensionFieldOperation;
+
+  PrimeFieldOperation Double() const { return dbl(); }
+  PrimeFieldOperation Square() const { return square(); }
+  absl::StatusOr<PrimeFieldOperation> Inverse() const {
+    if (op.isZero())
+      return absl::InvalidArgumentError("Cannot invert zero");
+    return inverse();
+  }
+  // Prime field has extension degree 1 (used by Frobenius)
+  static constexpr size_t ExtensionDegree() { return 1; }
+
   friend raw_ostream &operator<<(raw_ostream &os,
                                  const PrimeFieldOperation &op);
 
@@ -164,6 +199,167 @@ inline raw_ostream &operator<<(raw_ostream &os, const PrimeFieldOperation &op) {
   return os << op.op;
 }
 
+// Selects the appropriate zk_dtypes extension field operation based on degree.
+template <size_t N>
+struct ExtensionFieldOperationSelector;
+
+template <>
+struct ExtensionFieldOperationSelector<2> {
+  template <typename Derived>
+  using Type = zk_dtypes::QuadraticExtensionFieldOperation<Derived>;
+};
+
+template <>
+struct ExtensionFieldOperationSelector<3> {
+  template <typename Derived>
+  using Type = zk_dtypes::CubicExtensionFieldOperation<Derived>;
+};
+
+template <>
+struct ExtensionFieldOperationSelector<4> {
+  template <typename Derived>
+  using Type = zk_dtypes::QuarticExtensionFieldOperation<Derived>;
+};
+
+// Extension field operation class for compile-time evaluation.
+// Inherits from zk_dtypes CRTP operations for Square/Inverse algorithms.
+template <size_t N>
+class ExtensionFieldOperation
+    : public ExtensionFieldOperationSelector<N>::template Type<
+          ExtensionFieldOperation<N>> {
+  using Base = typename ExtensionFieldOperationSelector<N>::template Type<
+      ExtensionFieldOperation<N>>;
+
+public:
+  using Base::operator*;
+
+  // Construct from APInt coefficients (convenient one-liner usage)
+  ExtensionFieldOperation(const SmallVector<APInt> &coeffs,
+                          const APInt &nonResidue, PrimeFieldType baseFieldType)
+      : baseFieldType(baseFieldType) {
+    assert(coeffs.size() == N);
+    for (size_t i = 0; i < N; ++i) {
+      this->coeffs[i] = PrimeFieldOperation(coeffs[i], baseFieldType);
+    }
+    this->nonResidue = PrimeFieldOperation(nonResidue, baseFieldType);
+  }
+
+  // Construct from PrimeFieldOperation coefficients
+  ExtensionFieldOperation(const std::array<PrimeFieldOperation, N> &coeffs,
+                          const PrimeFieldOperation &nonResidue,
+                          PrimeFieldType baseFieldType)
+      : coeffs(coeffs), nonResidue(nonResidue), baseFieldType(baseFieldType) {}
+
+  const std::array<PrimeFieldOperation, N> &getCoeffs() const { return coeffs; }
+
+  // Convert coefficients to APInts (convenient for constant folding one-liners)
+  SmallVector<APInt> toAPInts() const {
+    SmallVector<APInt> result;
+    for (const auto &c : coeffs) {
+      result.push_back(static_cast<APInt>(c));
+    }
+    return result;
+  }
+
+  // TODO(junbeomlee): Add scalar multiplication (ExtensionField * BaseField)
+  // to zk_dtypes and reuse here.
+  ExtensionFieldOperation operator*(const PrimeFieldOperation &scalar) const {
+    std::array<PrimeFieldOperation, N> result;
+    for (size_t i = 0; i < N; ++i) {
+      result[i] = coeffs[i] * scalar;
+    }
+    return ExtensionFieldOperation(result, nonResidue, baseFieldType);
+  }
+
+private:
+  // PascalCase methods (zk_dtypes compatible)
+  template <typename>
+  friend class zk_dtypes::QuadraticExtensionFieldOperation;
+  template <typename>
+  friend class zk_dtypes::CubicExtensionFieldOperation;
+  template <typename>
+  friend class zk_dtypes::QuarticExtensionFieldOperation;
+  template <typename>
+  friend class zk_dtypes::KaratsubaOperation;
+  template <typename>
+  friend class zk_dtypes::ToomCookOperation;
+  template <typename>
+  friend class zk_dtypes::ExtensionFieldOperation;
+  template <typename>
+  friend class zk_dtypes::FrobeniusOperation;
+
+  const std::array<PrimeFieldOperation, N> &ToBaseFields() const {
+    return coeffs;
+  }
+
+  ExtensionFieldOperation
+  FromBaseFields(const std::array<PrimeFieldOperation, N> &c) const {
+    return ExtensionFieldOperation(c, nonResidue, baseFieldType);
+  }
+
+  PrimeFieldOperation NonResidue() const { return nonResidue; }
+
+  // TODO(junbeomlee): Refactor zk_dtypes C() and C2() macros into reusable
+  // functions that accept CreateConstBaseField, then implement
+  // GetVandermondeInverseMatrix and apply algorithm selection logic based on
+  // limb count and non-residue value (similar to ExtensionFieldCodeGen).
+  zk_dtypes::ExtensionFieldMulAlgorithm GetSquareAlgorithm() const {
+    return zk_dtypes::ExtensionFieldMulAlgorithm::kKaratsuba;
+  }
+
+  zk_dtypes::ExtensionFieldMulAlgorithm GetMulAlgorithm() const {
+    return zk_dtypes::ExtensionFieldMulAlgorithm::kKaratsuba;
+  }
+
+  PrimeFieldOperation CreateZeroBaseField() const {
+    APInt zero(baseFieldType.getStorageBitWidth(), 0);
+    return PrimeFieldOperation(zero, baseFieldType);
+  }
+
+  // Frobenius coefficients: coeffs[e-1][i-1] = ξ^(i * e * (p - 1) / n)
+  std::array<std::array<PrimeFieldOperation, N - 1>, N - 1>
+  GetFrobeniusCoeffs() const {
+    APInt p = baseFieldType.getModulus().getValue();
+    APInt nr = static_cast<APInt>(nonResidue);
+    PrimeFieldOperation nrOp(nr, baseFieldType);
+
+    unsigned extBitWidth = p.getBitWidth() * 2;
+    APInt pMinus1 = (p - 1).zext(extBitWidth);
+    APInt nVal(extBitWidth, N);
+
+    std::array<std::array<PrimeFieldOperation, N - 1>, N - 1> result;
+    for (size_t e = 1; e < N; ++e) {
+      for (size_t i = 1; i < N; ++i) {
+        APInt exp =
+            APInt(extBitWidth, i) * APInt(extBitWidth, e) * pMinus1.udiv(nVal);
+        result[e - 1][i - 1] = nrOp.power(exp);
+      }
+    }
+    return result;
+  }
+
+  // Required by ToomCookOperation but never called (we use kKaratsuba).
+  std::array<std::array<PrimeFieldOperation, 7>, 7>
+  GetVandermondeInverseMatrix() const {
+    llvm_unreachable("GetVandermondeInverseMatrix should not be called");
+  }
+
+  std::array<PrimeFieldOperation, N> coeffs;
+  PrimeFieldOperation nonResidue;
+  PrimeFieldType baseFieldType;
+};
+
 } // namespace mlir::zkir::field
+
+namespace zk_dtypes {
+template <size_t N>
+class ExtensionFieldOperationTraits<
+    mlir::zkir::field::ExtensionFieldOperation<N>> {
+public:
+  using BaseField = mlir::zkir::field::PrimeFieldOperation;
+  static constexpr size_t kDegree = N;
+};
+
+} // namespace zk_dtypes
 
 #endif // ZKIR_DIALECT_FIELD_IR_FIELDOPERATION_H_

--- a/zkir/Dialect/Field/IR/FieldOps.td
+++ b/zkir/Dialect/Field/IR/FieldOps.td
@@ -289,6 +289,7 @@ def Field_InverseOp : Field_UnaryOp<"inverse", [Involution]> {
     %inv_a = field.inverse %a : !field.pf<primeModulus>
     ```
   }];
+  let hasFolder = 1;
 }
 
 // Field double.
@@ -302,6 +303,7 @@ def Field_DoubleOp : Field_UnaryOp<"double"> {
     %double = field.double %a : !field.pf<primeModulus>
     ```
   }];
+  let hasFolder = 1;
 }
 
 // Field square.
@@ -315,6 +317,7 @@ def Field_SquareOp : Field_UnaryOp<"square"> {
     %square = field.square %a : !field.pf<primeModulus>
     ```
   }];
+  let hasFolder = 1;
 }
 
 // Field negation
@@ -328,6 +331,7 @@ def Field_NegateOp : Field_UnaryOp<"negate", [Involution]> {
     %negation = field.negate %a : !field.pf<primeModulus>
     ```
   }];
+  let hasFolder = 1;
 }
 
 // Field addition.

--- a/zkir/Dialect/Field/IR/FieldTypes.h
+++ b/zkir/Dialect/Field/IR/FieldTypes.h
@@ -36,6 +36,11 @@ limitations under the License.
 
 namespace mlir::zkir::field {
 
+// Supported extension field degrees: quadratic (2), cubic (3), quartic (4).
+constexpr size_t kMinExtDegree = 2;
+constexpr size_t kMaxExtDegree = 4;
+constexpr size_t kNumExtDegrees = kMaxExtDegree - kMinExtDegree + 1;
+
 class PrimeFieldType;
 
 bool isMontgomery(Type type);


### PR DESCRIPTION
## Description

Add constant folding support for extension field unary operations (NegateOp, DoubleOp, SquareOp, InverseOp). This enables compile-time evaluation of constant expressions on extension field types.

### Implementation Details

- Use `ExtensionFieldOperation<N>` template class that inherits from zk_dtypes CRTP operations
- Reuse zk_dtypes algorithms: `operator-()` for Negate, `Double()`, `Square()`, `Inverse()`
- PascalCase methods (zk_dtypes compatible) are private with friend declarations
- Add extension field degree constants (`kMinExtDegree`, `kMaxExtDegree`, `kNumExtDegrees`) to FieldTypes.h
- Runtime-to-compile-time dispatch using `std::make_index_sequence` for degree 2, 3, 4

## Related Issues/PRs

- #177 (TODO: Inverse(0) handling decision)

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline