### PR TITLE
docs(harness): add CLAUDE.md and .claude/ harness configuration

### DIFF
--- a/.claude/knowledge/architecture.md
+++ b/.claude/knowledge/architecture.md
@@ -1,0 +1,27 @@
+# prime-ir Architecture
+
+## Design Goals
+- Domain-specific optimization preserving algebraic structure
+- Hardware abstraction via MLIR's multi-level approach
+- Retargeting same IR to CPU, GPU, FPGA without rewriting
+
+## Lowering Pipeline
+```
+PrimeIR (high-level field ops)
+  ↓ Domain-specific optimizations
+PrimeIR (optimized)
+  ↓ Hardware-specific lowering
+LLVM IR / NVGPU / SPIR-V / AMDGPU
+  ↓
+Executable
+```
+
+## Key Dialects
+- Field Dialect: finite field arithmetic primitives
+- EllipticCurve Dialect: EC operations
+- Integration with MLIR standard dialects (arith, linalg, etc.)
+
+## Relationship to ZKX Pipeline
+```
+StableHLO → ZKIR → PrimeIR (this repo) → LLVM/GPU
+```

--- a/.claude/knowledge/solutions.md
+++ b/.claude/knowledge/solutions.md
@@ -1,0 +1,16 @@
+# Past Bugs & Resolution Patterns
+
+Record non-obvious bugs here as they are discovered. Format:
+- **Problem**: what went wrong
+- **Cause**: root cause
+- **Fix**: how it was resolved
+- **Prevention**: how to avoid recurrence
+
+## Template
+<!-- Copy this when adding a new entry:
+### [Date] — [Short description]
+- **Problem**:
+- **Cause**:
+- **Fix**:
+- **Prevention**:
+-->

--- a/.claude/knowledge/testing-guide.md
+++ b/.claude/knowledge/testing-guide.md
@@ -1,0 +1,16 @@
+# prime-ir Testing Guide
+
+## Running Tests
+```
+bazel test //...
+bazel test //tests/...
+```
+
+## Test Types
+- LIT tests: MLIR pass verification (`.mlir` files)
+- gtest: C++ unit tests (`*_test.cc`)
+
+## Conventions
+- Test files alongside source or in `tests/` subdirectory
+- LIT tests use FileCheck for output verification
+- Test both optimization correctness and algebraic identity preservation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md
+
+## Project Overview
+PrimeIR is a cryptography-aware Intermediate Representation built on MLIR.
+Enables domain-specific optimizations (e.g., -(-x) = x) and targets CPU, GPU,
+FPGA backends. Middle stage of the ZKX compiler pipeline.
+
+## Current Focus
+Q2: E2E proving p99 ≤ 7s on 16 GPUs (excluding verification).
+Sprint: E2E correctness — 5 test blocks Phase 1-3 bug-free.
+Out of scope: Multi-zkVM 2nd backend, community building, internal tooling, external talks.
+
+## Commands
+- Build: `bazel build //...`
+- Test all: `bazel test //...`
+- Test suite: `bazel test //tests/...`
+
+## Why Decisions
+- MLIR over custom IR: leverage existing dialects (NVGPU, SPIR-V, AMDGPU) for hardware abstraction without reimplementing.
+- Domain-specific algebraic optimizations: impossible at LLVM IR level where field structure is lost.
+- PrimeField as degree-1 ExtensionField: unifies field operation handling, eliminates duplicate logic.
+
+## Rules
+- Do NOT modify lowering passes affecting cryptographic correctness without expert review.
+- Do NOT call `BYInverter::Invert` without zero-initializing the output first.
+- Do NOT check for zero AFTER calling inverse — check BEFORE (`inv(0) = 0` by ZK convention).
+- Treat PrimeField as degree-1 ExtensionField to avoid duplicate handling logic.
+- Always run `bazel test //...` before committing.
+
+## Invisible Traps
+- `inv(0) = 0` by ZK convention. zkir checks for zero before calling zk_dtypes, returns `ub.poison`. Forgetting the zero-check produces silently wrong field inversions.
+- `BYInverter::Invert` returns false for non-invertible elements WITHOUT modifying output — if output isn't zero-initialized, you get garbage.
+- Pipeline position: StableHLO → ZKIR → **PrimeIR** → LLVM/GPU. Algebraic identity optimizations here affect all downstream code generation.
+
+## Knowledge Files
+Read ONLY when relevant to your current task:
+@.claude/knowledge/architecture.md — IR design, lowering pipeline
+@.claude/knowledge/testing-guide.md — LIT test and gtest conventions
+@.claude/knowledge/solutions.md — Past bug resolution patterns


### PR DESCRIPTION
## Description
Add project-specific AI harness configuration following the Harness Engineering decision tree.

## Checklist
- [x] CLAUDE.md with Q2 context and AI safety zones
- [x] .claude/knowledge/architecture.md
- [x] .claude/knowledge/testing-guide.md
- [x] .claude/knowledge/solutions.md (starter template)