### PR TITLE
feat(elliptic_curve): add constant folding on elliptic curve

### DIFF
--- a/prime_ir/Dialect/EllipticCurve/IR/BUILD.bazel
+++ b/prime_ir/Dialect/EllipticCurve/IR/BUILD.bazel
@@ -69,6 +69,7 @@ cc_library(
         "//prime_ir/Dialect/ModArith/IR:ModArith",
         "//prime_ir/Dialect/Poly/IR:Poly",
         "//prime_ir/Utils:CanonicalizationPatterns",
+        "//prime_ir/Utils:ConstantFolder",
         "//prime_ir/Utils:KnownModulus",
         "//prime_ir/Utils:OpUtils",
         "//prime_ir/Utils:ZkDtypes",

--- a/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveOps.td
+++ b/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveOps.td
@@ -175,6 +175,7 @@ def EllipticCurve_AddOp : EllipticCurve_BinaryOp<"add", [Commutative]> {
     %sum = elliptic_curve.add %a, %b : !affine, !jacobian -> !jacobian
     ```
   }];
+  let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
 
@@ -196,6 +197,7 @@ def EllipticCurve_SubOp : EllipticCurve_BinaryOp<"sub"> {
     %difference = elliptic_curve.sub %a, %b : !affine, !jacobian -> !jacobian
     ```
   }];
+  let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
 
@@ -214,6 +216,7 @@ def EllipticCurve_NegateOp : EllipticCurve_UnaryOp<"negate", [Involution, SameOp
     %negation = elliptic_curve.negate %a : !jacobian
     ```
   }];
+  let hasFolder = 1;
   let assemblyFormat = "operands attr-dict `:` type($output)";
 }
 
@@ -235,6 +238,7 @@ def EllipticCurve_DoubleOp : EllipticCurve_UnaryOp<"double"> {
     ```
   }];
   let hasVerifier = 1;
+  let hasFolder = 1;
   let assemblyFormat = "operands attr-dict `:` type($input) `->` type($output)";
 }
 

--- a/prime_ir/Dialect/EllipticCurve/IR/PointOperation.cpp
+++ b/prime_ir/Dialect/EllipticCurve/IR/PointOperation.cpp
@@ -26,6 +26,11 @@ PointKind PointOperation::getKind() const {
                     operation);
 }
 
+PointOperation PointOperation::operator-() const {
+  return std::visit([](const auto &v) -> PointOperation { return -v; },
+                    operation);
+}
+
 namespace {
 
 template <typename F>
@@ -70,6 +75,22 @@ PointOperation PointOperation::add(const PointOperation &other,
 
   return applyBinaryOp(operation, other.operation,
                        [](const auto &a, const auto &b) { return a + b; });
+}
+
+PointOperation PointOperation::sub(const PointOperation &other,
+                                   PointKind outputKind) const {
+  PointKind lhsKind = getKind();
+  PointKind rhsKind = other.getKind();
+  if (lhsKind == PointKind::kAffine && lhsKind == rhsKind) {
+    if (outputKind == PointKind::kXYZZ) {
+      // sub(a, b) = add(a, negate(b))
+      return std::get<AffinePointOperation>(operation).AddToXyzz(
+          -std::get<AffinePointOperation>(other.operation));
+    }
+  }
+
+  return applyBinaryOp(operation, other.operation,
+                       [](const auto &a, const auto &b) { return a - b; });
 }
 
 PointOperation PointOperation::dbl(PointKind outputKind) const {

--- a/prime_ir/Dialect/EllipticCurve/IR/PointOperation.h
+++ b/prime_ir/Dialect/EllipticCurve/IR/PointOperation.h
@@ -142,6 +142,12 @@ public:
 
   auto dbl() const { return this->Double(); }
 
+  const std::array<field::FieldOperation, kNumCoords> &getCoords() const {
+    return coords;
+  }
+
+  PointTypeInterface getPointType() const { return pointType; }
+
   bool operator==(const PointOperationBase &other) const {
     assert(pointType == other.pointType);
     return coords == other.coords;
@@ -331,9 +337,13 @@ public:
 
   PointKind getKind() const;
 
+  PointOperation operator-() const;
   PointOperation add(const PointOperation &other, PointKind outputKind) const;
+  PointOperation sub(const PointOperation &other, PointKind outputKind) const;
   PointOperation dbl(PointKind outputKind) const;
   PointOperation convert(PointKind outputKind) const;
+
+  const OperationType &getOperation() const { return operation; }
 
 private:
   OperationType operation;


### PR DESCRIPTION
## Description

This PR significantly optimizes the **Elliptic Curve** dialect by implementing constant folding for key point operations and restructuring the canonicalization logic based on algebraic structures.

These changes enable the compiler to evaluate elliptic curve arithmetic at compile-time when operands are constant and introduce a modular pattern system that distinguishes between **Additive Groups** (like Elliptic Curves) and **Fields** (like Prime Fields).

## Related Issues/PRs

depends on #206 

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212836789915773