### PR TITLE
chore: add comprehensive coding philosophy and collaboration rules

### DIFF
--- a/.cursor/rules/bazel-style-guide.mdc
+++ b/.cursor/rules/bazel-style-guide.mdc
@@ -7,3 +7,4 @@ alwaysApply: false
 # Bazel Style Rules
 
 - Every header included in a Bazel target must also be declared as a Bazel dependency.
+- When working with local LLVM clones for development, follow the process documented in `CONTRIBUTING.md` for updating patches.

--- a/.cursor/rules/collaboration.mdc
+++ b/.cursor/rules/collaboration.mdc
@@ -1,0 +1,35 @@
+---
+description: Collaboration Rules - Commits, Pull Requests, and Code Review
+alwaysApply: true
+---
+
+# Collaboration Rules
+
+## Commits (Angular Commit Convention)
+
+- Must follow the [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md).
+
+- Format:
+  ```
+  <type>(<scope>): <summary>
+  ```
+  where `type` ∈ {build, chore, ci, docs, feat, fix, perf, refactor, style, test}.
+
+- Commit body: explain **why** the change was made (minimum 20 characters).
+
+- Footer: record breaking changes, deprecations, and related issues/PRs.
+
+- Each commit must include only **minimal, logically related changes**. Avoid mixing style fixes with functional changes.
+
+## Pull Requests
+
+- Follow the [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md).
+- Commits must be **atomic** and independently buildable/testable.
+- Provide context and links (short SHA for external references).
+
+## Tooling Requirements
+
+- **Formatter:** `clang-format` (LLVM preset with project overrides). Refer to the `.clang-format` file in the repo.
+- **Linter:** `clang-tidy`.
+- **Pre-commit hooks:** Recommended for enforcing format and lint locally.
+- **CI:** All PRs must pass lint, format, and tests before merge.

--- a/.cursor/rules/general-philosophy.mdc
+++ b/.cursor/rules/general-philosophy.mdc
@@ -1,0 +1,31 @@
+---
+description: General Coding Philosophy and Core Principles
+alwaysApply: true
+---
+
+# General Coding Philosophy
+
+## Core Principles
+
+- **Readability:** Both code and commits should be immediately understandable.
+- **Maintainability:** Code should be easy to refactor and extend.
+- **Consistency:** Apply the same conventions across files and modules, except where external code (e.g., XLA) is imported.
+- **Performance:** Prioritize clarity, but optimize carefully where latency and cost are critical.
+
+## Comment Style
+
+- Non-trivial code changes must be accompanied by comments.
+- Comments explain **why** a change or design decision was made or explain the code for better readability.
+- Use full sentences with proper punctuation.
+
+## File Formatting
+
+- Every file must end with a single newline.
+- No trailing whitespace.
+- No extra blank lines at EOF.
+
+## License
+
+- Every file (that could be exceptional case, such as empty BUILD.bazel) should have license notice at the top.
+- **New Files**: For any new files created from now on, the copyright year should be set to 2026.
+- **Refactored Files**: If a file is moved or renamed as part of a refactoring process, you may retain the original creation year from the source file.

--- a/.cursor/rules/primeir-specific.mdc
+++ b/.cursor/rules/primeir-specific.mdc
@@ -1,0 +1,57 @@
+---
+description: PrimeIR-Specific Principles and Dialect Consistency Rules
+alwaysApply: true
+---
+
+# PrimeIR-Specific Principles
+
+To prevent technical debt and ensure a seamless developer experience, all dialects must adhere to the following principles of consistency and completeness.
+
+## Implementation Parity
+
+When a new feature, optimization, or simplification is introduced in one dialect, it must be evaluated for all other applicable dialects.
+
+- **Canonicalization & Constant Folding**: If an algebraic simplification or a constant folding rule is added to one dialect, it **should be implemented simultaneously** in all other dialects where that logic is mathematically valid.
+- **Symmetry of Support**: If `ModArith` supports a specific operation or data type (e.g., vector constant folding), the `Field` dialect should aim for equivalent support to avoid "gaps" in the IR's capabilities.
+
+### Unified Developer Experience (DX)
+
+If an operation is there for a certain purpose in one dialect, a corresponding operation should exist in others using the same naming convention and logic.
+
+### Test-Driven Completeness
+
+Functionality and reliability must be proven across all domains. Use a similar testing structure for other dialects to ensure comprehensive coverage.
+
+## Field/ModArith Type Accessors
+
+When working with `ModArithType` or `PrimeFieldType`:
+
+| Purpose              | Method                                  |
+| -------------------- | --------------------------------------- |
+| Storage type         | `getStorageType()`                      |
+| Storage bit width    | `getStorageBitWidth()`                  |
+| Arithmetic bit width | `getModulus().getValue().getBitWidth()` |
+
+**Do NOT use `getModulus().getType()`** for storage type. For binary fields GF(2ⁿ), the modulus 2ⁿ requires n+1 bits but storage only needs n bits. `getStorageType()` handles this automatically.
+
+```c++
+// ✅ Storage: use getStorageType() / getStorageBitWidth()
+unsigned bitWidth = fieldType.getStorageBitWidth();
+APInt nVal(bitWidth, n);
+IntegerAttr::get(fieldType.getStorageType(), nVal);
+
+// ✅ Arithmetic: use getModulus().getValue().getBitWidth()
+APInt modulus = fieldType.getModulus().getValue();
+APInt result = n.urem(modulus);
+
+// ❌ Bad: using getModulus().getType() for storage
+IntegerAttr::get(fieldType.getModulus().getType(), value);  // Wrong!
+```
+
+## MLIR Type Variable Naming
+
+| Type                     | Variable Name   |
+| ------------------------ | --------------- |
+| `ExtensionFieldType`     | `efType`        |
+| `PrimeFieldType`         | `pfType`        |
+| Base field type (`Type`) | `baseFieldType` |

--- a/.cursor/rules/tablegen.mdc
+++ b/.cursor/rules/tablegen.mdc
@@ -1,0 +1,58 @@
+---
+description: TableGen Rules for MLIR Dialects and Passes
+globs: *.td
+alwaysApply: false
+---
+
+# TableGen Rules
+
+This section defines standards for defining MLIR Dialects and Passes, particularly focusing on the use of `dependentDialects` in TableGen (`.td`) files.
+
+## Dialect: `dependentDialects` Management
+
+When defining a Dialect, the `dependentDialects` field is used to record dependencies on other dialects whose components (Operations, Attributes, or Types) are **reused, relied upon, or constructed** by the current Dialect itself.
+
+Example:
+
+```
+def MyDialect : Dialect {
+  // Here we register the Arithmetic and Func dialect as dependencies of our `MyDialect`.
+  let dependentDialects = [
+    "arith::ArithDialect",
+    "func::FuncDialect"
+  ];
+}
+```
+
+For every Dialect listed in the `dependentDialects` of a Dialect, the corresponding C++ header file **must** be included in the Dialect definition file.
+
+```c++
+// IWYU pragma: begin_keep
+// Headers needed for FieldDialect.cpp.inc
+#include "mlir/IR/OperationSupport.h"
+#include "prime_ir/Dialect/ModArith/IR/ModArithDialect.h"
+// IWYU pragma: end_keep
+```
+
+## Pass: `dependentDialects` Management
+
+The `dependentDialects` list in a `Pass` definition must only include Dialects for which the Pass **introduces new entities** (Operations, Attributes, Types, etc.) during its execution.
+
+- **Rule:** The list should contain only Dialects whose entities are **newly created or explicitly used to construct a transformation** by the Pass.
+- **Avoid:** Do not include Dialects that are merely consumed, transformed, or required for general Pass setup.
+  - _Example:_ If a Pass transforms `tensor` ops into `memref` ops, and does not create new `tensor` ops, `tensor::TensorDialect` should not be listed as a dependent dialect.
+
+For every Dialect listed in the `dependentDialects` of a Pass, the corresponding C++ header file **must** be included in the Pass definition file (e.g., `*Pass.h`).
+
+Example (for `TensorExtToTensorPass`):
+
+```c++
+// IWYU pragma: begin_keep
+// Headers needed for TensorExtToTensor.h.inc
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Pass/Pass.h"
+// IWYU pragma: end_keep
+```

--- a/.cursor/rules/testing-guide.mdc
+++ b/.cursor/rules/testing-guide.mdc
@@ -1,13 +1,14 @@
 ---
 description: Testing Rules
-globs: *_test.cc
+globs: *_test.cc,*_test.py
 alwaysApply: false
 ---
 
 # Testing Rules
 
-- **Framework**: Use gtest/gmock.
+- **Framework**: Use gtest/gmock for C++ tests.
 - **Coverage**: New features must include tests whenever applicable.
 - **Completeness**: Always include boundary cases and error paths.
 - **Determinism**: Tests must be deterministic and runnable independently (no hidden state dependencies).
 - **Performance**: Add benchmarks for performance-critical code paths when appropriate.
+- **Test-Driven Completeness**: When implementing features across dialects, use similar testing structures to ensure comprehensive coverage.


### PR DESCRIPTION
## Description

Add general coding philosophy, collaboration guidelines, PrimeIR-specific principles, and TableGen rules to .cursor/rules directory. These rules were previously documented in .gemini/styleguide.md but missing from the Cursor rules system, making them unavailable to AI assistants.

New files:
- general-philosophy.mdc: Core principles (readability, maintainability, consistency, performance), comment style, file formatting, license rules
- collaboration.mdc: Commit conventions (Angular), PR guidelines, tooling requirements
- primeir-specific.mdc: Implementation parity, dialect consistency, type accessor patterns, MLIR naming conventions
- tablegen.mdc: Dialect and Pass dependentDialects management rules

Updated files:
- testing-guide.mdc: Add Python test support and test-driven completeness
- bazel-style-guide.mdc: Add reference to LLVM patch update process

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
