### PR TITLE
ci: update license style guide for 2026 copyright year

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -295,6 +295,13 @@ ______________________________________________________________________
 Every file (that could be exceptional case, such as empty BUILD.bazel) should
 have license notice in the top.
 
+### Date of Creation
+
+- **New Files**: For any new files created from now on, the copyright year
+  should be set to 2026.
+- **Refactored Files**: If a file is moved or renamed as part of a refactoring
+  process, you may retain the original creation year from the source file.
+
 [.clang-format]: /.clang-format
 [angular commit convention]: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
 [commit message guideline]: https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md


### PR DESCRIPTION
## Description

This PR updates the license notice section in the style guide to clarify copyright year requirements for new and refactored files.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
