### PR TITLE
refactor: update zk_dtypes type names for explicit Montgomery convention

### DIFF
--- a/prime_ir/Dialect/EllipticCurve/IR/KnownCurves.cpp
+++ b/prime_ir/Dialect/EllipticCurve/IR/KnownCurves.cpp
@@ -78,11 +78,11 @@ std::optional<std::string> getKnownCurveAlias(ShortWeierstrassAttr attr) {
       return std::nullopt;
     if (alias == "bn254_bf") {
       if (pfType.isMontgomery()) {
-        if (isKnownCurve<zk_dtypes::bn254::G1Curve>(attr)) {
+        if (isKnownCurve<zk_dtypes::bn254::G1CurveMont>(attr)) {
           return "bn254_g1";
         }
       } else {
-        if (isKnownCurve<zk_dtypes::bn254::G1CurveStd>(attr)) {
+        if (isKnownCurve<zk_dtypes::bn254::G1Curve>(attr)) {
           return "bn254_g1";
         }
       }
@@ -96,11 +96,11 @@ std::optional<std::string> getKnownCurveAlias(ShortWeierstrassAttr attr) {
         return std::nullopt;
       if (alias == "bn254_bf") {
         if (pfType.isMontgomery()) {
-          if (isKnownCurve<zk_dtypes::bn254::G2Curve>(attr)) {
+          if (isKnownCurve<zk_dtypes::bn254::G2CurveMont>(attr)) {
             return "bn254_g2";
           }
         } else {
-          if (isKnownCurve<zk_dtypes::bn254::G2CurveStd>(attr)) {
+          if (isKnownCurve<zk_dtypes::bn254::G2Curve>(attr)) {
             return "bn254_g2";
           }
         }

--- a/tests/Dialect/EllipticCurve/bucket_acc_runner.mlir
+++ b/tests/Dialect/EllipticCurve/bucket_acc_runner.mlir
@@ -52,17 +52,17 @@ func.func @test_bucket_acc() {
   %result = elliptic_curve.bucket_acc %points, %sorted_point_indices, %sorted_unique_bucket_indices, %offsets: (tensor<3x!affine>, tensor<6xindex>, tensor<4xindex>, tensor<5xindex>) -> tensor<8x!jacobian>
 
   %jacobian_sum_13 = elliptic_curve.add %affine1, %affine3 : !affine, !affine -> !jacobian
-  func.call @printG1AffineFromJacobian(%jacobian_sum_13) : (!jacobian) -> ()
+  func.call @printG1AffineFromJacobianMont(%jacobian_sum_13) : (!jacobian) -> ()
 
   %jacobian_sum_12 = elliptic_curve.add %affine1, %affine2 : !affine, !affine -> !jacobian
-  func.call @printG1AffineFromJacobian(%jacobian_sum_12) : (!jacobian) -> ()
+  func.call @printG1AffineFromJacobianMont(%jacobian_sum_12) : (!jacobian) -> ()
 
-  func.call @printG1Affine(%affine2) : (!affine) -> ()
-  func.call @printG1Affine(%affine3) : (!affine) -> ()
+  func.call @printG1AffineMont(%affine2) : (!affine) -> ()
+  func.call @printG1AffineMont(%affine3) : (!affine) -> ()
 
   scf.for %i = %c0 to %c8 step %c1 {
     %point = tensor.extract %result[%i] : tensor<8x!jacobian>
-    func.call @printG1AffineFromJacobian(%point) : (!jacobian) -> ()
+    func.call @printG1AffineFromJacobianMont(%point) : (!jacobian) -> ()
     scf.yield
   }
   return

--- a/tests/Dialect/EllipticCurve/bucket_reduce_runner.mlir
+++ b/tests/Dialect/EllipticCurve/bucket_reduce_runner.mlir
@@ -60,29 +60,29 @@ func.func @test_bucket_reduce() {
   // 8G
   %k8 = field.constant 8 : !SF
   %result0 = func.call @getG1GeneratorMultiple(%k8) : (!SF) -> (!affine)
-  func.call @printG1Affine(%result0) : (!affine) -> ()
+  func.call @printG1AffineMont(%result0) : (!affine) -> ()
   %result_zero = tensor.extract %result[%i0] : tensor<4x!jacobian>
-  func.call @printG1AffineFromJacobian(%result_zero) : (!jacobian) -> ()
+  func.call @printG1AffineFromJacobianMont(%result_zero) : (!jacobian) -> ()
 
   // 4G
   %k4 = field.constant 4 : !SF
   %result1 = func.call @getG1GeneratorMultiple(%k4) : (!SF) -> (!affine)
-  func.call @printG1Affine(%result1) : (!affine) -> ()
+  func.call @printG1AffineMont(%result1) : (!affine) -> ()
   %result_one = tensor.extract %result[%i1] : tensor<4x!jacobian>
-  func.call @printG1AffineFromJacobian(%result_one) : (!jacobian) -> ()
+  func.call @printG1AffineFromJacobianMont(%result_one) : (!jacobian) -> ()
 
   // 3G
   %result2 = func.call @getG1GeneratorMultiple(%k3) : (!SF) -> (!affine)
-  func.call @printG1Affine(%result2) : (!affine) -> ()
+  func.call @printG1AffineMont(%result2) : (!affine) -> ()
   %result_two = tensor.extract %result[%i2] : tensor<4x!jacobian>
-  func.call @printG1AffineFromJacobian(%result_two) : (!jacobian) -> ()
+  func.call @printG1AffineFromJacobianMont(%result_two) : (!jacobian) -> ()
 
   // 7G
   %k7 = field.constant 7 : !SF
   %result3 = func.call @getG1GeneratorMultiple(%k7) : (!SF) -> (!affine)
-  func.call @printG1Affine(%result3) : (!affine) -> ()
+  func.call @printG1AffineMont(%result3) : (!affine) -> ()
   %result_three = tensor.extract %result[%i3] : tensor<4x!jacobian>
-  func.call @printG1AffineFromJacobian(%result_three) : (!jacobian) -> ()
+  func.call @printG1AffineFromJacobianMont(%result_three) : (!jacobian) -> ()
   return
 }
 

--- a/tests/Dialect/EllipticCurve/elliptic_curve_msm_runner.mlir
+++ b/tests/Dialect/EllipticCurve/elliptic_curve_msm_runner.mlir
@@ -43,13 +43,13 @@ func.func @test_msm() {
   %add1 = elliptic_curve.add %scalar_mul1, %scalar_mul2 : !jacobian, !jacobian -> !jacobian
   %add2 = elliptic_curve.add %scalar_mul3, %scalar_mul4 : !jacobian, !jacobian -> !jacobian
   %msm_true = elliptic_curve.add %add1, %add2 : !jacobian, !jacobian -> !jacobian
-  func.call @printG1AffineFromJacobian(%msm_true) : (!jacobian) -> ()
+  func.call @printG1AffineFromJacobianMont(%msm_true) : (!jacobian) -> ()
 
   // RUNNING MSM
   %scalars = tensor.from_elements %scalar3, %scalar3, %scalar5, %scalar7 : tensor<4x!SFm>
   %points = tensor.from_elements %jacobian1, %jacobian2, %jacobian3, %jacobian4 : tensor<4x!jacobian>
   %msm_test = elliptic_curve.msm %scalars, %points degree=2 parallel : tensor<4x!SFm>, tensor<4x!jacobian> -> !jacobian
-  func.call @printG1AffineFromJacobian(%msm_test) : (!jacobian) -> ()
+  func.call @printG1AffineFromJacobianMont(%msm_test) : (!jacobian) -> ()
 
   return
 }

--- a/tests/Dialect/EllipticCurve/elliptic_curve_to_field_runner.mlir
+++ b/tests/Dialect/EllipticCurve/elliptic_curve_to_field_runner.mlir
@@ -31,35 +31,35 @@ func.func @test_ops_in_order() {
   %jacobian1 = elliptic_curve.from_coords %var1, %var2, %var1 : (!PFm, !PFm, !PFm) -> !jacobian
 
   %jacobian2 = elliptic_curve.add %affine1, %jacobian1 : !affine, !jacobian -> !jacobian
-  func.call @printG1Jacobian(%jacobian2) : (!jacobian) -> ()
+  func.call @printG1JacobianMont(%jacobian2) : (!jacobian) -> ()
 
   %jacobian3 = elliptic_curve.sub %affine1, %jacobian2 : !affine, !jacobian -> !jacobian
-  func.call @printG1Jacobian(%jacobian3) : (!jacobian) -> ()
+  func.call @printG1JacobianMont(%jacobian3) : (!jacobian) -> ()
 
   %jacobian4 = elliptic_curve.negate %jacobian3 : !jacobian
-  func.call @printG1Jacobian(%jacobian4) : (!jacobian) -> ()
+  func.call @printG1JacobianMont(%jacobian4) : (!jacobian) -> ()
 
   %jacobian5 = elliptic_curve.double %jacobian4 : !jacobian -> !jacobian
-  func.call @printG1Jacobian(%jacobian5) : (!jacobian) -> ()
+  func.call @printG1JacobianMont(%jacobian5) : (!jacobian) -> ()
 
   %xyzz1 = elliptic_curve.convert_point_type %affine1 : !affine -> !xyzz
-  func.call @printG1Xyzz(%xyzz1) : (!xyzz) -> ()
+  func.call @printG1XyzzMont(%xyzz1) : (!xyzz) -> ()
 
   %affine2 = elliptic_curve.convert_point_type %xyzz1 : !xyzz -> !affine
-  func.call @printG1Affine(%affine2) : (!affine) -> ()
+  func.call @printG1AffineMont(%affine2) : (!affine) -> ()
 
   %jacobian6 = elliptic_curve.scalar_mul %var7, %affine2 : !SFm, !affine -> !jacobian
   %affine2_1 = elliptic_curve.convert_point_type %jacobian6 : !jacobian -> !affine
   %jacobian6_1 = elliptic_curve.convert_point_type %affine2_1 : !affine -> !jacobian
-  func.call @printG1Jacobian(%jacobian6_1) : (!jacobian) -> ()
+  func.call @printG1JacobianMont(%jacobian6_1) : (!jacobian) -> ()
 
   %affine3 = elliptic_curve.convert_point_type %jacobian6 : !jacobian -> !affine
-  func.call @printG1Affine(%affine3) : (!affine) -> ()
+  func.call @printG1AffineMont(%affine3) : (!affine) -> ()
 
   %xyzz2 = elliptic_curve.add %affine3, %xyzz1 : !affine, !xyzz -> !xyzz
   %affine4 = elliptic_curve.convert_point_type %xyzz2 : !xyzz -> !affine
   %xyzz3 = elliptic_curve.convert_point_type %affine4 : !affine -> !xyzz
-  func.call @printG1Xyzz(%xyzz3) : (!xyzz) -> ()
+  func.call @printG1XyzzMont(%xyzz3) : (!xyzz) -> ()
 
   return
 }

--- a/tests/Dialect/EllipticCurve/sparse_tensor_runner.mlir
+++ b/tests/Dialect/EllipticCurve/sparse_tensor_runner.mlir
@@ -53,13 +53,13 @@ func.func @test_bucket_acc_csr() {
 
 
   %jacobian_sum_13 = elliptic_curve.add %affine1, %affine3 : !affine, !affine -> !jacobian
-  func.call @printG1AffineFromJacobian(%jacobian_sum_13) : (!jacobian) -> ()
+  func.call @printG1AffineFromJacobianMont(%jacobian_sum_13) : (!jacobian) -> ()
 
   %jacobian_sum_12 = elliptic_curve.add %affine1, %affine2 : !affine, !affine -> !jacobian
-  func.call @printG1AffineFromJacobian(%jacobian_sum_12) : (!jacobian) -> ()
+  func.call @printG1AffineFromJacobianMont(%jacobian_sum_12) : (!jacobian) -> ()
 
-  func.call @printG1Affine(%affine2) : (!affine) -> ()
-  func.call @printG1Affine(%affine3) : (!affine) -> ()
+  func.call @printG1AffineMont(%affine2) : (!affine) -> ()
+  func.call @printG1AffineMont(%affine3) : (!affine) -> ()
 
   // Convert all affine points to jacobian before creating sparse matrix
   %jacobian1 = elliptic_curve.convert_point_type %affine1 : !affine -> !jacobian
@@ -111,7 +111,7 @@ func.func @test_bucket_acc_csr() {
   // Print results for comparison with bucket_acc
   scf.for %i = %c0 to %c8 step %c1 {
     %bucket_point = tensor.extract %result[%i] : tensor<8x!jacobian>
-    func.call @printG1AffineFromJacobian(%bucket_point) : (!jacobian) -> ()
+    func.call @printG1AffineFromJacobianMont(%bucket_point) : (!jacobian) -> ()
     scf.yield
   }
   return

--- a/tests/Dialect/EllipticCurve/window_reduce_runner.mlir
+++ b/tests/Dialect/EllipticCurve/window_reduce_runner.mlir
@@ -61,10 +61,10 @@ func.func @test_window_reduce() {
   // 57G
   %k57 = field.constant 57 : !SF
   %true_result = func.call @getG1GeneratorMultiple(%k57) : (!SF) -> (!affine)
-  func.call @printG1Affine(%true_result) : (!affine) -> ()
+  func.call @printG1AffineMont(%true_result) : (!affine) -> ()
 
   %result = elliptic_curve.window_reduce %windows {bitsPerWindow = 2 : i16, scalarType = !SF}: (tensor<128x!jacobian>) -> !jacobian
-  func.call @printG1AffineFromJacobian(%result) : (!jacobian) -> ()
+  func.call @printG1AffineFromJacobianMont(%result) : (!jacobian) -> ()
   return
 }
 

--- a/tests/Dialect/Field/BUILD.bazel
+++ b/tests/Dialect/Field/BUILD.bazel
@@ -49,9 +49,9 @@ cc_test(
         "@com_google_googletest//:gtest_main",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
-        "@zk_dtypes//zk_dtypes:babybear4",
-        "@zk_dtypes//zk_dtypes:bn254_fq2",
-        "@zk_dtypes//zk_dtypes:goldilocks3",
+        "@zk_dtypes//zk_dtypes:babybearx4",
+        "@zk_dtypes//zk_dtypes:bn254_fqx2",
+        "@zk_dtypes//zk_dtypes:goldilocksx3",
     ],
 )
 

--- a/tests/Dialect/Field/ExtensionFieldOperationTest.cpp
+++ b/tests/Dialect/Field/ExtensionFieldOperationTest.cpp
@@ -18,9 +18,9 @@ limitations under the License.
 #include "gtest/gtest.h"
 #include "prime_ir/Dialect/Field/IR/FieldDialect.h"
 #include "prime_ir/Utils/ZkDtypes.h"
-#include "zk_dtypes/include/elliptic_curve/bn/bn254/fq2.h"
-#include "zk_dtypes/include/field/babybear/babybear4.h"
-#include "zk_dtypes/include/field/goldilocks/goldilocks3.h"
+#include "zk_dtypes/include/elliptic_curve/bn/bn254/fqx2.h"
+#include "zk_dtypes/include/field/babybear/babybearx4.h"
+#include "zk_dtypes/include/field/goldilocks/goldilocksx3.h"
 
 namespace mlir::prime_ir::field {
 
@@ -97,15 +97,15 @@ using ExtensionFieldTypes = testing::Types<
     // modulus bits = 2³¹
     // modulus.getBitWidth() == 32
     // modulus.getActiveBits() == 31
-    zk_dtypes::Babybear4, zk_dtypes::Babybear4Std,
+    zk_dtypes::BabybearX4Mont, zk_dtypes::BabybearX4,
     // modulus bits = 2⁶⁴
     // modulus.getBitWidth() == 64
     // modulus.getActiveBits() == 64
-    zk_dtypes::Goldilocks3, zk_dtypes::Goldilocks3Std,
+    zk_dtypes::GoldilocksX3Mont, zk_dtypes::GoldilocksX3,
     // modulus bits = 2²⁵⁴
     // modulus.getBitWidth() == 254
     // modulus.getActiveBits() == 254
-    zk_dtypes::bn254::Fq2, zk_dtypes::bn254::Fq2Std>;
+    zk_dtypes::bn254::FqX2Mont, zk_dtypes::bn254::FqX2>;
 TYPED_TEST_SUITE(ExtensionFieldOperationTest, ExtensionFieldTypes);
 
 //===----------------------------------------------------------------------===//

--- a/tests/Dialect/Field/PrimeFieldOperationTest.cpp
+++ b/tests/Dialect/Field/PrimeFieldOperationTest.cpp
@@ -93,15 +93,15 @@ using PrimeFieldTypes = testing::Types<
     // modulus bits = 2³¹
     // modulus.getBitWidth() == 32
     // modulus.getActiveBits() == 31
-    zk_dtypes::Babybear, zk_dtypes::BabybearStd,
+    zk_dtypes::BabybearMont, zk_dtypes::Babybear,
     // modulus bits = 2⁶⁴
     // modulus.getBitWidth() == 64
     // modulus.getActiveBits() == 64
-    zk_dtypes::Goldilocks, zk_dtypes::GoldilocksStd,
+    zk_dtypes::GoldilocksMont, zk_dtypes::Goldilocks,
     // modulus bits = 2²⁵⁴
     // modulus.getBitWidth() == 254
     // modulus.getActiveBits() == 254
-    zk_dtypes::bn254::Fr, zk_dtypes::bn254::FrStd>;
+    zk_dtypes::bn254::FrMont, zk_dtypes::bn254::Fr>;
 TYPED_TEST_SUITE(PrimeFieldOperationTest, PrimeFieldTypes);
 
 //===----------------------------------------------------------------------===//

--- a/tests/Dialect/Field/linalg_fuse_elementwise_ops.mlir
+++ b/tests/Dialect/Field/linalg_fuse_elementwise_ops.mlir
@@ -15,37 +15,37 @@
 
 // RUN: prime-ir-opt -linalg-fuse-elementwise-ops %s | FileCheck %s -enable-var-scope
 
-!pf_babybear = !field.pf<2013265921 : i32, true>
+!pf_babybear_mont = !field.pf<2013265921 : i32, true>
 #map = affine_map<() -> ()>
 
-func.func @fusion(%arg0: tensor<!pf_babybear>, %arg1: tensor<!pf_babybear>) -> tensor<!pf_babybear> {
+func.func @fusion(%arg0: tensor<!pf_babybear_mont>, %arg1: tensor<!pf_babybear_mont>) -> tensor<!pf_babybear_mont> {
   // CHECK-LABEL: @fusion
-  // CHECK-SAME: (%[[ARG0:.*]]: tensor<!pf_babybear>, %[[ARG1:.*]]: tensor<!pf_babybear>) -> tensor<!pf_babybear>
-  // CHECK: %[[CST:.*]] = field.constant dense<536870908> : tensor<!pf_babybear>
-  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<!pf_babybear>
+  // CHECK-SAME: (%[[ARG0:.*]]: tensor<!pf_babybear_mont>, %[[ARG1:.*]]: tensor<!pf_babybear_mont>) -> tensor<!pf_babybear_mont>
+  // CHECK: %[[CST:.*]] = field.constant dense<536870908> : tensor<!pf_babybear_mont>
+  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<!pf_babybear_mont>
   // CHECK: %[[RESULT:.*]] = linalg.generic
   // The constant is passed as an input and used via block argument
-  // CHECK: ^bb0(%[[IN:.*]]: !pf_babybear, %[[IN_0:.*]]: !pf_babybear, %[[IN_1:.*]]: !pf_babybear, %[[OUT:.*]]: !pf_babybear):
-  // CHECK:   %[[ADD:.*]] = field.add %[[IN]], %[[IN_0]] : !pf_babybear
-  // CHECK:   %[[MUL1:.*]] = field.mul %[[ADD]], %[[IN]] : !pf_babybear
-  // CHECK:   %[[MUL2:.*]] = field.mul %[[MUL1]], %[[IN_1]] : !pf_babybear
-  // CHECK:   linalg.yield %[[MUL2]] : !pf_babybear
-  // CHECK: return %[[RESULT]] : tensor<!pf_babybear>
-  %0 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = []} ins(%arg0, %arg1 : tensor<!pf_babybear>, tensor<!pf_babybear>) outs(%arg0 : tensor<!pf_babybear>) {
-  ^bb0(%in: !pf_babybear, %in_0: !pf_babybear, %out: !pf_babybear):
-    %ret = field.add %in, %in_0 : !pf_babybear
-    linalg.yield %ret : !pf_babybear
-  } -> tensor<!pf_babybear>
-  %1 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = []} ins(%0, %arg0 : tensor<!pf_babybear>, tensor<!pf_babybear>) outs(%0 : tensor<!pf_babybear>) {
-  ^bb0(%in: !pf_babybear, %in_0: !pf_babybear, %out: !pf_babybear):
-    %ret = field.mul %in, %in_0 : !pf_babybear
-    linalg.yield %ret : !pf_babybear
-  } -> tensor<!pf_babybear>
-  %2 = field.constant dense<536870908> : tensor<!pf_babybear>
-  %3 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = []} ins(%1, %2 : tensor<!pf_babybear>, tensor<!pf_babybear>) outs(%1 : tensor<!pf_babybear>) {
-  ^bb0(%in: !pf_babybear, %in_0: !pf_babybear, %out: !pf_babybear):
-    %ret = field.mul %in, %in_0 : !pf_babybear
-    linalg.yield %ret : !pf_babybear
-  } -> tensor<!pf_babybear>
-  return %3 : tensor<!pf_babybear>
+  // CHECK: ^bb0(%[[IN:.*]]: !pf_babybear_mont, %[[IN_0:.*]]: !pf_babybear_mont, %[[IN_1:.*]]: !pf_babybear_mont, %[[OUT:.*]]: !pf_babybear_mont):
+  // CHECK:   %[[ADD:.*]] = field.add %[[IN]], %[[IN_0]] : !pf_babybear_mont
+  // CHECK:   %[[MUL1:.*]] = field.mul %[[ADD]], %[[IN]] : !pf_babybear_mont
+  // CHECK:   %[[MUL2:.*]] = field.mul %[[MUL1]], %[[IN_1]] : !pf_babybear_mont
+  // CHECK:   linalg.yield %[[MUL2]] : !pf_babybear_mont
+  // CHECK: return %[[RESULT]] : tensor<!pf_babybear_mont>
+  %0 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = []} ins(%arg0, %arg1 : tensor<!pf_babybear_mont>, tensor<!pf_babybear_mont>) outs(%arg0 : tensor<!pf_babybear_mont>) {
+  ^bb0(%in: !pf_babybear_mont, %in_0: !pf_babybear_mont, %out: !pf_babybear_mont):
+    %ret = field.add %in, %in_0 : !pf_babybear_mont
+    linalg.yield %ret : !pf_babybear_mont
+  } -> tensor<!pf_babybear_mont>
+  %1 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = []} ins(%0, %arg0 : tensor<!pf_babybear_mont>, tensor<!pf_babybear_mont>) outs(%0 : tensor<!pf_babybear_mont>) {
+  ^bb0(%in: !pf_babybear_mont, %in_0: !pf_babybear_mont, %out: !pf_babybear_mont):
+    %ret = field.mul %in, %in_0 : !pf_babybear_mont
+    linalg.yield %ret : !pf_babybear_mont
+  } -> tensor<!pf_babybear_mont>
+  %2 = field.constant dense<536870908> : tensor<!pf_babybear_mont>
+  %3 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = []} ins(%1, %2 : tensor<!pf_babybear_mont>, tensor<!pf_babybear_mont>) outs(%1 : tensor<!pf_babybear_mont>) {
+  ^bb0(%in: !pf_babybear_mont, %in_0: !pf_babybear_mont, %out: !pf_babybear_mont):
+    %ret = field.mul %in, %in_0 : !pf_babybear_mont
+    linalg.yield %ret : !pf_babybear_mont
+  } -> tensor<!pf_babybear_mont>
+  return %3 : tensor<!pf_babybear_mont>
 }

--- a/tests/Dialect/ModArith/ModArithOperationTest.cpp
+++ b/tests/Dialect/ModArith/ModArithOperationTest.cpp
@@ -89,15 +89,15 @@ using PrimeFieldTypes = testing::Types<
     // modulus bits = 2³¹
     // modulus.getBitWidth() == 32
     // modulus.getActiveBits() == 31
-    zk_dtypes::Babybear, zk_dtypes::BabybearStd,
+    zk_dtypes::BabybearMont, zk_dtypes::Babybear,
     // modulus bits = 2⁶⁴
     // modulus.getBitWidth() == 64
     // modulus.getActiveBits() == 64
-    zk_dtypes::Goldilocks, zk_dtypes::GoldilocksStd,
+    zk_dtypes::GoldilocksMont, zk_dtypes::Goldilocks,
     // modulus bits = 2²⁵⁴
     // modulus.getBitWidth() == 254
     // modulus.getActiveBits() == 254
-    zk_dtypes::bn254::Fr, zk_dtypes::bn254::FrStd>;
+    zk_dtypes::bn254::FrMont, zk_dtypes::bn254::Fr>;
 TYPED_TEST_SUITE(ModArithOperationTest, PrimeFieldTypes);
 
 //===----------------------------------------------------------------------===//

--- a/tests/bn254_ec_defs.mlir
+++ b/tests/bn254_ec_defs.mlir
@@ -27,24 +27,24 @@
 !g2jacobian = !elliptic_curve.jacobian<#g2curve>
 !g2xyzz = !elliptic_curve.xyzz<#g2curve>
 
-func.func private @printMemrefBn254G1AffineStd(memref<*x!affine>) attributes { llvm.emit_c_interface }
+func.func private @printMemrefBn254G1Affine(memref<*x!affine>) attributes { llvm.emit_c_interface }
 
 func.func private @printMemrefG1Affine(%affine: memref<*x!affine>) {
-  func.call @printMemrefBn254G1AffineStd(%affine) : (memref<*x!affine>) -> ()
+  func.call @printMemrefBn254G1Affine(%affine) : (memref<*x!affine>) -> ()
   return
 }
 
-func.func private @printMemrefBn254G1JacobianStd(memref<*x!jacobian>) attributes { llvm.emit_c_interface }
+func.func private @printMemrefBn254G1Jacobian(memref<*x!jacobian>) attributes { llvm.emit_c_interface }
 
 func.func private @printMemrefG1Jacobian(%jacobian: memref<*x!jacobian>) {
-  func.call @printMemrefBn254G1JacobianStd(%jacobian) : (memref<*x!jacobian>) -> ()
+  func.call @printMemrefBn254G1Jacobian(%jacobian) : (memref<*x!jacobian>) -> ()
   return
 }
 
-func.func private @printMemrefBn254G1XyzzStd(memref<*x!xyzz>) attributes { llvm.emit_c_interface }
+func.func private @printMemrefBn254G1Xyzz(memref<*x!xyzz>) attributes { llvm.emit_c_interface }
 
 func.func private @printMemrefG1Xyzz(%xyzz: memref<*x!xyzz>) {
-  func.call @printMemrefBn254G1XyzzStd(%xyzz) : (memref<*x!xyzz>) -> ()
+  func.call @printMemrefBn254G1Xyzz(%xyzz) : (memref<*x!xyzz>) -> ()
   return
 }
 

--- a/tests/bn254_ec_mont_defs.mlir
+++ b/tests/bn254_ec_mont_defs.mlir
@@ -27,24 +27,24 @@
 !g2jacobian = !elliptic_curve.jacobian<#g2curve>
 !g2xyzz = !elliptic_curve.xyzz<#g2curve>
 
-func.func private @printMemrefBn254G1Affine(memref<*x!affine>) attributes { llvm.emit_c_interface }
+func.func private @printMemrefBn254G1AffineMont(memref<*x!affine>) attributes { llvm.emit_c_interface }
 
-func.func private @printMemrefG1Affine(%affine: memref<*x!affine>) {
-  func.call @printMemrefBn254G1Affine(%affine) : (memref<*x!affine>) -> ()
+func.func private @printMemrefG1AffineMont(%affine: memref<*x!affine>) {
+  func.call @printMemrefBn254G1AffineMont(%affine) : (memref<*x!affine>) -> ()
   return
 }
 
-func.func private @printMemrefBn254G1Jacobian(memref<*x!jacobian>) attributes { llvm.emit_c_interface }
+func.func private @printMemrefBn254G1JacobianMont(memref<*x!jacobian>) attributes { llvm.emit_c_interface }
 
-func.func private @printMemrefG1Jacobian(%jacobian: memref<*x!jacobian>) {
-  func.call @printMemrefBn254G1Jacobian(%jacobian) : (memref<*x!jacobian>) -> ()
+func.func private @printMemrefG1JacobianMont(%jacobian: memref<*x!jacobian>) {
+  func.call @printMemrefBn254G1JacobianMont(%jacobian) : (memref<*x!jacobian>) -> ()
   return
 }
 
-func.func private @printMemrefBn254G1Xyzz(memref<*x!xyzz>) attributes { llvm.emit_c_interface }
+func.func private @printMemrefBn254G1XyzzMont(memref<*x!xyzz>) attributes { llvm.emit_c_interface }
 
-func.func private @printMemrefG1Xyzz(%xyzz: memref<*x!xyzz>) {
-  func.call @printMemrefBn254G1Xyzz(%xyzz) : (memref<*x!xyzz>) -> ()
+func.func private @printMemrefG1XyzzMont(%xyzz: memref<*x!xyzz>) {
+  func.call @printMemrefBn254G1XyzzMont(%xyzz) : (memref<*x!xyzz>) -> ()
   return
 }
 

--- a/tests/bn254_ec_utils.mlir
+++ b/tests/bn254_ec_utils.mlir
@@ -13,41 +13,41 @@
 // limitations under the License.
 // ==============================================================================
 
-func.func @printG1Affine(%affine: !affine) {
+func.func @printG1AffineMont(%affine: !affine) {
   %c0 = arith.constant 0 : index
   %affine_memref = memref.alloca() : memref<1x!affine>
   memref.store %affine, %affine_memref[%c0] : memref<1x!affine>
   %affine_memref_cast = memref.cast %affine_memref : memref<1x!affine> to memref<*x!affine>
-  func.call @printMemrefG1Affine(%affine_memref_cast) : (memref<*x!affine>) -> ()
+  func.call @printMemrefG1AffineMont(%affine_memref_cast) : (memref<*x!affine>) -> ()
   return
 }
 
-func.func @printG1Jacobian(%jacobian: !jacobian) {
+func.func @printG1JacobianMont(%jacobian: !jacobian) {
   %c0 = arith.constant 0 : index
   %jacobian_memref = memref.alloca() : memref<1x!jacobian>
   memref.store %jacobian, %jacobian_memref[%c0] : memref<1x!jacobian>
   %jacobian_memref_cast = memref.cast %jacobian_memref : memref<1x!jacobian> to memref<*x!jacobian>
-  func.call @printMemrefG1Jacobian(%jacobian_memref_cast) : (memref<*x!jacobian>) -> ()
+  func.call @printMemrefG1JacobianMont(%jacobian_memref_cast) : (memref<*x!jacobian>) -> ()
   return
 }
 
-func.func @printG1Xyzz(%xyzz: !xyzz) {
+func.func @printG1XyzzMont(%xyzz: !xyzz) {
   %c0 = arith.constant 0 : index
   %xyzz_memref = memref.alloca() : memref<1x!xyzz>
   memref.store %xyzz, %xyzz_memref[%c0] : memref<1x!xyzz>
   %xyzz_memref_cast = memref.cast %xyzz_memref : memref<1x!xyzz> to memref<*x!xyzz>
-  func.call @printMemrefG1Xyzz(%xyzz_memref_cast) : (memref<*x!xyzz>) -> ()
+  func.call @printMemrefG1XyzzMont(%xyzz_memref_cast) : (memref<*x!xyzz>) -> ()
   return
 }
 
-func.func @printG1AffineFromJacobian(%jacobian: !jacobian) {
+func.func @printG1AffineFromJacobianMont(%jacobian: !jacobian) {
   %affine = elliptic_curve.convert_point_type %jacobian : !jacobian -> !affine
-  func.call @printG1Affine(%affine) : (!affine) -> ()
+  func.call @printG1AffineMont(%affine) : (!affine) -> ()
   return
 }
 
-func.func @printG1AffineFromXyzz(%xyzz: !xyzz) {
+func.func @printG1AffineFromXyzzMont(%xyzz: !xyzz) {
   %affine = elliptic_curve.convert_point_type %xyzz : !xyzz -> !affine
-  func.call @printG1Affine(%affine) : (!affine) -> ()
+  func.call @printG1AffineMont(%affine) : (!affine) -> ()
   return
 }

--- a/third_party/zk_dtypes/workspace.bzl
+++ b/third_party/zk_dtypes/workspace.bzl
@@ -17,8 +17,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def repo():
-    ZK_DTYPES_COMMIT = "3b9c17dee9e73f30002399a07f9cfb63732ecad9"
-    ZK_DTYPES_SHA256 = "d5f5160a4b384e5e3ac0b6794063c7c0ec524c8a7e18fece71f5054c7cff7a3a"
+    ZK_DTYPES_COMMIT = "f1c6cfbe5abe76146f7df5e83b210e50e9923fb9"
+    ZK_DTYPES_SHA256 = "f8c2e8ac30df8e166f3a441c027e6ed9045489ba626b37b6e0d7f714438b2210"
     http_archive(
         name = "zk_dtypes",
         sha256 = ZK_DTYPES_SHA256,


### PR DESCRIPTION
## Description

- Update type names to match zk_dtypes explicit Montgomery naming convention
- Rename headers and Bazel targets for extension field types
- Update elliptic curve type names in KnownCurves.cpp

### Breaking Changes in zk_dtypes

| Old Name | New Name | Domain |
|----------|----------|--------|
| `Babybear` | `BabybearMont` | Montgomery |
| `BabybearStd` | `Babybear` | Standard |
| `Babybear4` | `BabybearX4Mont` | Montgomery |
| `Babybear4Std` | `BabybearX4` | Standard |
| `Goldilocks` | `GoldilocksMont` | Montgomery |
| `GoldilocksStd` | `Goldilocks` | Standard |
| `Goldilocks3` | `GoldilocksX3Mont` | Montgomery |
| `Goldilocks3Std` | `GoldilocksX3` | Standard |
| `bn254::Fr` | `bn254::FrMont` | Montgomery |
| `bn254::FrStd` | `bn254::Fr` | Standard |
| `bn254::Fq2` | `bn254::FqX2Mont` | Montgomery |
| `bn254::Fq2Std` | `bn254::FqX2` | Standard |
| `bn254::G1Curve` | `bn254::G1CurveMont` | Montgomery |
| `bn254::G1CurveStd` | `bn254::G1Curve` | Standard |
| `bn254::G2Curve` | `bn254::G2CurveMont` | Montgomery |
| `bn254::G2CurveStd` | `bn254::G2Curve` | Standard |

## Related Issues/PRs

https://github.com/fractalyze/zk_dtypes/pull/82

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/fractalyze/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/fractalyze/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/fractalyze/.github/blob/main/PULL_REQUEST_GUIDELINE.md)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213024709222444