### PR TITLE
ci: add knowledge extraction workflow

### DIFF
--- a/.github/workflows/extract-knowledge.yml
+++ b/.github/workflows/extract-knowledge.yml
@@ -9,8 +9,12 @@ jobs:
   extract-knowledge:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: fractalyze/github-actions/knowledge-extractor@main
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           knowledge_repo_token: ${{ secrets.KNOWLEDGE_REPO_TOKEN }}


### PR DESCRIPTION
## Description

Add GitHub Actions workflow to automatically extract knowledge from merged PRs
and store it in the knowledge-graph repo.

Uses `fractalyze/github-actions/knowledge-extractor@main` composite action
which leverages Claude Code Action to analyze each commit and extract knowledge.

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline