### PR TITLE
refactor: split rewrite patterns by mathematical structure

### DIFF
--- a/zkir/Dialect/Field/IR/BUILD.bazel
+++ b/zkir/Dialect/Field/IR/BUILD.bazel
@@ -64,6 +64,7 @@ cc_library(
         ":types_inc_gen",
         "//zkir/Dialect/ModArith/IR:ModArith",
         "//zkir/Utils:AssemblyFormatUtils",
+        "//zkir/Utils:CanonicalizationPatterns",
         "//zkir/Utils:KnownModulus",
         "//zkir/Utils:OpUtils",
         "//zkir/Utils:SimpleStructBuilder",
@@ -88,6 +89,7 @@ td_library(
     includes = ["../../../.."],
     deps = [
         "//zkir/Dialect/ModArith/IR:td_files",
+        "//zkir/Utils:CanonicalizationTd",
         "@llvm-project//mlir:ArithOpsTdFiles",
         "@llvm-project//mlir:BuiltinDialectTdFiles",
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",

--- a/zkir/Dialect/Field/IR/FieldCanonicalization.td
+++ b/zkir/Dialect/Field/IR/FieldCanonicalization.td
@@ -19,160 +19,27 @@ limitations under the License.
 include "mlir/IR/PatternBase.td"
 include "zkir/Dialect/Field/IR/FieldOps.td"
 
+def IsZero : Constraint<CPred<"isEqualTo($0, $1, 0)">>;
+def IsOne : Constraint<CPred<"isEqualTo($0, $1, 1)">>;
+def IsTwo : Constraint<CPred<"isEqualTo($0, $1, 2)">>;
+def IsNegativeOne : Constraint<CPred<"isNegativeOf($0, $1, 1)">>;
+def IsNegativeTwo : Constraint<CPred<"isNegativeOf($0, $1, 2)">>;
+def IsNegativeThree : Constraint<CPred<"isNegativeOf($0, $1, 3)">>;
+def IsNegativeFour : Constraint<CPred<"isNegativeOf($0, $1, 4)">>;
 def GetAsConstant : NativeCodeCall<"$_builder.create<ConstantOp>(odsLoc, $0.getType(), cast<TypedAttr>($1))">;
+def GetZeroAttr : NativeCodeCall<"$_builder.getZeroAttr(cast<IntegerType>($0))">;
+def GetIntegerType : NativeCodeCall<"cast<PrimeFieldType>($0.getType()).getStorageType()">;
 
-//===----------------------------------------------------------------------===//
-// AddOp
-//===----------------------------------------------------------------------===//
+include "zkir/Utils/AdditiveCanonicalization.td"
+include "zkir/Utils/MultiplicativeCanonicalization.td"
 
-// `AddOp` is commutative and will be canonicalized to have its constants appear
-// as the second operand.
+defm Field : AdditiveCanonicalizationPatterns<
+    Field_AddOp, Field_SubOp, Field_NegateOp,
+    Field_MulOp, Field_DoubleOp, Field_SquareOp>;
 
-// (x + c0) + c1 -> x + (c0 + c1)
-def AddConstantTwice :
-    Pat<(Field_AddOp (Field_AddOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)), (ConstantLikeMatcher TypedAttrInterface:$c1)),
-        (Field_AddOp $x, (Field_AddOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)))>;
-
-// (c0 - x) + c1 -> (c0 + c1) - x
-def AddConstantToSubLhs :
-    Pat<(Field_AddOp (Field_SubOp (ConstantLikeMatcher TypedAttrInterface:$c0), $x), (ConstantLikeMatcher TypedAttrInterface:$c1)),
-        (Field_SubOp (Field_AddOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)), $x)>;
-
-// (x - c0) + c1 -> x + (c1 - c0)
-def AddConstantToSubRhs :
-    Pat<(Field_AddOp (Field_SubOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)), (ConstantLikeMatcher TypedAttrInterface:$c1)),
-        (Field_AddOp $x, (Field_SubOp (GetAsConstant $x, $c1), (GetAsConstant $x, $c0)))>;
-
-// x + x -> double(x)
-def AddSelfIsDouble :
-    Pat<(Field_AddOp $x, $x),
-        (Field_DoubleOp $x)>;
-
-// (-x) + (-y) -> -(x + y)
-def AddBothNegated :
-    Pat<(Field_AddOp (Field_NegateOp $x), (Field_NegateOp $y)),
-        (Field_NegateOp (Field_AddOp $x, $y))>;
-
-// x - y + y -> x
-def AddAfterSub :
-    Pat<(Field_AddOp (Field_SubOp $x, $y), $y),
-        (replaceWithValue $x)>;
-
-// (-x) + y -> y - x
-def AddAfterNegLhs :
-    Pat<(Field_AddOp (Field_NegateOp $x), $y),
-        (Field_SubOp $y, $x)>;
-
-// x + (-y) -> x - y
-def AddAfterNegRhs :
-    Pat<(Field_AddOp $x, (Field_NegateOp $y)),
-        (Field_SubOp $x, $y)>;
-
-// xy + xz -> x(y + z)
-def FactorMulAdd :
-    Pat<(Field_AddOp (Field_MulOp $x, $y), (Field_MulOp $x, $z)),
-        (Field_MulOp $x, (Field_AddOp $y, $z))>;
-
-//===----------------------------------------------------------------------===//
-// SubOp
-//===----------------------------------------------------------------------===//
-
-// (x + c0) - c1 -> x + (c0 - c1)
-def SubConstantFromAdd :
-    Pat<(Field_SubOp (Field_AddOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)), (ConstantLikeMatcher TypedAttrInterface:$c1)),
-        (Field_AddOp $x, (Field_SubOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)))>;
-
-// (c0 - x) - c1 -> (c0 - c1) - x
-def SubConstantTwiceLhs :
-    Pat<(Field_SubOp (Field_SubOp (ConstantLikeMatcher TypedAttrInterface:$c0), $x), (ConstantLikeMatcher TypedAttrInterface:$c1)),
-        (Field_SubOp (Field_SubOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)), $x)>;
-
-// (x - c0) - c1 -> x - (c0 + c1)
-def SubConstantTwiceRhs :
-    Pat<(Field_SubOp (Field_SubOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)), (ConstantLikeMatcher TypedAttrInterface:$c1)),
-        (Field_SubOp $x, (Field_AddOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)))>;
-
-// c0 - (x + c1) -> (c0 - c1) - x
-def SubAddFromConstant :
-    Pat<(Field_SubOp (ConstantLikeMatcher TypedAttrInterface:$c0), (Field_AddOp $x, (ConstantLikeMatcher TypedAttrInterface:$c1))),
-        (Field_SubOp (Field_SubOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)), $x)>;
-
-// c0 - (c1 - x) -> x + (c0 - c1)
-def SubSubFromConstantLhs :
-    Pat<(Field_SubOp (ConstantLikeMatcher TypedAttrInterface:$c0), (Field_SubOp (ConstantLikeMatcher TypedAttrInterface:$c1), $x)),
-        (Field_AddOp $x, (Field_SubOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)))>;
-
-// c0 - (x - c1) -> (c0 + c1) - x
-def SubSubFromConstantRhs :
-    Pat<(Field_SubOp (ConstantLikeMatcher TypedAttrInterface:$c0), (Field_SubOp $x, (ConstantLikeMatcher TypedAttrInterface:$c1))),
-        (Field_SubOp (Field_AddOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)), $x)>;
-
-// (x + y) - x -> y
-def SubLhsAfterAdd :
-    Pat<(Field_SubOp (Field_AddOp $x, $y), $x),
-        (replaceWithValue $y)>;
-
-// (x + y) - y -> x
-def SubRhsAfterAdd :
-    Pat<(Field_SubOp (Field_AddOp $x, $y), $y),
-        (replaceWithValue $x)>;
-
-// (x - y) - x -> -y
-def SubLhsAfterSub :
-    Pat<(Field_SubOp (Field_SubOp $x, $y), $x),
-        (Field_NegateOp $y)>;
-
-// (-x) - y -> -(x + y)
-def SubAfterNegLhs :
-    Pat<(Field_SubOp (Field_NegateOp $x), $y),
-        (Field_NegateOp (Field_AddOp $x, $y))>;
-
-// x - (-y) -> x + y
-def SubAfterNegRhs :
-    Pat<(Field_SubOp $x, (Field_NegateOp $y)),
-        (Field_AddOp $x, $y)>;
-
-// (-x) - (-y) -> y - x
-def SubBothNegated :
-    Pat<(Field_SubOp (Field_NegateOp $x), (Field_NegateOp $y)),
-        (Field_SubOp $y, $x)>;
-
-// x² - y² -> (x - y)(x + y)
-def SubAfterSquareBoth :
-    Pat<(Field_SubOp (Field_SquareOp $x), (Field_SquareOp $y)),
-        (Field_MulOp (Field_SubOp $x, $y), (Field_AddOp $x, $y))>;
-
-// (x + y)² - x² - y² -> 2xy
-def SubAfterSumSquare :
-    Pat<(Field_SubOp (Field_SubOp (Field_SquareOp (Field_AddOp $x, $y)), (Field_SquareOp $x)), (Field_SquareOp $y)),
-        (Field_DoubleOp (Field_MulOp $x, $y))>;
-
-// xy - xz -> x(y - z)
-def FactorMulSub :
-    Pat<(Field_SubOp (Field_MulOp $x, $y), (Field_MulOp $x, $z)),
-        (Field_MulOp $x, (Field_SubOp $y, $z))>;
-
-//===----------------------------------------------------------------------===//
-// MulOp
-//===----------------------------------------------------------------------===//
-
-// `MulOp` is commutative and will be canonicalized to have its constants appear
-// as the second operand.
-
-// x * x -> square(x)
-def MulSelfIsSquare :
-    Pat<(Field_MulOp $x, $x),
-        (Field_SquareOp $x)>;
-
-// (x * c0) * c1 -> x * (c0 * c1)
-def MulConstantTwice :
-    Pat<(Field_MulOp (Field_MulOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)), (ConstantLikeMatcher TypedAttrInterface:$c1)),
-        (Field_MulOp $x, (Field_MulOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)))>;
-
-// (x * c0) * (y * c1) -> (x * y) * (c0 * c1)
-def MulOfMulByConstant :
-    Pat<(Field_MulOp (Field_MulOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)), (Field_MulOp $y, (ConstantLikeMatcher TypedAttrInterface:$c1))),
-        (Field_MulOp (Field_MulOp $x, $y), (Field_MulOp (GetAsConstant $x, $c0), (GetAsConstant $y, $c1)))>;
+defm Field : MultiplicativeCanonicalizationPatterns<
+    Field_MulOp, Field_SquareOp, Field_DoubleOp, Field_NegateOp, Field_AddOp,
+    Field_SubOp>;
 
 
 #endif // ZKIR_FIELD_IR_FIELD_CANONICALIZATION_TD

--- a/zkir/Dialect/ModArith/IR/BUILD.bazel
+++ b/zkir/Dialect/ModArith/IR/BUILD.bazel
@@ -63,6 +63,7 @@ cc_library(
         ":types_inc_gen",
         "//zkir/Utils:APIntUtils",
         "//zkir/Utils:AssemblyFormatUtils",
+        "//zkir/Utils:CanonicalizationPatterns",
         "//zkir/Utils:ConstantFolder",
         "//zkir/Utils:KnownModulus",
         "//zkir/Utils:OpUtils",
@@ -91,6 +92,7 @@ td_library(
     ],
     includes = ["../../../.."],
     deps = [
+        "//zkir/Utils:CanonicalizationTd",
         "//zkir/Utils:CommonTraits",
         "@llvm-project//mlir:ArithOpsTdFiles",
         "@llvm-project//mlir:BuiltinDialectTdFiles",

--- a/zkir/Dialect/ModArith/IR/ModArithCanonicalization.td
+++ b/zkir/Dialect/ModArith/IR/ModArithCanonicalization.td
@@ -19,9 +19,9 @@ limitations under the License.
 include "mlir/IR/PatternBase.td"
 include "zkir/Dialect/ModArith/IR/ModArithOps.td"
 
-def IsZero : Constraint<CPred<"isEqualTo($0, 0)">>;
-def IsOne : Constraint<CPred<"isEqualTo($0, 1)">>;
-def IsTwo : Constraint<CPred<"isEqualTo($0, 2)">>;
+def IsZero : Constraint<CPred<"isEqualTo($0, $1, 0)">>;
+def IsOne : Constraint<CPred<"isEqualTo($0, $1, 1)">>;
+def IsTwo : Constraint<CPred<"isEqualTo($0, $1, 2)">>;
 def IsNegativeOne : Constraint<CPred<"isNegativeOf($0, $1, 1)">>;
 def IsNegativeTwo : Constraint<CPred<"isNegativeOf($0, $1, 2)">>;
 def IsNegativeThree : Constraint<CPred<"isNegativeOf($0, $1, 3)">>;
@@ -30,207 +30,15 @@ def GetAsConstant : NativeCodeCall<"$_builder.create<ConstantOp>(odsLoc, $0.getT
 def GetZeroAttr : NativeCodeCall<"$_builder.getZeroAttr(cast<IntegerType>($0))">;
 def GetIntegerType : NativeCodeCall<"cast<ModArithType>($0.getType()).getStorageType()">;
 
-//===----------------------------------------------------------------------===//
-// AddOp
-//===----------------------------------------------------------------------===//
+include "zkir/Utils/AdditiveCanonicalization.td"
+include "zkir/Utils/MultiplicativeCanonicalization.td"
 
-// `AddOp` is commutative and will be canonicalized to have its constants appear
-// as the second operand.
+defm ModArith : AdditiveCanonicalizationPatterns<
+    ModArith_AddOp, ModArith_SubOp, ModArith_NegateOp,
+    ModArith_MulOp, ModArith_DoubleOp, ModArith_SquareOp>;
 
-// (x + c0) + c1 -> x + (c0 + c1)
-def AddConstantTwice :
-    Pat<(ModArith_AddOp (ModArith_AddOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)), (ConstantLikeMatcher TypedAttrInterface:$c1)),
-        (ModArith_AddOp $x, (ModArith_AddOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)))>;
-
-// (c0 - x) + c1 -> (c0 + c1) - x
-def AddConstantToSubLhs :
-    Pat<(ModArith_AddOp (ModArith_SubOp (ConstantLikeMatcher TypedAttrInterface:$c0), $x), (ConstantLikeMatcher TypedAttrInterface:$c1)),
-        (ModArith_SubOp (ModArith_AddOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)), $x)>;
-
-// (x - c0) + c1 -> x + (c1 - c0)
-def AddConstantToSubRhs :
-    Pat<(ModArith_AddOp (ModArith_SubOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)), (ConstantLikeMatcher TypedAttrInterface:$c1)),
-        (ModArith_AddOp $x, (ModArith_SubOp (GetAsConstant $x, $c1), (GetAsConstant $x, $c0)))>;
-
-// x + x -> double(x)
-def AddSelfIsDouble :
-    Pat<(ModArith_AddOp $x, $x),
-        (ModArith_DoubleOp $x)>;
-
-// (-x) + (-y) -> -(x + y)
-def AddBothNegated :
-    Pat<(ModArith_AddOp (ModArith_NegateOp $x), (ModArith_NegateOp $y)),
-        (ModArith_NegateOp (ModArith_AddOp $x, $y))>;
-
-// x - y + y -> x
-def AddAfterSub :
-    Pat<(ModArith_AddOp (ModArith_SubOp $x, $y), $y),
-        (replaceWithValue $x)>;
-
-// (-x) + y -> y - x
-def AddAfterNegLhs :
-    Pat<(ModArith_AddOp (ModArith_NegateOp $x), $y),
-        (ModArith_SubOp $y, $x)>;
-
-// x + (-y) -> x - y
-def AddAfterNegRhs :
-    Pat<(ModArith_AddOp $x, (ModArith_NegateOp $y)),
-        (ModArith_SubOp $x, $y)>;
-
-// xy + xz -> x(y + z)
-def FactorMulAdd :
-    Pat<(ModArith_AddOp (ModArith_MulOp $x, $y), (ModArith_MulOp $x, $z)),
-        (ModArith_MulOp $x, (ModArith_AddOp $y, $z))>;
-
-//===----------------------------------------------------------------------===//
-// SubOp
-//===----------------------------------------------------------------------===//
-
-// (x + c0) - c1 -> x + (c0 - c1)
-def SubConstantFromAdd :
-    Pat<(ModArith_SubOp (ModArith_AddOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)), (ConstantLikeMatcher TypedAttrInterface:$c1)),
-        (ModArith_AddOp $x, (ModArith_SubOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)))>;
-
-// (c0 - x) - c1 -> (c0 - c1) - x
-def SubConstantTwiceLhs :
-    Pat<(ModArith_SubOp (ModArith_SubOp (ConstantLikeMatcher TypedAttrInterface:$c0), $x), (ConstantLikeMatcher TypedAttrInterface:$c1)),
-        (ModArith_SubOp (ModArith_SubOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)), $x)>;
-
-// (x - c0) - c1 -> x - (c0 + c1)
-def SubConstantTwiceRhs :
-    Pat<(ModArith_SubOp (ModArith_SubOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)), (ConstantLikeMatcher TypedAttrInterface:$c1)),
-        (ModArith_SubOp $x, (ModArith_AddOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)))>;
-
-// c0 - (x + c1) -> (c0 - c1) - x
-def SubAddFromConstant :
-    Pat<(ModArith_SubOp (ConstantLikeMatcher TypedAttrInterface:$c0), (ModArith_AddOp $x, (ConstantLikeMatcher TypedAttrInterface:$c1))),
-        (ModArith_SubOp (ModArith_SubOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)), $x)>;
-
-// c0 - (c1 - x) -> x + (c0 - c1)
-def SubSubFromConstantLhs :
-    Pat<(ModArith_SubOp (ConstantLikeMatcher TypedAttrInterface:$c0), (ModArith_SubOp (ConstantLikeMatcher TypedAttrInterface:$c1), $x)),
-        (ModArith_AddOp $x, (ModArith_SubOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)))>;
-
-// c0 - (x - c1) -> (c0 + c1) - x
-def SubSubFromConstantRhs :
-    Pat<(ModArith_SubOp (ConstantLikeMatcher TypedAttrInterface:$c0), (ModArith_SubOp $x, (ConstantLikeMatcher TypedAttrInterface:$c1))),
-        (ModArith_SubOp (ModArith_AddOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)), $x)>;
-
-// x - x -> 0
-def SubSelfIsZero :
-    Pat<(ModArith_SubOp $x, $x),
-        (GetAsConstant $x, (GetZeroAttr (GetIntegerType $x)))>;
-
-// (x + y) - x -> y
-def SubLhsAfterAdd :
-    Pat<(ModArith_SubOp (ModArith_AddOp $x, $y), $x),
-        (replaceWithValue $y)>;
-
-// (x + y) - y -> x
-def SubRhsAfterAdd :
-    Pat<(ModArith_SubOp (ModArith_AddOp $x, $y), $y),
-        (replaceWithValue $x)>;
-
-// (x - y) - x -> -y
-def SubLhsAfterSub :
-    Pat<(ModArith_SubOp (ModArith_SubOp $x, $y), $x),
-        (ModArith_NegateOp $y)>;
-
-// (-x) - y -> -(x + y)
-def SubAfterNegLhs :
-    Pat<(ModArith_SubOp (ModArith_NegateOp $x), $y),
-        (ModArith_NegateOp (ModArith_AddOp $x, $y))>;
-
-// x - (-y) -> x + y
-def SubAfterNegRhs :
-    Pat<(ModArith_SubOp $x, (ModArith_NegateOp $y)),
-        (ModArith_AddOp $x, $y)>;
-
-// (-x) - (-y) -> y - x
-def SubBothNegated :
-    Pat<(ModArith_SubOp (ModArith_NegateOp $x), (ModArith_NegateOp $y)),
-        (ModArith_SubOp $y, $x)>;
-
-// x² - y² -> (x - y)(x + y)
-def SubAfterSquareBoth :
-    Pat<(ModArith_SubOp (ModArith_SquareOp $x), (ModArith_SquareOp $y)),
-        (ModArith_MulOp (ModArith_SubOp $x, $y), (ModArith_AddOp $x, $y))>;
-
-// (x + y)² - x² - y² -> 2xy
-def SubAfterSumSquare :
-    Pat<(ModArith_SubOp (ModArith_SubOp (ModArith_SquareOp (ModArith_AddOp $x, $y)), (ModArith_SquareOp $x)), (ModArith_SquareOp $y)),
-        (ModArith_DoubleOp (ModArith_MulOp $x, $y))>;
-
-// xy - xz -> x(y - z)
-def FactorMulSub :
-    Pat<(ModArith_SubOp (ModArith_MulOp $x, $y), (ModArith_MulOp $x, $z)),
-        (ModArith_MulOp $x, (ModArith_SubOp $y, $z))>;
-
-//===----------------------------------------------------------------------===//
-// MulOp
-//===----------------------------------------------------------------------===//
-
-// `MulOp` is commutative and will be canonicalized to have its constants appear
-// as the second operand.
-
-// x * 2 -> double(x)
-def MulByTwoIsDouble :
-    Pat<(ModArith_MulOp $x, (ConstantLikeMatcher TypedAttrInterface:$c2)),
-        (ModArith_DoubleOp $x),
-        [(IsTwo $c2)]>;
-
-// x * x -> square(x)
-def MulSelfIsSquare :
-    Pat<(ModArith_MulOp $x, $x),
-        (ModArith_SquareOp $x)>;
-
-// x * (-1) -> negate(x)
-def MulNegativeOneRhs :
-    Pat<(ModArith_MulOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)),
-        (ModArith_NegateOp $x),
-        [(IsNegativeOne $c0, $x)]>;
-
-// x * (-2) -> negate(double(x))
-def MulNegativeTwoRhs :
-    Pat<(ModArith_MulOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)),
-        (ModArith_NegateOp (ModArith_DoubleOp $x)),
-        [(IsNegativeTwo $c0, $x)]>;
-
-// x * (-3) -> negate(x + double(x))
-def MulNegativeThreeRhs :
-    Pat<(ModArith_MulOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)),
-        (ModArith_NegateOp (ModArith_AddOp (ModArith_DoubleOp $x), $x)),
-        [(IsNegativeThree $c0, $x)]>;
-
-// x * (-4) -> negate(double(double(x)))
-def MulNegativeFourRhs :
-    Pat<(ModArith_MulOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)),
-        (ModArith_NegateOp (ModArith_DoubleOp (ModArith_DoubleOp $x))),
-        [(IsNegativeFour $c0, $x)]>;
-
-// (x * c0) * c1 -> x * (c0 * c1)
-def MulConstantTwice :
-    Pat<(ModArith_MulOp (ModArith_MulOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)), (ConstantLikeMatcher TypedAttrInterface:$c1)),
-        (ModArith_MulOp $x, (ModArith_MulOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)))>;
-
-// (x * c0) * (y * c1) -> (x * y) * (c0 * c1)
-def MulOfMulByConstant :
-    Pat<(ModArith_MulOp (ModArith_MulOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)), (ModArith_MulOp $y, (ConstantLikeMatcher TypedAttrInterface:$c1))),
-        (ModArith_MulOp (ModArith_MulOp $x, $y), (ModArith_MulOp (GetAsConstant $x, $c0), (GetAsConstant $y, $c1)))>;
-
-// (x + c0) * c1 -> x * c1 + c0 * c1
-def MulAddDistributeConstant :
-    Pat<(ModArith_MulOp (ModArith_AddOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)), (ConstantLikeMatcher TypedAttrInterface:$c1)),
-        (ModArith_AddOp (ModArith_MulOp $x, (GetAsConstant $x, $c1)), (ModArith_MulOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)))>;
-
-// (x - c0) * c1 -> x * c1 - c0 * c1
-def MulSubDistributeConstantRhs :
-    Pat<(ModArith_MulOp (ModArith_SubOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)), (ConstantLikeMatcher TypedAttrInterface:$c1)),
-        (ModArith_SubOp (ModArith_MulOp $x, (GetAsConstant $x, $c1)), (ModArith_MulOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)))>;
-
-// (c0 - x) * c1 -> c0 * c1 - x * c1
-def MulSubDistributeConstantLhs :
-    Pat<(ModArith_MulOp (ModArith_SubOp (ConstantLikeMatcher TypedAttrInterface:$c0), $x), (ConstantLikeMatcher TypedAttrInterface:$c1)),
-        (ModArith_SubOp (ModArith_MulOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)), (ModArith_MulOp $x, (GetAsConstant $x, $c1)))>;
+defm ModArith : MultiplicativeCanonicalizationPatterns<
+    ModArith_MulOp, ModArith_SquareOp, ModArith_DoubleOp, ModArith_NegateOp,
+    ModArith_AddOp, ModArith_SubOp>;
 
 #endif // ZKIR_MODARITH_IR_MODARITH_CANONICALIZATION_TD

--- a/zkir/Utils/AdditiveCanonicalization.td
+++ b/zkir/Utils/AdditiveCanonicalization.td
@@ -1,0 +1,198 @@
+/* Copyright 2026 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZKIR_UTILS_ADDITIVE_CANONICALIZATION_TD
+#define ZKIR_UTILS_ADDITIVE_CANONICALIZATION_TD
+
+// The including file must define `GetAsConstant`.
+// Assumptions for the patterns below:
+// - AddOp/SubOp are associative and commutative where noted.
+// - NegOp is the additive inverse (additive group structure).
+// - Distributivity between MulOp and AddOp/SubOp when factoring.
+multiclass AdditiveCanonicalizationPatterns<
+    Op AddOp, Op SubOp, Op NegOp, Op MulOp, Op DoubleOp, Op SquareOp> {
+    //===--------------------------------------------------------------------===//
+    // AddOp
+    //===--------------------------------------------------------------------===//
+
+    // --- Associativity/commutativity ---
+    // AddOp is commutative and associative; rewrite to place constants on the RHS.
+
+    // (x + c0) + c1 -> x + (c0 + c1)
+    def AddConstantTwice :
+        Pat<(AddOp (AddOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)),
+                    (ConstantLikeMatcher TypedAttrInterface:$c1)),
+            (AddOp $x, (AddOp (GetAsConstant $x, $c0),
+                                (GetAsConstant $x, $c1)))>;
+
+    // (c0 - x) + c1 -> (c0 + c1) - x
+    def AddConstantToSubLhs :
+        Pat<(AddOp (SubOp (ConstantLikeMatcher TypedAttrInterface:$c0), $x),
+                    (ConstantLikeMatcher TypedAttrInterface:$c1)),
+            (SubOp (AddOp (GetAsConstant $x, $c0),
+                            (GetAsConstant $x, $c1)),
+                    $x)>;
+
+    // (x - c0) + c1 -> x + (c1 - c0)
+    def AddConstantToSubRhs :
+        Pat<(AddOp (SubOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)),
+                    (ConstantLikeMatcher TypedAttrInterface:$c1)),
+            (AddOp $x,
+                    (SubOp (GetAsConstant $x, $c1),
+                            (GetAsConstant $x, $c0)))>;
+
+    // --- Additive identity/duplication ---
+    // x + x -> double(x)
+    def AddSelfIsDouble :
+        Pat<(AddOp $x, $x),
+            (DoubleOp $x)>;
+
+    // --- Additive inverse ---
+    // (-x) + (-y) -> -(x + y)
+    def AddBothNegated :
+        Pat<(AddOp (NegOp $x), (NegOp $y)),
+            (NegOp (AddOp $x, $y))>;
+
+    // x - y + y -> x
+    def AddAfterSub :
+        Pat<(AddOp (SubOp $x, $y), $y),
+            (replaceWithValue $x)>;
+
+    // (-x) + y -> y - x
+    def AddAfterNegLhs :
+        Pat<(AddOp (NegOp $x), $y),
+            (SubOp $y, $x)>;
+
+    // x + (-y) -> x - y
+    def AddAfterNegRhs :
+        Pat<(AddOp $x, (NegOp $y)),
+            (SubOp $x, $y)>;
+
+    // --- Distributivity ---
+    // xy + xz -> x(y + z)
+    def FactorMulAdd :
+        Pat<(AddOp (MulOp $x, $y), (MulOp $x, $z)),
+            (MulOp $x, (AddOp $y, $z))>;
+
+    //===--------------------------------------------------------------------===//
+    // SubOp
+    //===--------------------------------------------------------------------===//
+
+    // --- Associativity/commutativity ---
+    // AddOp is commutative and associative; rewrite to place constants on the RHS.
+    // (x + c0) - c1 -> x + (c0 - c1)
+    def SubConstantFromAdd :
+        Pat<(SubOp (AddOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)),
+                    (ConstantLikeMatcher TypedAttrInterface:$c1)),
+            (AddOp $x,
+                    (SubOp (GetAsConstant $x, $c0),
+                            (GetAsConstant $x, $c1)))>;
+
+    // (c0 - x) - c1 -> (c0 - c1) - x
+    def SubConstantTwiceLhs :
+        Pat<(SubOp (SubOp (ConstantLikeMatcher TypedAttrInterface:$c0), $x),
+                    (ConstantLikeMatcher TypedAttrInterface:$c1)),
+            (SubOp (SubOp (GetAsConstant $x, $c0),
+                            (GetAsConstant $x, $c1)),
+                    $x)>;
+
+    // (x - c0) - c1 -> x - (c0 + c1)
+    def SubConstantTwiceRhs :
+        Pat<(SubOp (SubOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)),
+                    (ConstantLikeMatcher TypedAttrInterface:$c1)),
+            (SubOp $x,
+                    (AddOp (GetAsConstant $x, $c0),
+                            (GetAsConstant $x, $c1)))>;
+
+    // c0 - (x + c1) -> (c0 - c1) - x
+    def SubAddFromConstant :
+        Pat<(SubOp (ConstantLikeMatcher TypedAttrInterface:$c0),
+                    (AddOp $x, (ConstantLikeMatcher TypedAttrInterface:$c1))),
+            (SubOp (SubOp (GetAsConstant $x, $c0),
+                            (GetAsConstant $x, $c1)),
+                    $x)>;
+
+    // c0 - (c1 - x) -> x + (c0 - c1)
+    def SubSubFromConstantLhs :
+        Pat<(SubOp (ConstantLikeMatcher TypedAttrInterface:$c0),
+                    (SubOp (ConstantLikeMatcher TypedAttrInterface:$c1), $x)),
+            (AddOp $x,
+                    (SubOp (GetAsConstant $x, $c0),
+                            (GetAsConstant $x, $c1)))>;
+
+    // c0 - (x - c1) -> (c0 + c1) - x
+    def SubSubFromConstantRhs :
+        Pat<(SubOp (ConstantLikeMatcher TypedAttrInterface:$c0),
+                    (SubOp $x, (ConstantLikeMatcher TypedAttrInterface:$c1))),
+            (SubOp (AddOp (GetAsConstant $x, $c0),
+                            (GetAsConstant $x, $c1)),
+                    $x)>;
+
+    // --- Additive inverse/identity ---
+
+    // x - x -> 0
+    def SubSelfIsZero :
+        Pat<(SubOp $x, $x),
+            (GetAsConstant $x, (GetZeroAttr (GetIntegerType $x)))>;
+
+    // (x + y) - x -> y
+    def SubLhsAfterAdd :
+        Pat<(SubOp (AddOp $x, $y), $x),
+            (replaceWithValue $y)>;
+
+    // (x + y) - y -> x
+    def SubRhsAfterAdd :
+        Pat<(SubOp (AddOp $x, $y), $y),
+            (replaceWithValue $x)>;
+
+    // (x - y) - x -> -y
+    def SubLhsAfterSub :
+        Pat<(SubOp (SubOp $x, $y), $x),
+            (NegOp $y)>;
+
+    // (-x) - y -> -(x + y)
+    def SubAfterNegLhs :
+        Pat<(SubOp (NegOp $x), $y),
+            (NegOp (AddOp $x, $y))>;
+
+    // x - (-y) -> x + y
+    def SubAfterNegRhs :
+        Pat<(SubOp $x, (NegOp $y)),
+            (AddOp $x, $y)>;
+
+    // (-x) - (-y) -> y - x
+    def SubBothNegated :
+        Pat<(SubOp (NegOp $x), (NegOp $y)),
+            (SubOp $y, $x)>;
+
+    // --- Distributivity ---
+    // x² - y² -> (x - y)(x + y)
+    def SubAfterSquareBoth :
+        Pat<(SubOp (SquareOp $x), (SquareOp $y)),
+            (MulOp (SubOp $x, $y), (AddOp $x, $y))>;
+
+    // (x + y)² - x² - y² -> 2xy
+    def SubAfterSumSquare :
+        Pat<(SubOp (SubOp (SquareOp (AddOp $x, $y)), (SquareOp $x)),
+                    (SquareOp $y)),
+            (DoubleOp (MulOp $x, $y))>;
+
+    // xy - xz -> x(y - z)
+    def FactorMulSub :
+        Pat<(SubOp (MulOp $x, $y), (MulOp $x, $z)),
+            (MulOp $x, (SubOp $y, $z))>;
+}
+
+#endif // ZKIR_UTILS_ADDITIVE_CANONICALIZATION_TD

--- a/zkir/Utils/BUILD.bazel
+++ b/zkir/Utils/BUILD.bazel
@@ -54,6 +54,16 @@ td_library(
     deps = ["@llvm-project//mlir:BuiltinDialectTdFiles"],
 )
 
+td_library(
+    name = "CanonicalizationTd",
+    srcs = [
+        "AdditiveCanonicalization.td",
+        "MultiplicativeCanonicalization.td",
+    ],
+    includes = ["../.."],
+    deps = ["@llvm-project//mlir:OpBaseTdFiles"],
+)
+
 cc_library(
     name = "ConstantFolder",
     hdrs = ["ConstantFolder.h"],
@@ -61,6 +71,11 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
     ],
+)
+
+cc_library(
+    name = "CanonicalizationPatterns",
+    hdrs = ["CanonicalizationPatterns.inc"],
 )
 
 cc_library(

--- a/zkir/Utils/CanonicalizationPatterns.inc
+++ b/zkir/Utils/CanonicalizationPatterns.inc
@@ -1,0 +1,51 @@
+// Pattern suffix list for canonicalization patterns.
+// Usage:
+//   #include "zkir/Utils/CanonicalizationPatterns.inc"
+//   #define ZKIR_ADD_PATTERN(Name) patterns.add<Prefix##Name>(context);
+//   ZKIR_ADD_PATTERN_LIST(ZKIR_ADD_PATTERN)
+//   #undef ZKIR_ADD_PATTERN
+
+// AddOp patterns.
+#define ZKIR_ADD_PATTERN_LIST(X) \
+  X(AddConstantTwice)            \
+  X(AddConstantToSubLhs)         \
+  X(AddConstantToSubRhs)         \
+  X(AddSelfIsDouble)             \
+  X(AddBothNegated)              \
+  X(AddAfterSub)                 \
+  X(AddAfterNegLhs)              \
+  X(AddAfterNegRhs)              \
+  X(FactorMulAdd)
+
+// SubOp patterns.
+#define ZKIR_SUB_PATTERN_LIST(X) \
+  X(SubConstantFromAdd)          \
+  X(SubConstantTwiceLhs)         \
+  X(SubConstantTwiceRhs)         \
+  X(SubAddFromConstant)          \
+  X(SubSubFromConstantLhs)       \
+  X(SubSubFromConstantRhs)       \
+  X(SubSelfIsZero)               \
+  X(SubLhsAfterAdd)              \
+  X(SubRhsAfterAdd)              \
+  X(SubLhsAfterSub)              \
+  X(SubAfterNegLhs)              \
+  X(SubAfterNegRhs)              \
+  X(SubBothNegated)              \
+  X(SubAfterSquareBoth)          \
+  X(SubAfterSumSquare)           \
+  X(FactorMulSub)
+
+// MulOp patterns.
+#define ZKIR_MUL_PATTERN_LIST(X) \
+  X(MulByTwoIsDouble)            \
+  X(MulSelfIsSquare)             \
+  X(MulNegativeOneRhs)           \
+  X(MulNegativeTwoRhs)           \
+  X(MulNegativeThreeRhs)         \
+  X(MulNegativeFourRhs)          \
+  X(MulConstantTwice)            \
+  X(MulOfMulByConstant)          \
+  X(MulAddDistributeConstant)    \
+  X(MulSubDistributeConstantRhs) \
+  X(MulSubDistributeConstantLhs)

--- a/zkir/Utils/MultiplicativeCanonicalization.td
+++ b/zkir/Utils/MultiplicativeCanonicalization.td
@@ -1,0 +1,100 @@
+/* Copyright 2026 The ZKIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef ZKIR_UTILS_MULTIPLICATIVE_CANONICALIZATION_TD
+#define ZKIR_UTILS_MULTIPLICATIVE_CANONICALIZATION_TD
+
+// The including file must define `GetAsConstant`.
+// Assumptions for the patterns below:
+// - MulOp is associative and commutative where noted.
+// - No multiplicative inverses are required.
+multiclass MultiplicativeCanonicalizationPatterns<Op MulOp, Op SquareOp, Op DoubleOp,
+                                                 Op NegateOp, Op AddOp, Op SubOp> {
+    //===--------------------------------------------------------------------===//
+    // MulOp
+    //===--------------------------------------------------------------------===//
+
+    // --- Associativity/commutativity ---
+    // MulOp is commutative and associative; rewrite to place constants on the RHS.
+
+    // x * x -> square(x)
+    def MulSelfIsSquare :
+        Pat<(MulOp $x, $x),
+            (SquareOp $x)>;
+
+    // (x * c0) * c1 -> x * (c0 * c1)
+    def MulConstantTwice :
+        Pat<(MulOp (MulOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)),
+                    (ConstantLikeMatcher TypedAttrInterface:$c1)),
+            (MulOp $x,
+                    (MulOp (GetAsConstant $x, $c0),
+                            (GetAsConstant $x, $c1)))>;
+
+    // (x * c0) * (y * c1) -> (x * y) * (c0 * c1)
+    def MulOfMulByConstant :
+        Pat<(MulOp (MulOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)),
+                    (MulOp $y, (ConstantLikeMatcher TypedAttrInterface:$c1))),
+            (MulOp (MulOp $x, $y),
+                    (MulOp (GetAsConstant $x, $c0),
+                            (GetAsConstant $y, $c1)))>;
+
+    // x * 2 -> double(x)
+    def MulByTwoIsDouble :
+        Pat<(MulOp $x, (ConstantLikeMatcher TypedAttrInterface:$c2)),
+            (DoubleOp $x),
+            [(IsTwo $c2, $x)]>;
+
+    // x * (-1) -> negate(x)
+    def MulNegativeOneRhs :
+        Pat<(MulOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)),
+            (NegateOp $x),
+            [(IsNegativeOne $c0, $x)]>;
+
+    // x * (-2) -> negate(double(x))
+    def MulNegativeTwoRhs :
+        Pat<(MulOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)),
+            (NegateOp (DoubleOp $x)),
+            [(IsNegativeTwo $c0, $x)]>;
+
+    // x * (-3) -> negate(x + double(x))
+    def MulNegativeThreeRhs :
+        Pat<(MulOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)),
+            (NegateOp (AddOp (DoubleOp $x), $x)),
+            [(IsNegativeThree $c0, $x)]>;
+
+    // x * (-4) -> negate(double(double(x)))
+    def MulNegativeFourRhs :
+        Pat<(MulOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)),
+            (NegateOp (DoubleOp (DoubleOp $x))),
+            [(IsNegativeFour $c0, $x)]>;
+
+    // (x + c0) * c1 -> x * c1 + c0 * c1
+    def MulAddDistributeConstant :
+        Pat<(MulOp (AddOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)), (ConstantLikeMatcher TypedAttrInterface:$c1)),
+            (AddOp (MulOp $x, (GetAsConstant $x, $c1)), (MulOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)))>;
+
+    // (x - c0) * c1 -> x * c1 - c0 * c1
+    def MulSubDistributeConstantRhs :
+        Pat<(MulOp (SubOp $x, (ConstantLikeMatcher TypedAttrInterface:$c0)), (ConstantLikeMatcher TypedAttrInterface:$c1)),
+            (SubOp (MulOp $x, (GetAsConstant $x, $c1)), (MulOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)))>;
+
+    // (c0 - x) * c1 -> c0 * c1 - x * c1
+    def MulSubDistributeConstantLhs :
+        Pat<(MulOp (SubOp (ConstantLikeMatcher TypedAttrInterface:$c0), $x), (ConstantLikeMatcher TypedAttrInterface:$c1)),
+            (SubOp (MulOp (GetAsConstant $x, $c0), (GetAsConstant $x, $c1)), (MulOp $x, (GetAsConstant $x, $c1)))>;
+
+}
+
+#endif // ZKIR_UTILS_MULTIPLICATIVE_CANONICALIZATION_TD


### PR DESCRIPTION
## Description

This PR arranges rewrite patterns to align with mathematical structure.
Now specific rewrite rules are generated by multiclass with prefix.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
