### PR TITLE
feat(mod_arith): implement Mersenne reduction for moduli of form 2^k - 1

### DIFF
--- a/tests/Dialect/ModArith/mod_arith_to_arith.mlir
+++ b/tests/Dialect/ModArith/mod_arith_to_arith.mlir
@@ -18,6 +18,8 @@
 !Zp = !mod_arith.int<65537 : i32>
 !Zpv = tensor<4x!Zp>
 
+!M3 = !mod_arith.int<7 : i32>
+
 // CHECK-LABEL: @test_lower_constant
 // CHECK-SAME: () -> [[T:.*]] {
 func.func @test_lower_constant() -> !Zp {
@@ -175,6 +177,14 @@ func.func @test_lower_mul_vec(%lhs : !Zpv, %rhs : !Zpv) -> !Zpv {
   // CHECK-NOT: mod_arith.mul
   %res = mod_arith.mul %lhs, %rhs : !Zpv
   return %res : !Zpv
+}
+
+// CHECK-LABEL: @test_lower_mul_mersenne
+// CHECK-SAME: (%[[LHS:.*]]: [[T:.*]], %[[RHS:.*]]: [[T]]) -> [[T]] {
+func.func @test_lower_mul_mersenne(%lhs : !M3, %rhs : !M3) -> !M3 {
+  // CHECK-NOT: mod_arith.mul
+  %res = mod_arith.mul %lhs, %rhs : !M3
+  return %res : !M3
 }
 
 // CHECK-LABEL: @test_lower_cmp


### PR DESCRIPTION
## Description

Optimizes the multiplication lowering in `ModArithToArith` by using a bit-shift based reduction strategy when the modulus is a Mersenne number (2^k - 1).

 A runner test isn't added since this is covered by `field_runner.mlir`

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
