### PR TITLE
feat(elliptic_curve): introduce `ConstantOp` and coordinate parsing logic

### DIFF
--- a/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveDialect.td
+++ b/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveDialect.td
@@ -31,6 +31,7 @@ def EllipticCurve_Dialect : Dialect {
     "prime_ir::field::FieldDialect",
     "prime_ir::mod_arith::ModArithDialect",
   ];
+  let hasConstantMaterializer = 1;
 }
 
 #endif  // PRIME_IR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVEDIALECT_TD_

--- a/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveOps.h
+++ b/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveOps.h
@@ -17,6 +17,8 @@ limitations under the License.
 #define PRIME_IR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVEOPS_H_
 
 #include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/Types.h"
 
 // IWYU pragma: begin_keep
@@ -31,6 +33,9 @@ limitations under the License.
 #include "prime_ir/Dialect/EllipticCurve/IR/EllipticCurveOps.h.inc"
 
 namespace mlir::prime_ir::elliptic_curve {
+
+ParseResult parseEllipticCurveConstant(OpAsmParser &parser,
+                                       OperationState &result);
 
 // WARNING: Assumes Jacobian or XYZZ point types
 Value createZeroPoint(ImplicitLocOpBuilder &b, Type pointType);

--- a/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveOps.td
+++ b/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveOps.td
@@ -53,6 +53,49 @@ class EllipticCurve_BinaryOp<string mnemonic, list<Trait> traits = []> :
 
 ////////////// POINT INITIALIZATIONS //////////////
 
+def EllipticCurve_ConstantOp : EllipticCurve_Op<"constant", [ConstantLike]> {
+  let summary = "Define a constant elliptic curve point via coordinates";
+  let description = [{
+    Defines a constant elliptic curve point from integer coordinates. The number of
+    provided coordinates must match the point representation:
+    - 2 coordinates for Affine points
+    - 3 coordinates for Jacobian points
+    - 4 coordinates for XYZZ points
+
+    The resulting point must satisfy the specific curve equation (e.g., y² = x³ + ax + b).
+
+    Example:
+    ```mlir
+    // Affine point (x, y)
+    %0 = elliptic_curve.constant 1, 2 : !elliptic_curve.affine<#curve>
+    // Jacobian point (x, y, z)
+    %1 = elliptic_curve.constant 1, 2, 1 : !elliptic_curve.jacobian<#curve>
+    // XYZZ point (x, y, zz, zzz)
+    %2 = elliptic_curve.constant 1, 2, 1, 1 : !elliptic_curve.xyzz<#curve>
+    ```
+  }];
+  let arguments = (ins ArrayAttr:$coords);
+  let results = (outs PointLike:$output);
+  let hasCustomAssemblyFormat = 1;
+  let hasFolder = 1;
+  let extraClassDeclaration = [{
+    /// Build the constant op with `value` and `type` if possible, otherwise
+    /// returns null.
+    static ConstantOp materialize(OpBuilder &builder, Attribute value,
+                                  Type type, Location loc);
+  }];
+  // TODO(chokobole): The current verification DevEx is suboptimal due to
+  // Montgomery domain mismatches. If the elliptic curve is defined over a
+  // Montgomery base field, but the constant coordinates are provided in the
+  // standard (non-Montgomery) domain, the verifier will fail to validate the
+  // curve equation.
+  //
+  // We should enable the verifier once the field constant parser supports
+  // automatic domain conversion to ensure consistency between input literals
+  // and the target field representation.
+
+}
+
 def EllipticCurve_ExtFromCoordOp : EllipticCurve_Op<"ext_from_coord"> {
   let summary = "Constructs an elliptic curve point from coordinates";
   let description = [{

--- a/prime_ir/Dialect/Field/IR/FieldOps.h
+++ b/prime_ir/Dialect/Field/IR/FieldOps.h
@@ -40,6 +40,10 @@ PrimeFieldType getResultPrimeFieldType(OpType op) {
 Type getStandardFormType(Type type);
 Type getMontgomeryFormType(Type type);
 
+FailureOr<Attribute> validateAndCreateFieldAttribute(OpAsmParser &parser,
+                                                     Type type,
+                                                     ArrayRef<APInt> values);
+
 ParseResult parseFieldConstant(OpAsmParser &parser, OperationState &result);
 
 } // namespace mlir::prime_ir::field

--- a/tests/Dialect/EllipticCurve/elliptic_curve_to_field.mlir
+++ b/tests/Dialect/EllipticCurve/elliptic_curve_to_field.mlir
@@ -50,6 +50,20 @@ func.func @test_initialization_and_conversion() {
   return
 }
 
+// CHECK-LABEL: @test_constant
+func.func @test_constant() {
+  // CHECK-NOT: elliptic_curve.constant
+  // G1 constants (prime field - single integers)
+  %affine1 = elliptic_curve.constant 1, 2 : !affine
+  %jacobian1 = elliptic_curve.constant 1, 2, 1 : !jacobian
+  %xyzz1 = elliptic_curve.constant 1, 2, 1, 1 : !xyzz
+  // G2 constants (extension field - integer arrays)
+  %g2_affine1 = elliptic_curve.constant [1, 1], [2, 3] : !g2affine
+  %g2_jacobian1 = elliptic_curve.constant [1, 1], [2, 3], [1, 0] : !g2jacobian
+  %g2_xyzz1 = elliptic_curve.constant [1, 1], [2, 3], [1, 0], [1, 0] : !g2xyzz
+  return
+}
+
 // CHECK-LABEL: @test_addition
 func.func @test_addition(%affine1: !affine, %affine2: !affine, %jacobian1: !jacobian, %jacobian2: !jacobian, %xyzz1: !xyzz, %xyzz2: !xyzz) {
   // CHECK-NOT: elliptic_curve.add


### PR DESCRIPTION
## Description

Adds the `constant` operation to the Elliptic Curve dialect to define points via integer coordinates. The operation supports both:
- G1 curves (prime field): single integer coordinates (e.g., 1, 2)
- G2 curves (extension field): integer array coordinates (e.g., [1, 1], [2, 3])

Implements conversion to Field dialect and robust parsing/printing support for both prime field and extension field base types.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212836789915769