### PR TITLE
feat: add vector operation support to FieldToModArith and ModArithToArith

### DIFF
--- a/benchmark/vectorize/BUILD.bazel
+++ b/benchmark/vectorize/BUILD.bazel
@@ -1,0 +1,58 @@
+# Copyright 2026 The PrimeIR Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+load("//benchmark:benchmark.bzl", "prime_ir_benchmark", "prime_ir_mlir_cc_import")
+
+# Scalar (non-vectorized) version
+prime_ir_mlir_cc_import(
+    name = "vectorize_scalar_ciface",
+    llc_flags = ["-mcpu=native"],
+    mlir_src = "vectorize.mlir",
+    prime_ir_opt_flags = [
+        "-field-to-llvm",
+    ],
+)
+
+# Generate vectorized source with vec_ prefix to avoid symbol clashes
+genrule(
+    name = "vectorize_vec_mlir",
+    srcs = ["vectorize.mlir"],
+    outs = ["vectorize_vec.mlir"],
+    cmd = "sed 's/@\\([a-zA-Z0-9_]*\\)(/@vec_\\1(/g' $< > $@",
+)
+
+# Vectorized version using affine-super-vectorize
+prime_ir_mlir_cc_import(
+    name = "vectorize_vec_ciface",
+    llc_flags = ["-mcpu=native"],
+    mlir_src = ":vectorize_vec_mlir",
+    prime_ir_opt_flags = [
+        "-affine-super-vectorize=virtual-vector-size=16",
+        "-field-to-llvm",
+        "-convert-vector-to-llvm",
+        "-convert-arith-to-llvm",
+    ],
+)
+
+prime_ir_benchmark(
+    name = "vectorize_benchmark",
+    srcs = ["vectorize_benchmark.cc"],
+    deps = [
+        ":vectorize_scalar_ciface",
+        ":vectorize_vec_ciface",
+        "@llvm-project//mlir:ExecutionEngine",
+        "@llvm-project//mlir:Support",
+    ],
+)

--- a/benchmark/vectorize/vectorize.mlir
+++ b/benchmark/vectorize/vectorize.mlir
@@ -1,0 +1,58 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// Simple field operations benchmark to test affine-super-vectorize
+
+!pf = !field.pf<2013265921 : i32, true>
+
+// Square all elements in a buffer (1M elements, 1000 iterations)
+func.func @square_buffer(%buffer: memref<1048576x!pf>) attributes { llvm.emit_c_interface } {
+  affine.for %iter = 0 to 1000 {
+    affine.for %i = 0 to 1048576 {
+      %val = affine.load %buffer[%i] : memref<1048576x!pf>
+      %sq = field.square %val : !pf
+      affine.store %sq, %buffer[%i] : memref<1048576x!pf>
+    }
+  }
+  return
+}
+
+// Add two buffers element-wise
+func.func @add_buffers(%a: memref<1048576x!pf>, %b: memref<1048576x!pf>, %c: memref<1048576x!pf>) attributes { llvm.emit_c_interface } {
+  affine.for %iter = 0 to 1000 {
+    affine.for %i = 0 to 1048576 {
+      %va = affine.load %a[%i] : memref<1048576x!pf>
+      %vb = affine.load %b[%i] : memref<1048576x!pf>
+      %sum = field.add %va, %vb : !pf
+      affine.store %sum, %c[%i] : memref<1048576x!pf>
+    }
+  }
+  return
+}
+
+// Multiply-accumulate: c[i] = a[i] * b[i] + c[i]
+func.func @mul_add_buffers(%a: memref<1048576x!pf>, %b: memref<1048576x!pf>, %c: memref<1048576x!pf>) attributes { llvm.emit_c_interface } {
+  affine.for %iter = 0 to 1000 {
+    affine.for %i = 0 to 1048576 {
+      %va = affine.load %a[%i] : memref<1048576x!pf>
+      %vb = affine.load %b[%i] : memref<1048576x!pf>
+      %vc = affine.load %c[%i] : memref<1048576x!pf>
+      %prod = field.mul %va, %vb : !pf
+      %sum = field.add %prod, %vc : !pf
+      affine.store %sum, %c[%i] : memref<1048576x!pf>
+    }
+  }
+  return
+}

--- a/benchmark/vectorize/vectorize_benchmark.cc
+++ b/benchmark/vectorize/vectorize_benchmark.cc
@@ -1,0 +1,128 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "benchmark/benchmark.h"
+#include "mlir/ExecutionEngine/MemRefUtils.h"
+#include "mlir/Support/LLVM.h"
+
+namespace mlir::prime_ir::benchmark {
+namespace {
+
+constexpr int64_t kBufferSize = 1048576; // 1M elements
+
+// Scalar versions
+extern "C" void _mlir_ciface_square_buffer(StridedMemRefType<uint32_t, 1> *buf);
+extern "C" void _mlir_ciface_add_buffers(StridedMemRefType<uint32_t, 1> *a,
+                                         StridedMemRefType<uint32_t, 1> *b,
+                                         StridedMemRefType<uint32_t, 1> *c);
+extern "C" void _mlir_ciface_mul_add_buffers(StridedMemRefType<uint32_t, 1> *a,
+                                             StridedMemRefType<uint32_t, 1> *b,
+                                             StridedMemRefType<uint32_t, 1> *c);
+
+// Vectorized versions (same functions, different compilation)
+extern "C" void
+_mlir_ciface_vec_square_buffer(StridedMemRefType<uint32_t, 1> *buf);
+extern "C" void _mlir_ciface_vec_add_buffers(StridedMemRefType<uint32_t, 1> *a,
+                                             StridedMemRefType<uint32_t, 1> *b,
+                                             StridedMemRefType<uint32_t, 1> *c);
+extern "C" void
+_mlir_ciface_vec_mul_add_buffers(StridedMemRefType<uint32_t, 1> *a,
+                                 StridedMemRefType<uint32_t, 1> *b,
+                                 StridedMemRefType<uint32_t, 1> *c);
+
+void fillWithValue(uint32_t &elem, ArrayRef<int64_t> coords) {
+  elem = static_cast<uint32_t>(coords[0] % 1000 + 1);
+}
+
+// Square buffer benchmarks
+void BM_square_scalar(::benchmark::State &state) {
+  OwningMemRef<uint32_t, 1> buf({kBufferSize}, {}, fillWithValue);
+  for (auto _ : state) {
+    _mlir_ciface_square_buffer(&*buf);
+  }
+}
+
+void BM_square_vectorized(::benchmark::State &state) {
+  OwningMemRef<uint32_t, 1> buf({kBufferSize}, {}, fillWithValue);
+  for (auto _ : state) {
+    _mlir_ciface_vec_square_buffer(&*buf);
+  }
+}
+
+// Add buffers benchmarks
+void BM_add_scalar(::benchmark::State &state) {
+  OwningMemRef<uint32_t, 1> a({kBufferSize}, {}, fillWithValue);
+  OwningMemRef<uint32_t, 1> b({kBufferSize}, {}, fillWithValue);
+  OwningMemRef<uint32_t, 1> c({kBufferSize}, {}, fillWithValue);
+  for (auto _ : state) {
+    _mlir_ciface_add_buffers(&*a, &*b, &*c);
+  }
+}
+
+void BM_add_vectorized(::benchmark::State &state) {
+  OwningMemRef<uint32_t, 1> a({kBufferSize}, {}, fillWithValue);
+  OwningMemRef<uint32_t, 1> b({kBufferSize}, {}, fillWithValue);
+  OwningMemRef<uint32_t, 1> c({kBufferSize}, {}, fillWithValue);
+  for (auto _ : state) {
+    _mlir_ciface_vec_add_buffers(&*a, &*b, &*c);
+  }
+}
+
+// Mul-add buffers benchmarks
+void BM_mul_add_scalar(::benchmark::State &state) {
+  OwningMemRef<uint32_t, 1> a({kBufferSize}, {}, fillWithValue);
+  OwningMemRef<uint32_t, 1> b({kBufferSize}, {}, fillWithValue);
+  OwningMemRef<uint32_t, 1> c({kBufferSize}, {}, fillWithValue);
+  for (auto _ : state) {
+    _mlir_ciface_mul_add_buffers(&*a, &*b, &*c);
+  }
+}
+
+void BM_mul_add_vectorized(::benchmark::State &state) {
+  OwningMemRef<uint32_t, 1> a({kBufferSize}, {}, fillWithValue);
+  OwningMemRef<uint32_t, 1> b({kBufferSize}, {}, fillWithValue);
+  OwningMemRef<uint32_t, 1> c({kBufferSize}, {}, fillWithValue);
+  for (auto _ : state) {
+    _mlir_ciface_vec_mul_add_buffers(&*a, &*b, &*c);
+  }
+}
+
+BENCHMARK(BM_square_scalar)->Unit(::benchmark::kMillisecond);
+BENCHMARK(BM_square_vectorized)->Unit(::benchmark::kMillisecond);
+BENCHMARK(BM_add_scalar)->Unit(::benchmark::kMillisecond);
+BENCHMARK(BM_add_vectorized)->Unit(::benchmark::kMillisecond);
+BENCHMARK(BM_mul_add_scalar)->Unit(::benchmark::kMillisecond);
+BENCHMARK(BM_mul_add_vectorized)->Unit(::benchmark::kMillisecond);
+
+} // namespace
+} // namespace mlir::prime_ir::benchmark
+
+// 2026-01-24T11:44:54+00:00
+// Run on (32 X 624 MHz CPU s)
+// CPU Caches:
+//   L1 Data 48 KiB (x16)
+//   L1 Instruction 32 KiB (x16)
+//   L2 Unified 1024 KiB (x16)
+//   L3 Unified 98304 KiB (x2)
+// Load Average: 1.50, 1.08, 3.59
+// ----------------------------------------------------------------
+// Benchmark                      Time             CPU   Iterations
+// ----------------------------------------------------------------
+// BM_square_scalar             487 ms          486 ms            2
+// BM_square_vectorized        77.6 ms         77.6 ms            9
+// BM_add_scalar                238 ms          238 ms            3
+// BM_add_vectorized           87.7 ms         87.6 ms            8
+// BM_mul_add_scalar            714 ms          714 ms            1
+// BM_mul_add_vectorized        123 ms          123 ms            6

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/BUILD.bazel
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/BUILD.bazel
@@ -95,6 +95,7 @@ cc_library(
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformUtils",
+        "@llvm-project//mlir:UBDialect",
         "@llvm-project//mlir:VectorDialect",
     ],
 )

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
@@ -23,7 +23,6 @@ limitations under the License.
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
@@ -693,7 +692,11 @@ void FieldToModArith::runOnOperation() {
       ConvertAny<tensor::ReshapeOp>,
       ConvertAny<tensor::YieldOp>,
       ConvertAny<tensor_ext::BitReverseOp>,
-      ConvertAny<vector::SplatOp>
+      ConvertAny<ub::PoisonOp>,
+      ConvertAny<vector::BroadcastOp>,
+      ConvertAny<vector::SplatOp>,
+      ConvertAny<vector::TransferReadOp>,
+      ConvertAny<vector::TransferWriteOp>
       // clang-format on
       >(typeConverter, context);
 
@@ -745,7 +748,11 @@ void FieldToModArith::runOnOperation() {
       tensor::ReshapeOp,
       tensor::YieldOp,
       tensor_ext::BitReverseOp,
-      vector::SplatOp
+      ub::PoisonOp,
+      vector::BroadcastOp,
+      vector::SplatOp,
+      vector::TransferReadOp,
+      vector::TransferWriteOp
       // clang-format on
       >([&](auto op) { return typeConverter.isLegal(op); });
 

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.h
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.h
@@ -20,6 +20,8 @@ limitations under the License.
 // Headers needed for FieldToModArith.h.inc
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Pass/Pass.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithDialect.h"
 // IWYU pragma: end_keep

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.td
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.td
@@ -29,6 +29,8 @@ def FieldToModArith : Pass<"field-to-mod-arith", "ModuleOp"> {
     "arith::ArithDialect",
     "scf::SCFDialect",
     "tensor::TensorDialect",
+    "ub::UBDialect",
+    "vector::VectorDialect",
     "prime_ir::mod_arith::ModArithDialect",
   ];
 }

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/BUILD.bazel
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/BUILD.bazel
@@ -51,6 +51,7 @@ cc_library(
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformUtils",
+        "@llvm-project//mlir:UBDialect",
         "@llvm-project//mlir:VectorDialect",
     ],
 )

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -23,8 +23,6 @@ limitations under the License.
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinAttributeInterfaces.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -1017,7 +1015,11 @@ void ModArithToArith::runOnOperation() {
       ConvertAny<tensor::ReshapeOp>,
       ConvertAny<tensor::YieldOp>,
       ConvertAny<tensor_ext::BitReverseOp>,
-      ConvertAny<vector::SplatOp>
+      ConvertAny<ub::PoisonOp>,
+      ConvertAny<vector::BroadcastOp>,
+      ConvertAny<vector::SplatOp>,
+      ConvertAny<vector::TransferReadOp>,
+      ConvertAny<vector::TransferWriteOp>
       // clang-format on
       >(typeConverter, context);
 
@@ -1070,7 +1072,11 @@ void ModArithToArith::runOnOperation() {
       tensor::ReshapeOp,
       tensor::YieldOp,
       tensor_ext::BitReverseOp,
-      vector::SplatOp
+      ub::PoisonOp,
+      vector::BroadcastOp,
+      vector::SplatOp,
+      vector::TransferReadOp,
+      vector::TransferWriteOp
       // clang-format on
       >([&](auto op) { return typeConverter.isLegal(op); });
 

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.h
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.h
@@ -22,6 +22,8 @@ limitations under the License.
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Pass/Pass.h"
 // IWYU pragma: end_keep
 

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.td
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.td
@@ -31,6 +31,8 @@ def ModArithToArith : Pass<"mod-arith-to-arith", "ModuleOp"> {
     "math::MathDialect",
     "scf::SCFDialect",
     "tensor::TensorDialect",
+    "ub::UBDialect",
+    "vector::VectorDialect",
     "prime_ir::mod_arith::ModArithDialect",
   ];
 }


### PR DESCRIPTION
## Description

Add conversion patterns for vector operations (vector.transfer_read, vector.transfer_write, vector.broadcast) and ub.poison to enable affine-super-vectorize pass to work with field types.

This enables automatic SIMD vectorization of field operations:
- Add ConvertAny patterns for vector operations
- Add UBDialect dependency for ub.poison padding support
- Create vectorize benchmark showing 3-7x speedup with vectorization

Benchmark results (1M element buffers):
- square: 487ms → 77.6ms (6.3x speedup)
- add: 238ms → 87.7ms (2.7x speedup)
- mul_add: 714ms → 123ms (5.8x speedup)

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
