### PR TITLE
ci: add knowledge extraction workflow

### DIFF
--- a/.github/workflows/extract-knowledge.yml
+++ b/.github/workflows/extract-knowledge.yml
@@ -1,0 +1,16 @@
+name: Extract Knowledge from PR
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  extract-knowledge:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fractalyze/github-actions/knowledge-extractor@main
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          knowledge_repo_token: ${{ secrets.KNOWLEDGE_REPO_TOKEN }}


### PR DESCRIPTION
## Description

Enable automatic knowledge extraction from merged PRs using Claude Code Action.

When a PR is merged to main:
1. Claude Code Action analyzes each commit
2. Extracts knowledge (concepts, decisions, pitfalls)
3. Stores in `fractalyze/knowledge-graph` repo with Obsidian-style [[wikilinks]]

This builds a central knowledge base that can be used by Claude Code reviewer
to provide context-aware code reviews.

## Related Issues/PRs

- Related: fractalyze/knowledge-graph (new repo)
- Related: fractalyze/github-actions/knowledge-extractor (new action)

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline