### PR TITLE
feat(field): enable ToomCook algorithm for quartic extensions

### DIFF
--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/BUILD.bazel
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/BUILD.bazel
@@ -39,7 +39,6 @@ cc_library(
     hdrs = [
         "ExtensionFieldCodeGen.h",
         "FrobeniusCoeffs.h",
-        "VandermondeMatrix.h",
     ],
     deps = [
         ":ConversionUtils",

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/ExtensionFieldCodeGen.h
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/ExtensionFieldCodeGen.h
@@ -26,11 +26,11 @@ limitations under the License.
 #include "prime_ir/Dialect/Field/Conversions/FieldToModArith/ConversionUtils.h"
 #include "prime_ir/Dialect/Field/Conversions/FieldToModArith/FrobeniusCoeffs.h"
 #include "prime_ir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.h"
-#include "prime_ir/Dialect/Field/Conversions/FieldToModArith/VandermondeMatrix.h"
 #include "prime_ir/Dialect/Field/IR/ExtensionFieldOperationSelector.h"
 #include "prime_ir/Dialect/Field/IR/FieldOps.h"
 #include "prime_ir/Dialect/Field/IR/FieldTypes.h"
 #include "prime_ir/Dialect/Field/IR/PrimeFieldOperation.h"
+#include "prime_ir/Dialect/Field/IR/VandermondeMatrix.h"
 #include "prime_ir/Utils/BuilderContext.h"
 
 namespace mlir::prime_ir::field {

--- a/prime_ir/Dialect/Field/IR/BUILD.bazel
+++ b/prime_ir/Dialect/Field/IR/BUILD.bazel
@@ -68,6 +68,7 @@ cc_library(
         "FieldTypes.h",
         "PrimeFieldOperation.h",
         "TowerFieldConfig.h",
+        "VandermondeMatrix.h",
     ],
     deps = [
         ":ExtensionFieldOperationSelector",
@@ -95,6 +96,7 @@ cc_library(
         "@llvm-project//mlir:InliningUtils",
         "@llvm-project//mlir:Support",
         "@zk_dtypes//zk_dtypes:binary_field_multiplication",
+        "@zk_dtypes//zk_dtypes:extension_field_operation_traits_forward",
         "@zk_dtypes//zk_dtypes:point_declarations",
     ],
 )

--- a/prime_ir/Dialect/Field/IR/VandermondeMatrix.h
+++ b/prime_ir/Dialect/Field/IR/VandermondeMatrix.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef PRIME_IR_DIALECT_FIELD_CONVERSIONS_FIELDTOMODARITH_VANDERMONDEMATRIX_H_
-#define PRIME_IR_DIALECT_FIELD_CONVERSIONS_FIELDTOMODARITH_VANDERMONDEMATRIX_H_
+#ifndef PRIME_IR_DIALECT_FIELD_IR_VANDERMONDEMATRIX_H_
+#define PRIME_IR_DIALECT_FIELD_IR_VANDERMONDEMATRIX_H_
 
 #include <array>
 
@@ -67,5 +67,4 @@ public:
 
 } // namespace mlir::prime_ir::field
 
-// NOLINTNEXTLINE(whitespace/line_length)
-#endif // PRIME_IR_DIALECT_FIELD_CONVERSIONS_FIELDTOMODARITH_VANDERMONDEMATRIX_H_
+#endif // PRIME_IR_DIALECT_FIELD_IR_VANDERMONDEMATRIX_H_


### PR DESCRIPTION
## Description

Move VandermondeMatrix from Conversions to IR layer and add it as a mixin to ExtensionFieldOperation. This resolves the static caching conflict by overriding GetVandermondeInverseMatrix, allowing ToomCook multiplication algorithm for non-tower quartic (N=4) extensions.

## Related Issues/PRs

depends on #213 

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212995766866624
  - https://app.asana.com/0/0/1213254678680296