### PR TITLE
feat(field): simplify modulus access by exposing `PyIntegerAttribute`

### DIFF
--- a/prime_ir/Dialect/Field/Python/FieldTypes.cpp
+++ b/prime_ir/Dialect/Field/Python/FieldTypes.cpp
@@ -34,9 +34,9 @@ void PyPrimeFieldType::bindDerived(ClassTy &c) {
       nb::arg("context") = nb::none(), "Create a prime field type");
   c.def_prop_ro(
       "modulus",
-      [](PyPrimeFieldType &self) -> PyAttribute {
-        return PyAttribute(self.getContext(),
-                           primeIRPrimeFieldTypeGetModulus(self));
+      [](PyPrimeFieldType &self) -> PyIntegerAttribute {
+        return PyIntegerAttribute(self.getContext(),
+                                  primeIRPrimeFieldTypeGetModulus(self));
       },
       "Returns the modulus of the prime field type");
   c.def_prop_ro(
@@ -74,9 +74,9 @@ void PyExtensionFieldType::bindDerived(ClassTy &c) {
       "Returns the base field of the extension field type");
   c.def_prop_ro(
       "non_residue",
-      [](PyExtensionFieldType &self) -> PyAttribute {
-        return PyAttribute(self.getContext(),
-                           primeIRExtensionFieldTypeGetNonResidue(self));
+      [](PyExtensionFieldType &self) -> PyIntegerAttribute {
+        return PyIntegerAttribute(self.getContext(),
+                                  primeIRExtensionFieldTypeGetNonResidue(self));
       },
       "Returns the non-residue of the extension field type");
   c.def_prop_ro(

--- a/prime_ir/Dialect/Field/Python/FieldTypes.h
+++ b/prime_ir/Dialect/Field/Python/FieldTypes.h
@@ -16,8 +16,12 @@ limitations under the License.
 #ifndef PRIME_IR_DIALECT_FIELD_PYTHON_FIELDTYPES_H_
 #define PRIME_IR_DIALECT_FIELD_PYTHON_FIELDTYPES_H_
 
-#include "mlir/Bindings/Python/Nanobind.h"
+// clang-format off
+// This should be included before mlir/Bindings/Python/IRAttributes.h
 #include "mlir/lib/Bindings/Python/IRModule.h"
+// clang-format on
+#include "mlir/Bindings/Python/IRAttributes.h"
+#include "mlir/Bindings/Python/Nanobind.h"
 #include "prime_ir/Dialect/Field/C/FieldTypes.h"
 
 namespace mlir::prime_ir::field::python {

--- a/tests/python/field_test.py
+++ b/tests/python/field_test.py
@@ -26,11 +26,7 @@ class FieldTest(absltest.TestCase):
       field.register_dialect(ctx)
       pf = _createBabybearType(ctx)
       self.assertEqual(str(pf), "!field.pf<2013265921 : i32, true>")
-      i32 = IntegerType.get_signless(32)
-      # TODO(chokobole): The direct comparison to a native Python 'int' fails here:
-      # self.assertEqual(int(pf.modulus), BABYBEAR_MODULUS)
-      # See https://github.com/fractalyze/prime-ir/issues/110
-      self.assertEqual(pf.modulus, IntegerAttr.get(i32, BABYBEAR_MODULUS))
+      self.assertEqual(int(pf.modulus), BABYBEAR_MODULUS)
       self.assertTrue(pf.is_montgomery)
 
   def testExtensionFieldTypes(self):
@@ -48,7 +44,7 @@ class FieldTest(absltest.TestCase):
       )
       self.assertEqual(ef2_type.degree, 2)
       self.assertEqual(ef2_type.base_field, pf)
-      self.assertEqual(ef2_type.non_residue, non_residue_attr_2)
+      self.assertEqual(int(ef2_type.non_residue), non_residue_2)
       self.assertTrue(ef2_type.is_montgomery)
 
       # Test degree 3 (2 is a valid cubic non-residue)
@@ -61,7 +57,7 @@ class FieldTest(absltest.TestCase):
       )
       self.assertEqual(ef3_type.degree, 3)
       self.assertEqual(ef3_type.base_field, pf)
-      self.assertEqual(ef3_type.non_residue, non_residue_attr_3)
+      self.assertEqual(int(ef3_type.non_residue), non_residue_3)
       self.assertTrue(ef3_type.is_montgomery)
 
       # Test degree 4 (11 is a valid quartic non-residue)
@@ -74,7 +70,7 @@ class FieldTest(absltest.TestCase):
       )
       self.assertEqual(ef4_type.degree, 4)
       self.assertEqual(ef4_type.base_field, pf)
-      self.assertEqual(ef4_type.non_residue, non_residue_attr_4)
+      self.assertEqual(int(ef4_type.non_residue), non_residue_4)
       self.assertTrue(ef4_type.is_montgomery)
 
 

--- a/third_party/llvm-project/expose_py_integer_attribute.patch
+++ b/third_party/llvm-project/expose_py_integer_attribute.patch
@@ -1,0 +1,138 @@
+diff --git a/mlir/include/mlir/Bindings/Python/IRAttributes.h b/mlir/include/mlir/Bindings/Python/IRAttributes.h
+new file mode 100644
+index 000000000000..a954874152dc
+--- /dev/null
++++ b/mlir/include/mlir/Bindings/Python/IRAttributes.h
+@@ -0,0 +1,32 @@
++//===- IRAttributes.h - Attribute Interfaces ------------------------------===//
++//
++// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
++// See https://llvm.org/LICENSE.txt for license information.
++// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
++//
++//===----------------------------------------------------------------------===//
++
++#ifndef MLIR_BINDINGS_PYTHON_IRATTRIBUTES_H
++#define MLIR_BINDINGS_PYTHON_IRATTRIBUTES_H
++
++#include "mlir/Bindings/Python/NanobindAdaptors.h"
++
++namespace mlir {
++
++/// Integer Attribute subclass - IntegerAttr
++class PyIntegerAttribute
++    : public python::PyConcreteAttribute<PyIntegerAttribute> {
++public:
++  static const IsAFunctionTy isaFunction;
++  static constexpr const char *pyClassName = "IntegerAttr";
++  using PyConcreteAttribute::PyConcreteAttribute;
++
++  static void bindDerived(ClassTy &c);
++
++private:
++  static int64_t toPyInt(PyIntegerAttribute &self);
++};
++
++} // namespace mlir
++
++#endif // MLIR_BINDINGS_PYTHON_IRATTRIBUTES_H
+diff --git a/mlir/lib/Bindings/Python/IRAttributes.cpp b/mlir/lib/Bindings/Python/IRAttributes.cpp
+index 12725a0ed093..d21f84cb9df8 100644
+--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
++++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
+@@ -12,7 +12,11 @@
+ #include <string_view>
+ #include <utility>
+ 
++// clang-format off
+ #include "IRModule.h"
++#include "mlir/Bindings/Python/IRAttributes.h"
++// clang-format on
++
+ #include "NanobindUtils.h"
+ #include "mlir-c/BuiltinAttributes.h"
+ #include "mlir-c/BuiltinTypes.h"
+@@ -591,42 +595,8 @@ public:
+   }
+ };
+ 
+-/// Integer Attribute subclass - IntegerAttr.
+-class PyIntegerAttribute : public PyConcreteAttribute<PyIntegerAttribute> {
+-public:
+-  static constexpr IsAFunctionTy isaFunction = mlirAttributeIsAInteger;
+-  static constexpr const char *pyClassName = "IntegerAttr";
+-  using PyConcreteAttribute::PyConcreteAttribute;
+-
+-  static void bindDerived(ClassTy &c) {
+-    c.def_static(
+-        "get",
+-        [](PyType &type, int64_t value) {
+-          MlirAttribute attr = mlirIntegerAttrGet(type, value);
+-          return PyIntegerAttribute(type.getContext(), attr);
+-        },
+-        nb::arg("type"), nb::arg("value"),
+-        "Gets an uniqued integer attribute associated to a type");
+-    c.def_prop_ro("value", toPyInt,
+-                  "Returns the value of the integer attribute");
+-    c.def("__int__", toPyInt,
+-          "Converts the value of the integer attribute to a Python int");
+-    c.def_prop_ro_static("static_typeid",
+-                         [](nb::object & /*class*/) -> MlirTypeID {
+-                           return mlirIntegerAttrGetTypeID();
+-                         });
+-  }
+-
+-private:
+-  static int64_t toPyInt(PyIntegerAttribute &self) {
+-    MlirType type = mlirAttributeGetType(self);
+-    if (mlirTypeIsAIndex(type) || mlirIntegerTypeIsSignless(type))
+-      return mlirIntegerAttrGetValueInt(self);
+-    if (mlirIntegerTypeIsSigned(type))
+-      return mlirIntegerAttrGetValueSInt(self);
+-    return mlirIntegerAttrGetValueUInt(self);
+-  }
+-};
++// Note: PyIntegerAttribute is declared in
++// mlir/include/mlir/Bindings/Python/IRAttributes.h
+ 
+ /// Bool Attribute subclass - BoolAttr.
+ class PyBoolAttribute : public PyConcreteAttribute<PyBoolAttribute> {
+@@ -1756,6 +1726,38 @@ nb::object symbolRefOrFlatSymbolRefAttributeCaster(PyAttribute &pyAttribute) {
+ 
+ } // namespace
+ 
++// Integer Attribute subclass - IntegerAttr
++void mlir::PyIntegerAttribute::bindDerived(ClassTy &c) {
++  c.def_static(
++      "get",
++      [](PyType &type, int64_t value) {
++        MlirAttribute attr = mlirIntegerAttrGet(type, value);
++        return PyIntegerAttribute(type.getContext(), attr);
++      },
++      nb::arg("type"), nb::arg("value"),
++      "Gets an uniqued integer attribute associated to a type");
++  c.def_prop_ro("value", toPyInt,
++                "Returns the value of the integer attribute");
++  c.def("__int__", toPyInt,
++        "Converts the value of the integer attribute to a Python int");
++  c.def_prop_ro_static("static_typeid",
++                       [](nb::object & /*class*/) -> MlirTypeID {
++                         return mlirIntegerAttrGetTypeID();
++                       });
++}
++
++int64_t mlir::PyIntegerAttribute::toPyInt(PyIntegerAttribute &self) {
++  MlirType type = mlirAttributeGetType(self);
++  if (mlirTypeIsAIndex(type) || mlirIntegerTypeIsSignless(type))
++    return mlirIntegerAttrGetValueInt(self);
++  if (mlirIntegerTypeIsSigned(type))
++    return mlirIntegerAttrGetValueSInt(self);
++  return mlirIntegerAttrGetValueUInt(self);
++}
++
++const mlir::PyIntegerAttribute::IsAFunctionTy
++    mlir::PyIntegerAttribute::isaFunction = mlirAttributeIsAInteger;
++
+ void mlir::python::populateIRAttributes(nb::module_ &m) {
+   PyAffineMapAttribute::bind(m);
+   PyDenseBoolArrayAttribute::bind(m);

--- a/third_party/llvm-project/workspace.bzl
+++ b/third_party/llvm-project/workspace.bzl
@@ -40,4 +40,5 @@ LLVM_PATCHES = [
     "@prime_ir//third_party/llvm-project:lazy_linking.patch",
     "@prime_ir//third_party/llvm-project:elementwise_op_fusion_constant_support.patch",
     "@prime_ir//third_party/llvm-project:constant_like_interface.patch",
+    "@prime_ir//third_party/llvm-project:expose_py_integer_attribute.patch",
 ]

--- a/tools/setup_llvm_clone.sh
+++ b/tools/setup_llvm_clone.sh
@@ -62,6 +62,7 @@ patches=(
     "$patch_dir/lazy_linking.patch"
     "$patch_dir/elementwise_op_fusion_constant_support.patch"
     "$patch_dir/constant_like_interface.patch"
+    "$patch_dir/expose_py_integer_attribute.patch"
 )
 shopt -u nullglob
 


### PR DESCRIPTION
## Description

Patches LLVM to expose `PyIntegerAttribute` in the C++ API, enabling field type properties to return integer attributes directly.

Key Changes:
- LLVM: Added `expose_py_integer_attribute.patch` to move `PyIntegerAttribute` definition to a public header (`IRAttributes.h`).
- Bindings: Updated `modulus` and `non_residue` getters in `FieldTypes.cpp` to return `PyIntegerAttribute` instead of generic `PyAttribute`.
- Tests: Simplified `field_test.py` to compare integer values directly, resolving issue #110.

## Related Issues/PRs

Resolves: #110

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
