### PR TITLE
fix(mod_arith): give BY inverter limb type signed headroom for n > 62

### DIFF
--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Inverter/BYInverter.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Inverter/BYInverter.cpp
@@ -39,7 +39,7 @@ BYInverter::BYInverter(ImplicitLocOpBuilder &b, Type inputType)
   unsigned extModBitWidth = byAttr.getNewBitWidth().getValue().getZExtValue();
   unsigned modBitWidth = modulus.getValue().getBitWidth();
   unsigned n = byAttr.getDivsteps().getValue().getZExtValue();
-  unsigned limbBitWidth = n > 64 ? n : 64;
+  unsigned limbBitWidth = byAttr.getLimbBitWidth();
 
   intType = IntegerType::get(b.getContext(), modBitWidth);
   extIntType = IntegerType::get(b.getContext(), extModBitWidth);

--- a/prime_ir/Dialect/ModArith/IR/ModArithAttributes.cpp
+++ b/prime_ir/Dialect/ModArith/IR/ModArithAttributes.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include <utility>
 
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/MathExtras.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithOperation.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithTypes.h"
@@ -141,6 +142,7 @@ IntegerAttr BYAttr::getModulus() const { return getImpl()->modulus; }
 IntegerAttr BYAttr::getDivsteps() const { return getImpl()->divsteps; }
 IntegerAttr BYAttr::getMInv() const { return getImpl()->mInv; }
 IntegerAttr BYAttr::getNewBitWidth() const { return getImpl()->newBitWidth; }
+unsigned BYAttr::getLimbBitWidth() const { return getImpl()->limbBitWidth; }
 
 namespace detail {
 
@@ -163,8 +165,18 @@ BYAttrStorage *BYAttrStorage::construct(AttributeStorageAllocator &allocator,
     divsteps++;
   }
 
-  // need one extra limb to properly store the intermediate results
-  bitWidth += APInt::APINT_BITS_PER_WORD;
+  // The BY inverter codegen (BYInverter.cpp) selects a "limb" type sized to
+  // hold a signed value of magnitude up to 2^(divsteps+1) (the bound on the
+  // intermediate `md = t00*isNegD + t01*isNegE`), rounded up to the next
+  // power of two and never smaller than 64. The extended modulus type used
+  // for `d, e` updates needs at least `limbBitWidth` headroom over the
+  // modulus bit width because the update step computes
+  // `m * sext_extInt(md)` whose product can occupy up to
+  // `modBitWidth + limbBitWidth` bits. Keep the formula here in sync with
+  // BYInverter.cpp.
+  unsigned limbBitWidth = std::max<unsigned>(APInt::APINT_BITS_PER_WORD,
+                                             llvm::PowerOf2Ceil(divsteps + 2));
+  bitWidth += limbBitWidth;
 
   APInt mask = APInt::getOneBitSet(bitWidth, divsteps);
   APInt mInv =
@@ -174,9 +186,9 @@ BYAttrStorage *BYAttrStorage::construct(AttributeStorageAllocator &allocator,
   auto divstepsAttr = IntegerAttr::get(intType, divsteps);
   auto mInvAttr = IntegerAttr::get(intType, mInv);
   auto newBitWidthAttr = IntegerAttr::get(intType, bitWidth);
-  return new (allocator.allocate<BYAttrStorage>())
-      BYAttrStorage(std::move(modAttr), std::move(divstepsAttr),
-                    std::move(mInvAttr), std::move(newBitWidthAttr));
+  return new (allocator.allocate<BYAttrStorage>()) BYAttrStorage(
+      std::move(modAttr), std::move(divstepsAttr), std::move(mInvAttr),
+      std::move(newBitWidthAttr), limbBitWidth);
 }
 
 } // namespace detail

--- a/prime_ir/Dialect/ModArith/IR/ModArithAttributes.cpp
+++ b/prime_ir/Dialect/ModArith/IR/ModArithAttributes.cpp
@@ -165,15 +165,15 @@ BYAttrStorage *BYAttrStorage::construct(AttributeStorageAllocator &allocator,
     divsteps++;
   }
 
-  // The BY inverter codegen (BYInverter.cpp) selects a "limb" type sized to
-  // hold a signed value of magnitude up to 2^(divsteps+1) (the bound on the
-  // intermediate `md = t00*isNegD + t01*isNegE`), rounded up to the next
-  // power of two and never smaller than 64. The extended modulus type used
+  // The BY inverter codegen needs a "limb" type sized to hold a signed value
+  // of magnitude up to 2^(divsteps+1) (the bound on the intermediate
+  // `md = t00*isNegD + t01*isNegE`), rounded up to the next power of two and
+  // never smaller than a single APInt word. The extended modulus type used
   // for `d, e` updates needs at least `limbBitWidth` headroom over the
   // modulus bit width because the update step computes
   // `m * sext_extInt(md)` whose product can occupy up to
-  // `modBitWidth + limbBitWidth` bits. Keep the formula here in sync with
-  // BYInverter.cpp.
+  // `modBitWidth + limbBitWidth` bits. The computed value is stored on the
+  // attribute and consumed by BYInverter via `BYAttr::getLimbBitWidth()`.
   unsigned limbBitWidth = std::max<unsigned>(APInt::APINT_BITS_PER_WORD,
                                              llvm::PowerOf2Ceil(divsteps + 2));
   bitWidth += limbBitWidth;

--- a/prime_ir/Dialect/ModArith/IR/ModArithAttributes.h
+++ b/prime_ir/Dialect/ModArith/IR/ModArithAttributes.h
@@ -61,9 +61,10 @@ struct BYAttrStorage : public AttributeStorage {
   using KeyTy = IntegerAttr;
 
   BYAttrStorage(IntegerAttr modulus, IntegerAttr divsteps, IntegerAttr mInv,
-                IntegerAttr newBitWidth)
+                IntegerAttr newBitWidth, unsigned limbBitWidth)
       : modulus(std::move(modulus)), divsteps(std::move(divsteps)),
-        mInv(std::move(mInv)), newBitWidth(std::move(newBitWidth)) {}
+        mInv(std::move(mInv)), newBitWidth(std::move(newBitWidth)),
+        limbBitWidth(limbBitWidth) {}
 
   KeyTy getAsKey() const { return KeyTy(modulus); }
 
@@ -80,6 +81,7 @@ struct BYAttrStorage : public AttributeStorage {
   IntegerAttr divsteps;
   IntegerAttr mInv;
   IntegerAttr newBitWidth;
+  unsigned limbBitWidth;
 };
 
 } // namespace mlir::prime_ir::mod_arith::detail

--- a/prime_ir/Dialect/ModArith/IR/ModArithAttributes.td
+++ b/prime_ir/Dialect/ModArith/IR/ModArithAttributes.td
@@ -63,6 +63,12 @@ def ModArith_BYAttr : ModArith_Attr<"BY", "by"> {
     IntegerAttr getDivsteps() const;
     IntegerAttr getMInv() const;
     IntegerAttr getNewBitWidth() const;
+    // Bit width of the "limb" type used by the BY inverter codegen for the
+    // matrix entries `t.t00, t.t01, t.t10, t.t11` and intermediates such as
+    // `md`. Sized to hold a signed value of magnitude up to 2^(divsteps+1)
+    // (the bound on `md = t00*isNegD + t01*isNegE`), rounded up to the next
+    // power of two with a floor of 64.
+    unsigned getLimbBitWidth() const;
   }];
   let assemblyFormat = "`<`$modulus`>`";
   let genStorageClass = 0;

--- a/tests/Dialect/ModArith/mod_arith_bls12381_runner.mlir
+++ b/tests/Dialect/ModArith/mod_arith_bls12381_runner.mlir
@@ -1,0 +1,74 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// Runner tests for the BLS12-381 base field (384-bit modulus). Exercises the
+// Bernstein-Yang inverter codegen path with `divsteps > 64`, which goes
+// through the `limbBitWidth = n` branch in BYInverter.cpp. Catches the bug
+// where modular inverse computed via the lowered MLIR code disagreed with
+// zk_dtypes::bls12_381::FqMont::Inverse() for any non-trivial denominator.
+
+// RUN: prime-ir-opt %s -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_bls12381_inverse -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_INVERSE < %t
+
+// RUN: prime-ir-opt %s -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_bls12381_mont_inverse -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_MONT_INVERSE < %t
+
+func.func private @printMemrefI32(memref<*xi32>) attributes { llvm.emit_c_interface }
+
+// BLS12-381 base field prime:
+// p = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f624
+//     1eabfffeb153ffffb9feffffffffaaab
+!Fp = !mod_arith.int<4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787 : i384>
+!Fpm = !mod_arith.int<4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787 : i384, true>
+
+// Test inverse: inv(a) * a == 1 in the canonical (non-Montgomery) domain.
+func.func @test_bls12381_inverse() {
+  %a = mod_arith.constant 3723 : !Fp
+  %inv = mod_arith.inverse %a : !Fp
+  %check = mod_arith.mul %inv, %a : !Fp
+  %v = mod_arith.bitcast %check : !Fp -> i384
+  %v32 = arith.trunci %v : i384 to i32
+  %t = tensor.from_elements %v32 : tensor<1xi32>
+  %m = bufferization.to_buffer %t : tensor<1xi32> to memref<1xi32>
+  %U = memref.cast %m : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+  return
+}
+
+// CHECK_INVERSE: data =
+// CHECK_INVERSE-NEXT: [1]
+
+// Test mont_inverse: inv(a) * a == 1 in the Montgomery domain.
+func.func @test_bls12381_mont_inverse() {
+  %a = mod_arith.constant 3723 : !Fp
+  %a_mont = mod_arith.to_mont %a : !Fpm
+  %inv_mont = mod_arith.mont_inverse %a_mont : !Fpm
+  %check_mont = mod_arith.mul %inv_mont, %a_mont : !Fpm
+  %check = mod_arith.from_mont %check_mont : !Fp
+  %v = mod_arith.bitcast %check : !Fp -> i384
+  %v32 = arith.trunci %v : i384 to i32
+  %t = tensor.from_elements %v32 : tensor<1xi32>
+  %m = bufferization.to_buffer %t : tensor<1xi32> to memref<1xi32>
+  %U = memref.cast %m : memref<1xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+  return
+}
+
+// CHECK_MONT_INVERSE: data =
+// CHECK_MONT_INVERSE-NEXT: [1]

--- a/tests/Dialect/ModArith/mod_arith_bls12381_runner.mlir
+++ b/tests/Dialect/ModArith/mod_arith_bls12381_runner.mlir
@@ -14,10 +14,11 @@
 // ==============================================================================
 
 // Runner tests for the BLS12-381 base field (384-bit modulus). Exercises the
-// Bernstein-Yang inverter codegen path with `divsteps > 64`, which goes
-// through the `limbBitWidth = n` branch in BYInverter.cpp. Catches the bug
-// where modular inverse computed via the lowered MLIR code disagreed with
-// zk_dtypes::bls12_381::FqMont::Inverse() for any non-trivial denominator.
+// Bernstein-Yang inverter codegen path for a modulus where divsteps > 62, so
+// the limb type produced by BYAttr::getLimbBitWidth() is wider than 64 bits.
+// Catches the bug where modular inverse computed via the lowered MLIR code
+// disagreed with zk_dtypes::bls12_381::FqMont::Inverse() for any non-trivial
+// denominator (because the limb type had no signed headroom for `md`).
 
 // RUN: prime-ir-opt %s -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
 // RUN:   | mlir-runner -e test_bls12381_inverse -entry-point-result=void \
@@ -38,13 +39,17 @@ func.func private @printMemrefI32(memref<*xi32>) attributes { llvm.emit_c_interf
 !Fpm = !mod_arith.int<4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787 : i384, true>
 
 // Test inverse: inv(a) * a == 1 in the canonical (non-Montgomery) domain.
+// Compares the full i384 result against 1 (not just its low 32 bits) so a
+// mismatch in any limb fails the test.
 func.func @test_bls12381_inverse() {
   %a = mod_arith.constant 3723 : !Fp
   %inv = mod_arith.inverse %a : !Fp
   %check = mod_arith.mul %inv, %a : !Fp
   %v = mod_arith.bitcast %check : !Fp -> i384
-  %v32 = arith.trunci %v : i384 to i32
-  %t = tensor.from_elements %v32 : tensor<1xi32>
+  %one = arith.constant 1 : i384
+  %ok = arith.cmpi eq, %v, %one : i384
+  %ok32 = arith.extui %ok : i1 to i32
+  %t = tensor.from_elements %ok32 : tensor<1xi32>
   %m = bufferization.to_buffer %t : tensor<1xi32> to memref<1xi32>
   %U = memref.cast %m : memref<1xi32> to memref<*xi32>
   func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
@@ -54,7 +59,8 @@ func.func @test_bls12381_inverse() {
 // CHECK_INVERSE: data =
 // CHECK_INVERSE-NEXT: [1]
 
-// Test mont_inverse: inv(a) * a == 1 in the Montgomery domain.
+// Test mont_inverse: inv(a) * a == 1 in the Montgomery domain. Same full
+// i384 comparison as above.
 func.func @test_bls12381_mont_inverse() {
   %a = mod_arith.constant 3723 : !Fp
   %a_mont = mod_arith.to_mont %a : !Fpm
@@ -62,8 +68,10 @@ func.func @test_bls12381_mont_inverse() {
   %check_mont = mod_arith.mul %inv_mont, %a_mont : !Fpm
   %check = mod_arith.from_mont %check_mont : !Fp
   %v = mod_arith.bitcast %check : !Fp -> i384
-  %v32 = arith.trunci %v : i384 to i32
-  %t = tensor.from_elements %v32 : tensor<1xi32>
+  %one = arith.constant 1 : i384
+  %ok = arith.cmpi eq, %v, %one : i384
+  %ok32 = arith.extui %ok : i1 to i32
+  %t = tensor.from_elements %ok32 : tensor<1xi32>
   %m = bufferization.to_buffer %t : tensor<1xi32> to memref<1xi32>
   %U = memref.cast %m : memref<1xi32> to memref<*xi32>
   func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()


### PR DESCRIPTION
## Description

The Bernstein-Yang inverter codegen sized its limb type as
`n > 64 ? n : 64`, where `n = divsteps`. For 256-bit moduli (`n=62`) the
formula picked `i64`, which happened to give 2 bits of signed headroom over
the n-bit matrix entries — just enough for the intermediate
`md = t00*isNegD + t01*isNegE`, whose magnitude can reach `2^(n+1)`.

For 384-bit moduli (`n=93`) the same formula picked `i93` with **zero**
headroom. `md` overflowed, the subsequent `ExtSIOp` sign-extended a
wrapped value, and `mod_arith.inverse` / `mod_arith.mont_inverse`
returned wrong results: the lowered code disagreed with
`zk_dtypes::bls12_381::FqMont::Inverse()` from the very first byte for
any non-trivial denominator.

The bug was caught downstream by the riscv-witness BLS12-381 EC
add/double precompile traces, which had to work around it by computing
slope/inverse directly in C++ via `zk_dtypes`. 256-bit curves
(secp256k1, secp256r1, BN254) were unaffected because their `n=62`
falls into the headroom-by-accident case.

### Fix

- `BYAttrStorage::construct` now sizes `limbBitWidth` as
  `max(APINT_BITS_PER_WORD, PowerOf2Ceil(divsteps + 2))` and stores it
  on `BYAttrStorage`. For `n <= 62` this is unchanged (`i64`); for
  `n=93` it becomes `i128`. Power-of-two rounding keeps the lowering on
  hardware-friendly types.
- The extended modulus type used for `d, e` updates now gets
  `+limbBitWidth` headroom instead of a hard-coded `+64`. This is
  required because the codegen computes `m * sext_extInt(md)`, whose
  product can occupy `modBitWidth + limbBitWidth` bits and would
  otherwise overflow the old `+64` `extIntType` when `limbBitWidth > 64`.
- `BYAttr` exposes the new `getLimbBitWidth()` accessor; `BYInverter`
  reads it instead of recomputing the formula, so the two callers stay
  in sync by construction.

### Test

New runner test `tests/Dialect/ModArith/mod_arith_bls12381_runner.mlir`
exercises both `mod_arith.inverse` and `mod_arith.mont_inverse` over
the BLS12-381 base field (384-bit, `n=93`). Both check that
`inv(a) * a == 1`. The test fails on `main` and passes after this
change. The existing 256-bit `mod_arith_runner` and
`mod_arith_secp256k1_runner` tests are unchanged and still pass
(`limbBitWidth` is byte-identical for `n <= 62`).

Full `//tests/Dialect/{ModArith,Field,EllipticCurve}/...` was run:
86/87 pass. The single failure (`pairing_check_4pairs_runner`
TIMEOUT@900s) was independently verified to time out on the unmodified
`main` baseline as well — pre-existing, unrelated.

## Related Issues/PRs

Surfaces and fixes the upstream bug referenced in the riscv-witness
`fix/bls12381-trace-diffs` branch (BLS12-381 EC add/double precompile
trace divergence). Once this lands and gets bumped into riscv-witness,
the C++ workaround in `riscv_witness/chip/input_gen/ec_input_gen_aot.h`
(`BatchEcAdd<12>` / `BatchEcDouble<12>` computing slope/inv via
`zk_dtypes` directly) can be reverted to use the AOT externs again.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline