### PR TITLE
fix(mod_arith): handle REDC overflow for primes with no spare bit

### DIFF
--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.cpp
@@ -114,7 +114,7 @@ Value MontReducer::getCanonicalDiff(Value lhs, Value rhs) {
   auto add = b.create<arith::AddIOp>(sub, cmod);
   APInt mod = cast<IntegerAttr>(modAttr).getValue();
   if (mod.isSignBitSet()) {
-    // When p > 2^(w-1), diff + p can overflow, so minui gives wrong results.
+    // When p > 2ʷ⁻¹, diff + p can overflow, so minui gives wrong results.
     // Fall back to cmpi + select.
     auto underflowed =
         b.create<arith::CmpIOp>(arith::CmpIPredicate::ult, lhs, rhs);
@@ -250,6 +250,37 @@ Value MontReducer::reduceMultiLimb(Value tLow, Value tHigh, bool lazy) {
   tHigh = b.create<arith::SelectOp>(carry, tHighPlusOne, tHigh);
   // Shift right `T` by `limbWidth` to discard the zeroed limb.
   tLow = b.create<arith::ShRUIOp>(tLow, limbWidthConst);
+
+  // When p > 2ʷ⁻¹ (modulus uses all w bits), the REDC result can exceed
+  // 2ʷ because 2p > 2ʷ. The upper bits of tHigh (above the lowest limb)
+  // represent the overflow: real_value = tLow_combined + tHighUpper * 2ʷ.
+  // Since 2ʷ ≡ R (mod p) where R = 2ʷ mod p, we recover the correct value
+  // by adding tHighUpper * R to tLow, then conditionally subtracting p.
+  APInt mod = cast<IntegerAttr>(modAttr).getValue();
+  if (mod.isSignBitSet()) {
+    Value tHighUpper = b.create<arith::ShRUIOp>(tHigh, limbWidthConst);
+    // Mask tHigh to only the lowest limb before the left-shift.
+    tHigh = b.create<arith::AndIOp>(tHigh, limbMaskConst);
+    tHigh = b.create<arith::ShLIOp>(tHigh, limbShiftConst);
+    tLow = b.create<arith::OrIOp>(tLow, tHigh);
+
+    // Add overflow * R to recover the truncated value mod p.
+    // R = 2ʷ mod p is small, so tHighUpper * R fits in w bits.
+    // R = 2ʷ mod p = 2ʷ - p. Compute without overflow: -p in w-bit wraps
+    // to 2ʷ - p since p < 2ʷ.
+    APInt rVal = -mod; // R = 2ʷ - p (unsigned wrap in w bits)
+    TypedAttr rAttr = b.getIntegerAttr(getElementTypeOrSelf(tLow), rVal);
+    Value rConst;
+    if (auto shapedType = dyn_cast<ShapedType>(tLow.getType()))
+      rConst = createSplatConst(b, rAttr, shapedType, tLow);
+    else
+      rConst = b.create<arith::ConstantOp>(rAttr);
+    Value correction = b.create<arith::MulIOp>(tHighUpper, rConst);
+    tLow = b.create<arith::AddIOp>(tLow, correction);
+
+    return getCanonicalFromExtended(tLow);
+  }
+
   tHigh = b.create<arith::ShLIOp>(tHigh, limbShiftConst);
   tLow = b.create<arith::OrIOp>(tLow, tHigh);
 
@@ -261,6 +292,15 @@ Value MontReducer::reduceMultiLimb(Value tLow, Value tHigh, bool lazy) {
 }
 
 Value MontReducer::reduce(Value tLow, Value tHigh, bool lazy) {
+  // Lazy REDC returns [0, 2p), which requires 2p ≤ 2ʷ. When the modulus
+  // uses all w bits (p > 2ʷ⁻¹), 2p > 2ʷ and lazy is not representable.
+  APInt mod = cast<IntegerAttr>(modAttr).getValue();
+  if (mod.isSignBitSet()) {
+    // Lazy is not possible when 2p > 2ʷ because [0, 2p) does not fit in
+    // w bits. Always reduce to [0, p).
+    assert(!lazy &&
+           "lazy REDC not supported for primes using all w bits (2p > 2ʷ)");
+  }
   const unsigned numLimbs = montAttr.getNumLimbs();
   return numLimbs == 1 ? reduceSingleLimb(tLow, tHigh, lazy)
                        : reduceMultiLimb(tLow, tHigh, lazy);

--- a/tests/Dialect/ModArith/mod_arith_secp256k1_runner.mlir
+++ b/tests/Dialect/ModArith/mod_arith_secp256k1_runner.mlir
@@ -1,0 +1,104 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// Runner tests for secp256k1 base field (256-bit modulus with NO spare bit).
+// secp256k1: p = 2^256 - 2^32 - 977, so p > 2^255 and 2p > 2^256.
+// This exercises the REDC overflow path in reduceMultiLimb.
+
+// RUN: prime-ir-opt %s -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_secp256k1_mont_mul -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_MONT_MUL < %t
+
+// RUN: prime-ir-opt %s -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_secp256k1_self_mul -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_SELF_MUL < %t
+
+// RUN: prime-ir-opt %s -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_secp256k1_inverse -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_INVERSE < %t
+
+func.func private @printMemrefI32(memref<*xi32>) attributes { llvm.emit_c_interface }
+
+// secp256k1 base field: p = 115792089237316195423570985008687907853269984665640564039457584007908834671663
+!Fp = !mod_arith.int<115792089237316195423570985008687907853269984665640564039457584007908834671663 : i256>
+!Fpm = !mod_arith.int<115792089237316195423570985008687907853269984665640564039457584007908834671663 : i256, true>
+
+// Test mont_mul: a * b mod p
+func.func @test_secp256k1_mont_mul() {
+  %a = mod_arith.constant 100720434724302814904028779430100746620855462830062608636120953741433830196001 : !Fp
+  %b = mod_arith.constant 77194843949812472705866951895890002278064767165192463917288049357869258772753 : !Fp
+  %a_mont = mod_arith.to_mont %a : !Fpm
+  %b_mont = mod_arith.to_mont %b : !Fpm
+  %ab_mont = mod_arith.mont_mul %a_mont, %b_mont : !Fpm
+  %ab = mod_arith.from_mont %ab_mont : !Fp
+
+  %v = mod_arith.bitcast %ab : !Fp -> i256
+  %vec = vector.from_elements %v : vector<1xi256>
+  %i32vec = vector.bitcast %vec : vector<1xi256> to vector<8xi32>
+  %mem = memref.alloc() : memref<8xi32>
+  %c0 = arith.constant 0 : index
+  vector.store %i32vec, %mem[%c0] : memref<8xi32>, vector<8xi32>
+  %U = memref.cast %mem : memref<8xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+  return
+}
+
+// a*b mod p = 60982711392264587969682996417164316263579529872982963815222662697680270146463
+// CHECK_MONT_MUL: [-317572193, 234547340, -933347341, 937312186, 925532681, -193108322, -782384468, -2032992815]
+
+// Test: mont_mul(a, a) — exercises the REDC overflow path with MulUIExtendedOp.
+// When REDC result >= 2^256 (possible for secp256k1 where 2p > 2^256), the
+// overflow detection in reduceMultiLimb is needed for correctness.
+func.func @test_secp256k1_self_mul() {
+  %a = mod_arith.constant 100720434724302814904028779430100746620855462830062608636120953741433830196001 : !Fp
+  %a_mont = mod_arith.to_mont %a : !Fpm
+  %a2_mont = mod_arith.mont_mul %a_mont, %a_mont : !Fpm
+  %a2 = mod_arith.from_mont %a2_mont : !Fp
+
+  %v = mod_arith.bitcast %a2 : !Fp -> i256
+  %vec = vector.from_elements %v : vector<1xi256>
+  %i32vec = vector.bitcast %vec : vector<1xi256> to vector<8xi32>
+  %mem = memref.alloc() : memref<8xi32>
+  %c0 = arith.constant 0 : index
+  vector.store %i32vec, %mem[%c0] : memref<8xi32>, vector<8xi32>
+  %U = memref.cast %mem : memref<8xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+  return
+}
+
+// a^2 mod p = 31420896780135511602482624633964787057105052135029862436193230832710629143834
+// CHECK_SELF_MUL: [410727706, -880396485, -539256400, -604627336, 995880535, 1108136652, -129139622, 1165465835]
+
+// Test inverse: inv(a) * a == 1
+func.func @test_secp256k1_inverse() {
+  %a = mod_arith.constant 100720434724302814904028779430100746620855462830062608636120953741433830196001 : !Fp
+  %a_mont = mod_arith.to_mont %a : !Fpm
+  %inv_mont = mod_arith.mont_inverse %a_mont : !Fpm
+  %check_mont = mod_arith.mul %inv_mont, %a_mont : !Fpm
+  %check = mod_arith.from_mont %check_mont : !Fp
+  %v = mod_arith.bitcast %check : !Fp -> i256
+  %v32 = arith.trunci %v : i256 to i32
+  %t = tensor.from_elements %v32 : tensor<1xi32>
+  %m = bufferization.to_buffer %t : tensor<1xi32> to memref<1xi32>
+  %U = memref.cast %m : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+  return
+}
+
+// inv(a) * a mod p == 1
+// CHECK_INVERSE: [1]


### PR DESCRIPTION
## Description

The multi-limb REDC (`reduceMultiLimb`) produces results in [0, 2p). When
p > 2^(w-1) (e.g., secp256k1 with 256-bit p ≈ 2^256), 2p > 2^w and the
result can overflow the w-bit integer type. The final `tLow |= tHigh`
discards the overflow bit, and the conditional subtraction operates on a
truncated value, producing results that are off by R = 2^w mod p.

**Root cause**: after the last REDC iteration, `tHigh` can have bits above
its lowest limb, indicating the combined result exceeds 2^w. The left-shift
`tHigh <<= limbShift` followed by `tLow |= tHigh` silently drops these bits.

**Fix**: for moduli with no spare bit (`mod.isSignBitSet()`), detect overflow
in `tHigh` before the left-shift discards it, and pass the overflow flag to
`getCanonicalFromExtended(tLow, overflow)` to force the modular reduction.
Primes with spare bits (e.g., bn254 Fr) take the existing path with no
overhead.

**Reproduction**: `field.mul` on secp256k1 (`!field.pf<p:i256, true>`)
produces results off by exactly 1 in natural form (= R in Montgomery form).
Verified with AOT-compiled EC point addition: `inv` (via BYInverter, no mul)
was correct, but `slope = numer * inv` was off by 1.

## Related Issues/PRs

Found during riscv-witness EC precompile trace comparison against SP1.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline