### PR TITLE
feat(field): add fold-field-linalg-contraction pass

### DIFF
--- a/prime_ir/Dialect/Field/Pipelines/BUILD.bazel
+++ b/prime_ir/Dialect/Field/Pipelines/BUILD.bazel
@@ -27,6 +27,7 @@ cc_library(
         "//prime_ir/Dialect/ArithExt/Conversions/SpecializeArithToAVX",
         "//prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToLLVM",
         "//prime_ir/Dialect/Field/Conversions/FieldToModArith",
+        "//prime_ir/Dialect/Field/Transforms:FoldFieldLinalgContraction",
         "//prime_ir/Dialect/ModArith/Conversions/ModArithToArith",
         "//prime_ir/Dialect/TensorExt/Conversions/TensorExtToTensor",
         "@llvm-project//mlir:AffineToStandard",

--- a/prime_ir/Dialect/Field/Pipelines/Passes.cpp
+++ b/prime_ir/Dialect/Field/Pipelines/Passes.cpp
@@ -35,6 +35,7 @@ limitations under the License.
 #include "prime_ir/Dialect/ArithExt/Conversions/SpecializeArithToAVX/SpecializeArithToAVX.h"
 #include "prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToLLVM/EllipticCurveToLLVM.h"
 #include "prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.h"
+#include "prime_ir/Dialect/Field/Transforms/FoldFieldLinalgContraction.h"
 #include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.h"
 #include "prime_ir/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.h"
 
@@ -45,6 +46,7 @@ limitations under the License.
 namespace mlir::prime_ir::field {
 
 void buildFieldToLLVM(OpPassManager &pm, const FieldToLLVMOptions &options) {
+  pm.addNestedPass<func::FuncOp>(createFoldFieldLinalgContraction());
   pm.addNestedPass<func::FuncOp>(createLinalgGeneralizeNamedOpsPass());
 
   // If we convert elementwise to linalg, tensor folding in ModArithDialect will

--- a/prime_ir/Dialect/Field/Transforms/BUILD.bazel
+++ b/prime_ir/Dialect/Field/Transforms/BUILD.bazel
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(
@@ -26,5 +27,37 @@ cc_library(
     deps = [
         "//prime_ir/Dialect/Field/IR:Field",
         "//prime_ir/Utils:BufferizationUtils",
+    ],
+)
+
+cc_library(
+    name = "FoldFieldLinalgContraction",
+    srcs = ["FoldFieldLinalgContraction.cpp"],
+    hdrs = ["FoldFieldLinalgContraction.h"],
+    deps = [
+        ":pass_inc_gen",
+        "//prime_ir/Dialect/Field/IR:Field",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TransformUtils",
+    ],
+)
+
+gentbl_cc_library(
+    name = "pass_inc_gen",
+    tbl_outs = {
+        "FoldFieldLinalgContraction.h.inc": [
+            "-gen-pass-decls",
+            "-name=FoldFieldLinalgContraction",
+        ],
+    },
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "FoldFieldLinalgContraction.td",
+    deps = [
+        "@llvm-project//mlir:PassBaseTdFiles",
     ],
 )

--- a/prime_ir/Dialect/Field/Transforms/FoldFieldLinalgContraction.cpp
+++ b/prime_ir/Dialect/Field/Transforms/FoldFieldLinalgContraction.cpp
@@ -1,0 +1,298 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "prime_ir/Dialect/Field/Transforms/FoldFieldLinalgContraction.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "prime_ir/Dialect/Field/IR/FieldOperation.h"
+#include "prime_ir/Dialect/Field/IR/FieldOps.h"
+#include "prime_ir/Dialect/Field/IR/FieldTypes.h"
+
+namespace mlir::prime_ir::field {
+
+#define GEN_PASS_DEF_FOLDFIELDLINALGCONTRACTION
+#include "prime_ir/Dialect/Field/Transforms/FoldFieldLinalgContraction.h.inc"
+
+namespace {
+
+// Get the degree of a field type (1 for PrimeField, n for ExtensionField).
+unsigned getFieldDegree(Type elementType) {
+  if (isa<PrimeFieldType>(elementType))
+    return 1;
+  return cast<ExtensionFieldType>(elementType).getDegree();
+}
+
+// Extract a scalar field element's attribute from a dense tensor attribute.
+// For tensor<MxN x PrimeField>: denseAttr has M*N elements
+// For tensor<MxN x ExtensionField<degree>>: denseAttr has M*N*degree elements
+TypedAttr extractFieldElementAttr(DenseIntElementsAttr denseAttr,
+                                  Type elementType, int64_t linearIndex) {
+  unsigned degree = getFieldDegree(elementType);
+  auto values = denseAttr.getValues<APInt>();
+
+  if (auto pfType = dyn_cast<PrimeFieldType>(elementType)) {
+    return IntegerAttr::get(pfType.getStorageType(), values[linearIndex]);
+  }
+
+  auto efType = cast<ExtensionFieldType>(elementType);
+  SmallVector<APInt> coeffs;
+  for (unsigned d = 0; d < degree; ++d) {
+    coeffs.push_back(values[linearIndex * degree + d]);
+  }
+  auto tensorType = RankedTensorType::get(
+      {static_cast<int64_t>(degree)}, efType.getBaseField().getStorageType());
+  return DenseIntElementsAttr::get(tensorType, coeffs);
+}
+
+// Create a zero constant using
+// ConstantLikeInterface::createConstantAttrFromValues.
+Value createFieldZero(PatternRewriter &rewriter, Location loc,
+                      Type elementType) {
+  auto constantLike = cast<ConstantLikeInterface>(elementType);
+  return rewriter.create<ConstantOp>(loc, elementType,
+                                     constantLike.createConstantAttr(0));
+}
+
+// Pattern to fold linalg.matvec when the matrix operand is a field.constant.
+// Transforms: out[i] = Σⱼ matrix[i,j] * vec[j]
+// Into: out[i] = c₀ᵢ * x[0] + c₁ᵢ * x[1] + ...
+struct FoldMatvecWithConstantMatrix : OpRewritePattern<linalg::MatvecOp> {
+  FoldMatvecWithConstantMatrix(MLIRContext *context, unsigned maxUnrollSize)
+      : OpRewritePattern<linalg::MatvecOp>(context),
+        maxUnrollSize(maxUnrollSize) {}
+
+  LogicalResult matchAndRewrite(linalg::MatvecOp op,
+                                PatternRewriter &rewriter) const override {
+    // Get operands: matrix (MxN), vec (N), output (M)
+    Value matrix = op.getInputs()[0];
+    Value vec = op.getInputs()[1];
+    Value output = op.getOutputs()[0];
+
+    // Check if matrix is a field.constant
+    auto matrixConst = matrix.getDefiningOp<ConstantOp>();
+    if (!matrixConst)
+      return failure();
+
+    // Get the dense attribute from the constant
+    auto denseAttr = dyn_cast<DenseIntElementsAttr>(matrixConst.getValue());
+    if (!denseAttr)
+      return failure();
+
+    // Get matrix shape
+    auto matrixType = cast<RankedTensorType>(matrix.getType());
+    if (matrixType.getRank() != 2)
+      return failure();
+
+    int64_t numRows = matrixType.getShape()[0];
+    int64_t numCols = matrixType.getShape()[1];
+
+    // Check size limit
+    if (static_cast<unsigned>(numCols) > maxUnrollSize)
+      return failure();
+
+    Location loc = op.getLoc();
+    Type elementType = matrixType.getElementType();
+
+    // Extract vector elements
+    SmallVector<Value> vecElements;
+    for (int64_t j = 0; j < numCols; ++j) {
+      Value idx = rewriter.create<arith::ConstantIndexOp>(loc, j);
+      Value elem = rewriter.create<tensor::ExtractOp>(loc, vec, idx);
+      vecElements.push_back(elem);
+    }
+
+    // Compute each output element
+    SmallVector<Value> resultElements;
+    for (int64_t i = 0; i < numRows; ++i) {
+      Value sum;
+      bool hasTerms = false;
+
+      for (int64_t j = 0; j < numCols; ++j) {
+        int64_t linearIndex = i * numCols + j;
+        TypedAttr coeffAttr =
+            extractFieldElementAttr(denseAttr, elementType, linearIndex);
+        FieldOperation coeffOp =
+            FieldOperation::fromUnchecked(coeffAttr, elementType);
+
+        // Skip zero coefficients
+        if (coeffOp.isZero())
+          continue;
+
+        Value term;
+        if (coeffOp.isOne()) {
+          // Optimization: 1 * x = x
+          term = vecElements[j];
+        } else {
+          // Create constant for coefficient
+          Value coeffVal =
+              rewriter.create<ConstantOp>(loc, elementType, coeffAttr);
+          term = rewriter.create<MulOp>(loc, coeffVal, vecElements[j]);
+        }
+
+        if (!hasTerms) {
+          sum = term;
+          hasTerms = true;
+        } else {
+          sum = rewriter.create<AddOp>(loc, sum, term);
+        }
+      }
+
+      // Handle the case where all coefficients are zero
+      if (!hasTerms) {
+        sum = createFieldZero(rewriter, loc, elementType);
+      }
+
+      resultElements.push_back(sum);
+    }
+
+    // Build result tensor using tensor.from_elements
+    auto resultType = cast<RankedTensorType>(output.getType());
+    Value result = rewriter.create<tensor::FromElementsOp>(loc, resultType,
+                                                           resultElements);
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+
+private:
+  unsigned maxUnrollSize;
+};
+
+// Pattern to fold linalg.dot when one operand is a field.constant vector.
+// Transforms: result = Σᵢ vec1[i] * vec2[i]
+// Into: result = c₀ * x[0] + c₁ * x[1] + ...
+struct FoldDotWithConstantVector : OpRewritePattern<linalg::DotOp> {
+  FoldDotWithConstantVector(MLIRContext *context, unsigned maxUnrollSize)
+      : OpRewritePattern<linalg::DotOp>(context), maxUnrollSize(maxUnrollSize) {
+  }
+
+  LogicalResult matchAndRewrite(linalg::DotOp op,
+                                PatternRewriter &rewriter) const override {
+    Value lhs = op.getInputs()[0];
+    Value rhs = op.getInputs()[1];
+
+    // Try to find a constant operand (either lhs or rhs)
+    auto lhsConst = lhs.getDefiningOp<ConstantOp>();
+    auto rhsConst = rhs.getDefiningOp<ConstantOp>();
+
+    ConstantOp constOp;
+    Value varVec;
+    if (lhsConst) {
+      constOp = lhsConst;
+      varVec = rhs;
+    } else if (rhsConst) {
+      constOp = rhsConst;
+      varVec = lhs;
+    } else {
+      return failure();
+    }
+
+    // Get the dense attribute from the constant
+    auto denseAttr = dyn_cast<DenseIntElementsAttr>(constOp.getValue());
+    if (!denseAttr)
+      return failure();
+
+    // Get vector shape
+    auto vecType = cast<RankedTensorType>(constOp.getType());
+    if (vecType.getRank() != 1)
+      return failure();
+
+    int64_t vecSize = vecType.getShape()[0];
+
+    // Check size limit
+    if (static_cast<unsigned>(vecSize) > maxUnrollSize)
+      return failure();
+
+    Location loc = op.getLoc();
+    Type elementType = vecType.getElementType();
+
+    // Compute the dot product
+    Value sum;
+    bool hasTerms = false;
+
+    for (int64_t i = 0; i < vecSize; ++i) {
+      TypedAttr coeffAttr = extractFieldElementAttr(denseAttr, elementType, i);
+      FieldOperation coeffOp =
+          FieldOperation::fromUnchecked(coeffAttr, elementType);
+
+      // Skip zero coefficients
+      if (coeffOp.isZero())
+        continue;
+
+      // Extract variable vector element
+      Value idx = rewriter.create<arith::ConstantIndexOp>(loc, i);
+      Value varElem = rewriter.create<tensor::ExtractOp>(loc, varVec, idx);
+
+      Value term;
+      if (coeffOp.isOne()) {
+        // Optimization: 1 * x = x
+        term = varElem;
+      } else {
+        // Create constant for coefficient
+        Value coeffVal =
+            rewriter.create<ConstantOp>(loc, elementType, coeffAttr);
+        term = rewriter.create<MulOp>(loc, coeffVal, varElem);
+      }
+
+      if (!hasTerms) {
+        sum = term;
+        hasTerms = true;
+      } else {
+        sum = rewriter.create<AddOp>(loc, sum, term);
+      }
+    }
+
+    // Handle the case where all coefficients are zero
+    if (!hasTerms) {
+      sum = createFieldZero(rewriter, loc, elementType);
+    }
+
+    // Wrap the scalar result in a 0-D tensor
+    auto resultType = cast<RankedTensorType>(op.getOutputs()[0].getType());
+    Value result =
+        rewriter.create<tensor::FromElementsOp>(loc, resultType, sum);
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+
+private:
+  unsigned maxUnrollSize;
+};
+
+} // namespace
+
+struct FoldFieldLinalgContraction
+    : impl::FoldFieldLinalgContractionBase<FoldFieldLinalgContraction> {
+  using FoldFieldLinalgContractionBase::FoldFieldLinalgContractionBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+
+    patterns.add<FoldMatvecWithConstantMatrix>(context, maxUnrollSize);
+    patterns.add<FoldDotWithConstantVector>(context, maxUnrollSize);
+
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace mlir::prime_ir::field

--- a/prime_ir/Dialect/Field/Transforms/FoldFieldLinalgContraction.h
+++ b/prime_ir/Dialect/Field/Transforms/FoldFieldLinalgContraction.h
@@ -1,0 +1,39 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef PRIME_IR_DIALECT_FIELD_TRANSFORMS_FOLDFIELDLINALGCONTRACTION_H_
+#define PRIME_IR_DIALECT_FIELD_TRANSFORMS_FOLDFIELDLINALGCONTRACTION_H_
+
+// IWYU pragma: begin_keep
+// Headers needed for FoldFieldLinalgContraction.h.inc
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Pass/Pass.h"
+#include "prime_ir/Dialect/Field/IR/FieldDialect.h"
+// IWYU pragma: end_keep
+
+namespace mlir::prime_ir::field {
+
+#define GEN_PASS_DECL
+#include "prime_ir/Dialect/Field/Transforms/FoldFieldLinalgContraction.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "prime_ir/Dialect/Field/Transforms/FoldFieldLinalgContraction.h.inc" // NOLINT(build/include)
+
+} // namespace mlir::prime_ir::field
+
+#endif // PRIME_IR_DIALECT_FIELD_TRANSFORMS_FOLDFIELDLINALGCONTRACTION_H_

--- a/prime_ir/Dialect/Field/Transforms/FoldFieldLinalgContraction.td
+++ b/prime_ir/Dialect/Field/Transforms/FoldFieldLinalgContraction.td
@@ -1,0 +1,49 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef PRIME_IR_DIALECT_FIELD_TRANSFORMS_FOLDFIELDLINALGCONTRACTION_TD_
+#define PRIME_IR_DIALECT_FIELD_TRANSFORMS_FOLDFIELDLINALGCONTRACTION_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def FoldFieldLinalgContraction
+    : Pass<"fold-field-linalg-contraction", "func::FuncOp"> {
+  let summary = "Fold linalg.matvec/dot with constant field tensors";
+  let description = [{
+    This pass folds `linalg.matvec` and `linalg.dot` operations when one operand
+    is a constant field tensor, inlining scalar `field.mul` and `field.add`
+    operations.
+
+    For `linalg.matvec` with a constant matrix and variable vector:
+      out[i] = c₀ᵢ * x[0] + c₁ᵢ * x[1] + ...
+
+    For `linalg.dot` with a constant vector and variable vector:
+      result = c₀ * x[0] + c₁ * x[1] + ...
+
+    The pass includes optimizations to skip zero coefficient terms and use the
+    value directly for one coefficient terms.
+  }];
+  let dependentDialects = [
+    "arith::ArithDialect",
+    "tensor::TensorDialect",
+    "prime_ir::field::FieldDialect",
+  ];
+  let options = [
+    Option<"maxUnrollSize", "max-unroll-size", "unsigned", "16",
+           "Maximum vector size to unroll">,
+  ];
+}
+
+#endif // PRIME_IR_DIALECT_FIELD_TRANSFORMS_FOLDFIELDLINALGCONTRACTION_TD_

--- a/tests/Dialect/Field/fold_field_linalg_contraction.mlir
+++ b/tests/Dialect/Field/fold_field_linalg_contraction.mlir
@@ -1,0 +1,253 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// RUN: prime-ir-opt -fold-field-linalg-contraction %s | FileCheck %s
+// RUN: prime-ir-opt -fold-field-linalg-contraction="max-unroll-size=2" %s | FileCheck %s --check-prefix=CHECK-SMALL
+
+!PF = !field.pf<97:i32>
+
+// -----
+// Test 1: Basic matvec - should fold constant matrix into scalar operations
+
+// CHECK-LABEL: @test_matvec_basic
+// CHECK-NOT: linalg.matvec
+// CHECK-DAG: tensor.extract
+// CHECK-DAG: field.mul
+// CHECK-DAG: field.add
+// CHECK: tensor.from_elements
+func.func @test_matvec_basic(%vec: tensor<3x!PF>) -> tensor<2x!PF> {
+  %matrix = field.constant dense<[[1, 2, 3], [4, 5, 6]]> : tensor<2x3x!PF>
+  %init = bufferization.alloc_tensor() : tensor<2x!PF>
+  %result = linalg.matvec ins(%matrix, %vec : tensor<2x3x!PF>, tensor<3x!PF>)
+                          outs(%init : tensor<2x!PF>) -> tensor<2x!PF>
+  return %result : tensor<2x!PF>
+}
+
+// -----
+// Test 2: Basic dot - should fold constant vector into scalar operations
+
+// CHECK-LABEL: @test_dot_basic
+// CHECK-NOT: linalg.dot
+// CHECK-DAG: tensor.extract
+// CHECK-DAG: field.mul
+// CHECK-DAG: field.add
+// CHECK: tensor.from_elements
+func.func @test_dot_basic(%vec: tensor<3x!PF>) -> tensor<!PF> {
+  %const_vec = field.constant dense<[1, 2, 3]> : tensor<3x!PF>
+  %init = bufferization.alloc_tensor() : tensor<!PF>
+  %result = linalg.dot ins(%const_vec, %vec : tensor<3x!PF>, tensor<3x!PF>)
+                       outs(%init : tensor<!PF>) -> tensor<!PF>
+  return %result : tensor<!PF>
+}
+
+// -----
+// Test 3: Dot with constant on RHS - should also fold
+
+// CHECK-LABEL: @test_dot_const_rhs
+// CHECK-NOT: linalg.dot
+// CHECK-DAG: tensor.extract
+// CHECK-DAG: field.mul
+// CHECK-DAG: field.add
+// CHECK: tensor.from_elements
+func.func @test_dot_const_rhs(%vec: tensor<3x!PF>) -> tensor<!PF> {
+  %const_vec = field.constant dense<[7, 8, 9]> : tensor<3x!PF>
+  %init = bufferization.alloc_tensor() : tensor<!PF>
+  %result = linalg.dot ins(%vec, %const_vec : tensor<3x!PF>, tensor<3x!PF>)
+                       outs(%init : tensor<!PF>) -> tensor<!PF>
+  return %result : tensor<!PF>
+}
+
+// -----
+// Test 4: Size limit (with default limit=16) - should fold since 10 <= 16
+
+// CHECK-LABEL: @test_size_within_limit
+// CHECK-NOT: linalg.dot
+// CHECK: tensor.from_elements
+func.func @test_size_within_limit(%vec: tensor<10x!PF>) -> tensor<!PF> {
+  %const_vec = field.constant dense<[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]> : tensor<10x!PF>
+  %init = bufferization.alloc_tensor() : tensor<!PF>
+  %result = linalg.dot ins(%const_vec, %vec : tensor<10x!PF>, tensor<10x!PF>)
+                       outs(%init : tensor<!PF>) -> tensor<!PF>
+  return %result : tensor<!PF>
+}
+
+// -----
+// Test 5: Size limit exceeded with small option - should NOT fold
+
+// CHECK-SMALL-LABEL: @test_exceeds_small_limit
+// CHECK-SMALL: linalg.dot
+func.func @test_exceeds_small_limit(%vec: tensor<3x!PF>) -> tensor<!PF> {
+  %const_vec = field.constant dense<[1, 2, 3]> : tensor<3x!PF>
+  %init = bufferization.alloc_tensor() : tensor<!PF>
+  %result = linalg.dot ins(%const_vec, %vec : tensor<3x!PF>, tensor<3x!PF>)
+                       outs(%init : tensor<!PF>) -> tensor<!PF>
+  return %result : tensor<!PF>
+}
+
+// -----
+// Test 6: Variable matrix - should NOT fold
+
+// CHECK-LABEL: @test_variable_matrix
+// CHECK: linalg.matvec
+func.func @test_variable_matrix(%matrix: tensor<2x3x!PF>, %vec: tensor<3x!PF>) -> tensor<2x!PF> {
+  %init = bufferization.alloc_tensor() : tensor<2x!PF>
+  %result = linalg.matvec ins(%matrix, %vec : tensor<2x3x!PF>, tensor<3x!PF>)
+                          outs(%init : tensor<2x!PF>) -> tensor<2x!PF>
+  return %result : tensor<2x!PF>
+}
+
+// -----
+// Test 7: Both vectors variable in dot - should NOT fold
+
+// CHECK-LABEL: @test_both_variable
+// CHECK: linalg.dot
+func.func @test_both_variable(%vec1: tensor<3x!PF>, %vec2: tensor<3x!PF>) -> tensor<!PF> {
+  %init = bufferization.alloc_tensor() : tensor<!PF>
+  %result = linalg.dot ins(%vec1, %vec2 : tensor<3x!PF>, tensor<3x!PF>)
+                       outs(%init : tensor<!PF>) -> tensor<!PF>
+  return %result : tensor<!PF>
+}
+
+// -----
+// Test 8: Zero coefficient optimization - zeros should be skipped
+
+// CHECK-LABEL: @test_zero_coefficients
+// CHECK-NOT: linalg.dot
+// Note: The number of field.mul ops should be less than 3 since zeros are skipped
+// Coefficient at index 1 is zero, so we skip c₁ * x[1]
+// CHECK-COUNT-2: field.mul
+// CHECK-NOT: field.mul
+func.func @test_zero_coefficients(%vec: tensor<3x!PF>) -> tensor<!PF> {
+  %const_vec = field.constant dense<[5, 0, 7]> : tensor<3x!PF>
+  %init = bufferization.alloc_tensor() : tensor<!PF>
+  %result = linalg.dot ins(%const_vec, %vec : tensor<3x!PF>, tensor<3x!PF>)
+                       outs(%init : tensor<!PF>) -> tensor<!PF>
+  return %result : tensor<!PF>
+}
+
+// -----
+// Test 9: One coefficient optimization - no mul for coefficient=1
+
+// CHECK-LABEL: @test_one_coefficient
+// CHECK-NOT: linalg.dot
+// Only 2 multiplications (for coefficients 2 and 3), the coefficient 1 is optimized away
+// CHECK-COUNT-2: field.mul
+// CHECK-NOT: field.mul
+func.func @test_one_coefficient(%vec: tensor<3x!PF>) -> tensor<!PF> {
+  %const_vec = field.constant dense<[1, 2, 3]> : tensor<3x!PF>
+  %init = bufferization.alloc_tensor() : tensor<!PF>
+  %result = linalg.dot ins(%const_vec, %vec : tensor<3x!PF>, tensor<3x!PF>)
+                       outs(%init : tensor<!PF>) -> tensor<!PF>
+  return %result : tensor<!PF>
+}
+
+// -----
+// Test 10: All zeros - should generate a zero constant
+
+// CHECK-LABEL: @test_all_zeros
+// CHECK-NOT: linalg.dot
+// CHECK-NOT: field.mul
+// CHECK-NOT: field.add
+// CHECK: field.constant dense<0>
+func.func @test_all_zeros(%vec: tensor<3x!PF>) -> tensor<!PF> {
+  %const_vec = field.constant dense<[0, 0, 0]> : tensor<3x!PF>
+  %init = bufferization.alloc_tensor() : tensor<!PF>
+  %result = linalg.dot ins(%const_vec, %vec : tensor<3x!PF>, tensor<3x!PF>)
+                       outs(%init : tensor<!PF>) -> tensor<!PF>
+  return %result : tensor<!PF>
+}
+
+// -----
+// Test 11: Extension field matvec - should fold constant matrix
+
+!QF = !field.ef<2x!field.pf<97:i32>, 5:i32>
+
+// CHECK-LABEL: @test_matvec_ext_field
+// CHECK-NOT: linalg.matvec
+// CHECK-DAG: tensor.extract
+// CHECK-DAG: field.mul
+// CHECK-DAG: field.add
+// CHECK: tensor.from_elements
+func.func @test_matvec_ext_field(%vec: tensor<2x!QF>) -> tensor<2x!QF> {
+  // Matrix 2x2 of quadratic extension field elements
+  // Each element is [c₀, c₁] representing c₀ + c₁v
+  %matrix = field.constant dense<[[[1, 0], [2, 1]], [[3, 2], [4, 3]]]> : tensor<2x2x!QF>
+  %init = bufferization.alloc_tensor() : tensor<2x!QF>
+  %result = linalg.matvec ins(%matrix, %vec : tensor<2x2x!QF>, tensor<2x!QF>)
+                          outs(%init : tensor<2x!QF>) -> tensor<2x!QF>
+  return %result : tensor<2x!QF>
+}
+
+// -----
+// Test 12: Extension field dot - should fold constant vector
+
+!QF2 = !field.ef<2x!field.pf<97:i32>, 5:i32>
+
+// CHECK-LABEL: @test_dot_ext_field
+// CHECK-NOT: linalg.dot
+// CHECK-DAG: tensor.extract
+// CHECK-DAG: field.mul
+// CHECK-DAG: field.add
+// CHECK: tensor.from_elements
+func.func @test_dot_ext_field(%vec: tensor<2x!QF2>) -> tensor<!QF2> {
+  %const_vec = field.constant dense<[[1, 2], [3, 4]]> : tensor<2x!QF2>
+  %init = bufferization.alloc_tensor() : tensor<!QF2>
+  %result = linalg.dot ins(%const_vec, %vec : tensor<2x!QF2>, tensor<2x!QF2>)
+                       outs(%init : tensor<!QF2>) -> tensor<!QF2>
+  return %result : tensor<!QF2>
+}
+
+// -----
+// Test 13: Extension field with zero element optimization
+// [0, 0] is the additive identity
+
+!QF3 = !field.ef<2x!field.pf<97:i32>, 5:i32>
+
+// CHECK-LABEL: @test_ext_field_zero_coeff
+// CHECK-NOT: linalg.dot
+// Only one mul since [0, 0] is zero
+// CHECK-COUNT-1: field.mul
+// CHECK-NOT: field.mul
+func.func @test_ext_field_zero_coeff(%vec: tensor<2x!QF3>) -> tensor<!QF3> {
+  %const_vec = field.constant dense<[[1, 2], [0, 0]]> : tensor<2x!QF3>
+  %init = bufferization.alloc_tensor() : tensor<!QF3>
+  %result = linalg.dot ins(%const_vec, %vec : tensor<2x!QF3>, tensor<2x!QF3>)
+                       outs(%init : tensor<!QF3>) -> tensor<!QF3>
+  return %result : tensor<!QF3>
+}
+
+// -----
+// Test 14: Extension field with one element optimization
+// [1, 0] is the multiplicative identity
+
+!QF4 = !field.ef<2x!field.pf<97:i32>, 5:i32>
+
+// CHECK-LABEL: @test_ext_field_one_coeff
+// CHECK-NOT: linalg.dot
+// Only one mul since [1, 0] doesn't need multiplication
+// CHECK-COUNT-1: field.mul
+// CHECK-NOT: field.mul
+func.func @test_ext_field_one_coeff(%vec: tensor<2x!QF4>) -> tensor<!QF4> {
+  %const_vec = field.constant dense<[[1, 0], [2, 3]]> : tensor<2x!QF4>
+  %init = bufferization.alloc_tensor() : tensor<!QF4>
+  %result = linalg.dot ins(%const_vec, %vec : tensor<2x!QF4>, tensor<2x!QF4>)
+                       outs(%init : tensor<!QF4>) -> tensor<!QF4>
+  return %result : tensor<!QF4>
+}
+
+// Note: Extension field "all zeros" test is omitted because
+// maybeConvertPrimeIRToBuiltinType in prime_ir/IR/Attributes.cpp doesn't handle
+// ExtensionFieldType yet. Once added, tensor.from_elements fold will work for
+// extension fields when all elements are constant.

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -47,6 +47,7 @@ cc_binary(
         "//prime_ir/Dialect/Field/IR:Field",
         "//prime_ir/Dialect/Field/Pipelines:Passes",
         "//prime_ir/Dialect/Field/Transforms:BufferizableOpInterfaceImpl",
+        "//prime_ir/Dialect/Field/Transforms:FoldFieldLinalgContraction",
         "//prime_ir/Dialect/ModArith/Conversions/ModArithToArith",
         "//prime_ir/Dialect/ModArith/IR:ModArith",
         "//prime_ir/Dialect/ModArith/Transforms:BufferizableOpInterfaceImpl",

--- a/tools/prime-ir-opt.cpp
+++ b/tools/prime-ir-opt.cpp
@@ -30,6 +30,7 @@ limitations under the License.
 #include "prime_ir/Dialect/Field/IR/FieldDialect.h"
 #include "prime_ir/Dialect/Field/Pipelines/Passes.h"
 #include "prime_ir/Dialect/Field/Transforms/BufferizableOpInterfaceImpl.h"
+#include "prime_ir/Dialect/Field/Transforms/FoldFieldLinalgContraction.h"
 #include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithDialect.h"
 #include "prime_ir/Dialect/ModArith/Transforms/BufferizableOpInterfaceImpl.h"
@@ -69,6 +70,7 @@ int main(int argc, char **argv) {
   mlir::prime_ir::elliptic_curve::registerEllipticCurveToFieldPasses();
   mlir::prime_ir::elliptic_curve::registerEllipticCurveToLLVMPasses();
   mlir::prime_ir::tensor_ext::registerTensorExtToTensorPasses();
+  mlir::prime_ir::field::registerFoldFieldLinalgContractionPasses();
 
   mlir::prime_ir::field::registerFieldPipelines();
 


### PR DESCRIPTION
## Description

Add a new transform pass `fold-field-linalg-contraction` that folds `linalg.matvec` and `linalg.dot` operations when one operand is a constant field tensor, inlining scalar `field.mul` and `field.add` operations.

## Background

In cryptographic applications, matrix-vector products and dot products often involve constant matrices or vectors (e.g., poseidon2). Instead of lowering these through general linalg contraction which requires loop-based codegen, we can directly inline the computation as a sequence of scalar field operations when the constant operand is known at compile time.

This enables:
- Elimination of loop overhead for small constant matrices/vectors
- Better optimization opportunities for subsequent passes
- Direct lowering path to scalar field arithmetic

### Features
- `FoldMatvecWithConstantMatrix`: folds `linalg.matvec` with constant matrix
  - Input: `linalg.matvec ins(%const_matrix, %var_vec)`
  - Output: `out[i] = c₀ᵢ * x[0] + c₁ᵢ * x[1] + ...`
- `FoldDotWithConstantVector`: folds `linalg.dot` with constant vector
  - Input: `linalg.dot ins(%const_vec, %var_vec)`
  - Output: `c₀ * x[0] + c₁ * x[1] + ...`
- Zero coefficient optimization: skips `0 * x` terms
- One coefficient optimization: uses `x` directly for `1 * x`
- Configurable `max-unroll-size` option (default: 16)

The pass is integrated into the `field-to-llvm` pipeline and runs before linalg generalization.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212969625895119
