### PR TITLE
feat(elliptic_curve): add twisted Edwards point operations and codegen

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,7 @@
+[codespell]
+skip =
+  MODULE.bazel.lock
+
+ignore-words-list =
+  te,
+  TE,

--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
@@ -50,6 +50,10 @@ static llvm::StringRef pointKindToString(PointKind kind) {
     return "jacobian";
   case PointKind::kXYZZ:
     return "xyzz";
+  case PointKind::kEdAffine:
+    return "ed_affine";
+  case PointKind::kEdExtended:
+    return "ed_extended";
   }
   llvm_unreachable("unknown PointKind");
 }
@@ -153,9 +157,7 @@ struct ConvertConstant : public OpConversionPattern<ConstantOp> {
     Type resultType = op.getType();
     Type pointType = getElementTypeOrSelf(resultType);
     auto pointTypeInterface = cast<PointTypeInterface>(pointType);
-    Type baseFieldType =
-        cast<ShortWeierstrassAttr>(pointTypeInterface.getCurveAttr())
-            .getBaseField();
+    Type baseFieldType = pointTypeInterface.getBaseFieldType();
 
     // Convert coordinate attributes to field constants
     // Unified structure: ArrayAttr<ArrayAttr<Attr>> where outer array contains
@@ -551,10 +553,20 @@ struct ConvertNegate : public OpConversionPattern<NegateOp> {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
     Operation::result_range coords = toCoords(b, op.getInput());
-
-    auto negatedY = b.create<field::NegateOp>(coords[1]);
     SmallVector<Value> outputCoords(coords);
-    outputCoords[1] = negatedY;
+
+    Type elementType = getElementTypeOrSelf(op.getType());
+    if (isa<EdAffineType>(elementType)) {
+      // Twisted Edwards affine: -(x, y) = (-x, y)
+      outputCoords[0] = b.create<field::NegateOp>(coords[0]);
+    } else if (isa<EdExtendedType>(elementType)) {
+      // Twisted Edwards extended: -(X, Y, Z, T) = (-X, Y, Z, -T)
+      outputCoords[0] = b.create<field::NegateOp>(coords[0]);
+      outputCoords[3] = b.create<field::NegateOp>(coords[3]);
+    } else {
+      // Short Weierstrass: negate Y coordinate.
+      outputCoords[1] = b.create<field::NegateOp>(coords[1]);
+    }
 
     rewriter.replaceOp(op, fromCoords(b, op.getType(), outputCoords));
     return success();

--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
@@ -265,13 +265,32 @@ struct ConvertIsZero : public OpConversionPattern<IsZeroOp> {
     Value zeroBF = field::createFieldZero(baseFieldType, b);
 
     Value isZero;
-    if (isa<AffineType>(op.getInput().getType())) {
+    Type inputType = op.getInput().getType();
+    if (isa<AffineType>(inputType)) {
+      // SW affine identity: (0, 0)
       Value xIsZero =
           b.create<field::CmpOp>(arith::CmpIPredicate::eq, coords[0], zeroBF);
       Value yIsZero =
           b.create<field::CmpOp>(arith::CmpIPredicate::eq, coords[1], zeroBF);
       isZero = b.create<arith::AndIOp>(xIsZero, yIsZero);
+    } else if (isa<EdAffineType>(inputType)) {
+      // Edwards affine identity: (0, 1)
+      Value oneBF = field::createFieldOne(baseFieldType, b);
+      Value xIsZero =
+          b.create<field::CmpOp>(arith::CmpIPredicate::eq, coords[0], zeroBF);
+      Value yIsOne =
+          b.create<field::CmpOp>(arith::CmpIPredicate::eq, coords[1], oneBF);
+      isZero = b.create<arith::AndIOp>(xIsZero, yIsOne);
+    } else if (isa<EdExtendedType>(inputType)) {
+      // Edwards extended identity: (0, c, c, 0) for any c != 0.
+      // Check X == 0 and Y == Z (projective equivalence to (0, 1, 1, 0)).
+      Value xIsZero =
+          b.create<field::CmpOp>(arith::CmpIPredicate::eq, coords[0], zeroBF);
+      Value yEqZ = b.create<field::CmpOp>(arith::CmpIPredicate::eq, coords[1],
+                                          coords[2]);
+      isZero = b.create<arith::AndIOp>(xIsZero, yEqZ);
     } else {
+      // SW projective: identity has Z == 0
       isZero =
           b.create<field::CmpOp>(arith::CmpIPredicate::eq, coords[2], zeroBF);
     }

--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/PointCodeGen.cpp
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/PointCodeGen.cpp
@@ -22,6 +22,8 @@ namespace mlir::prime_ir::elliptic_curve {
 template class PointCodeGenBase<PointKind::kAffine>;
 template class PointCodeGenBase<PointKind::kJacobian>;
 template class PointCodeGenBase<PointKind::kXYZZ>;
+template class PointCodeGenBase<PointKind::kEdAffine>;
+template class PointCodeGenBase<PointKind::kEdExtended>;
 
 PointCodeGen::PointCodeGen(Type type, Value value) {
   if (isa<AffineType>(type)) {
@@ -30,8 +32,12 @@ PointCodeGen::PointCodeGen(Type type, Value value) {
     codeGen = JacobianPointCodeGen(value);
   } else if (isa<XYZZType>(type)) {
     codeGen = XYZZPointCodeGen(value);
+  } else if (isa<EdAffineType>(type)) {
+    codeGen = EdAffinePointCodeGen(value);
+  } else if (isa<EdExtendedType>(type)) {
+    codeGen = EdExtendedPointCodeGen(value);
   } else {
-    llvm_unreachable("Unsupported extension field type");
+    llvm_unreachable("Unsupported point type");
   }
 }
 
@@ -58,14 +64,19 @@ PointCodeGen applyBinaryOp(const PointCodeGen::CodeGenType &a,
                            const PointCodeGen::CodeGenType &b, F op) {
   return std::visit(
       [&](const auto &lhs, const auto &rhs) -> PointCodeGen {
-        if constexpr (std::is_same_v<std::decay_t<decltype(lhs)>,
-                                     std::decay_t<decltype(rhs)>>) {
+        using LHS = std::decay_t<decltype(lhs)>;
+        using RHS = std::decay_t<decltype(rhs)>;
+        constexpr bool lhsIsEd = std::is_same_v<LHS, EdAffinePointCodeGen> ||
+                                 std::is_same_v<LHS, EdExtendedPointCodeGen>;
+        constexpr bool rhsIsEd = std::is_same_v<RHS, EdAffinePointCodeGen> ||
+                                 std::is_same_v<RHS, EdExtendedPointCodeGen>;
+        if constexpr (lhsIsEd != rhsIsEd) {
+          llvm_unreachable("Cross-family binary op not supported");
+        } else if constexpr (std::is_same_v<LHS, RHS>) {
           return op(lhs, rhs);
           // NOLINTNEXTLINE(readability/braces)
-        } else if constexpr (std::is_same_v<std::decay_t<decltype(lhs)>,
-                                            AffinePointCodeGen> ||
-                             std::is_same_v<std::decay_t<decltype(rhs)>,
-                                            AffinePointCodeGen>) {
+        } else if constexpr (std::is_same_v<LHS, AffinePointCodeGen> ||
+                             std::is_same_v<RHS, AffinePointCodeGen>) {
           return op(lhs, rhs);
         }
         llvm_unreachable("Unsupported field type in binary operator");
@@ -123,6 +134,10 @@ PointCodeGen PointCodeGen::convert(PointKind outputKind) const {
     return convertImpl<PointKind::kJacobian>(codeGen);
   case PointKind::kXYZZ:
     return convertImpl<PointKind::kXYZZ>(codeGen);
+  case PointKind::kEdAffine:
+    return convertImpl<PointKind::kEdAffine>(codeGen);
+  case PointKind::kEdExtended:
+    return convertImpl<PointKind::kEdExtended>(codeGen);
   }
   llvm_unreachable("Unsupported point kind");
 }

--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/PointCodeGen.h
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/PointCodeGen.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <array>
 
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Support/LLVM.h"
@@ -199,16 +200,22 @@ protected:
     return b->create<field::CmpOp>(arith::CmpIPredicate::eq, GetA(), zero);
   }
 
-  FieldCodeGen GetA() const {
+  FieldCodeGen getCurveParamCodeGen(
+      llvm::function_ref<TypedAttr(ShortWeierstrassAttr)> swFn,
+      llvm::function_ref<TypedAttr(TwistedEdwardsAttr)> teFn) const {
     ImplicitLocOpBuilder *b = BuilderContext::GetInstance().Top();
-    auto curveAttr = cast<PointTypeInterface>(value.getType()).getCurveAttr();
-    if (auto swAttr = dyn_cast<ShortWeierstrassAttr>(curveAttr)) {
-      return FieldCodeGen(
-          b->create<field::ConstantOp>(swAttr.getBaseField(), swAttr.getA()));
-    }
-    auto teAttr = cast<TwistedEdwardsAttr>(curveAttr);
+    auto pti = cast<PointTypeInterface>(value.getType());
+    TypedAttr attr = llvm::TypeSwitch<Attribute, TypedAttr>(pti.getCurveAttr())
+                         .Case<ShortWeierstrassAttr>(swFn)
+                         .Case<TwistedEdwardsAttr>(teFn);
     return FieldCodeGen(
-        b->create<field::ConstantOp>(teAttr.getBaseField(), teAttr.getA()));
+        b->create<field::ConstantOp>(pti.getBaseFieldType(), attr));
+  }
+
+  FieldCodeGen GetA() const {
+    return getCurveParamCodeGen(
+        [](ShortWeierstrassAttr sw) { return sw.getA(); },
+        [](TwistedEdwardsAttr te) { return te.getA(); });
   }
 
   FieldCodeGen GetD() const {

--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/PointCodeGen.h
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/PointOperations/PointCodeGen.h
@@ -37,7 +37,9 @@ limitations under the License.
 namespace zk_dtypes {
 
 template <mlir::prime_ir::elliptic_curve::PointKind Kind>
-class PointTraits<mlir::prime_ir::elliptic_curve::PointCodeGenBase<Kind>> {
+class PointTraits<
+    mlir::prime_ir::elliptic_curve::PointCodeGenBase<Kind>,
+    std::enable_if_t<!mlir::prime_ir::elliptic_curve::isEdwards(Kind)>> {
 public:
   constexpr static CurveType kType = CurveType::kShortWeierstrass;
 
@@ -50,6 +52,20 @@ public:
   using BaseField = mlir::prime_ir::elliptic_curve::FieldCodeGen;
 };
 
+template <mlir::prime_ir::elliptic_curve::PointKind Kind>
+class PointTraits<
+    mlir::prime_ir::elliptic_curve::PointCodeGenBase<Kind>,
+    std::enable_if_t<mlir::prime_ir::elliptic_curve::isEdwards(Kind)>> {
+public:
+  constexpr static CurveType kType = CurveType::kTwistedEdwards;
+
+  using AffinePoint = mlir::prime_ir::elliptic_curve::PointCodeGenBase<
+      mlir::prime_ir::elliptic_curve::PointKind::kEdAffine>;
+  using ExtendedPoint = mlir::prime_ir::elliptic_curve::PointCodeGenBase<
+      mlir::prime_ir::elliptic_curve::PointKind::kEdExtended>;
+  using BaseField = mlir::prime_ir::elliptic_curve::FieldCodeGen;
+};
+
 } // namespace zk_dtypes
 
 namespace mlir::prime_ir::elliptic_curve {
@@ -58,7 +74,7 @@ template <PointKind Kind>
 class PointCodeGenBase : public PointOperationSelector<Kind>::template Type<
                              PointCodeGenBase<Kind>> {
 public:
-  static constexpr size_t kNumCoords = static_cast<size_t>(Kind) + 2;
+  static constexpr size_t kNumCoords = getNumCoords(Kind);
 
   PointCodeGenBase() = default;
   explicit PointCodeGenBase(Value value) : value(value) {}
@@ -70,6 +86,17 @@ public:
   PointCodeGenBase<Kind2> convert() const {
     if constexpr (Kind == Kind2) {
       return *this;
+    } else if constexpr (isEdwards(Kind) != isEdwards(Kind2)) {
+      llvm_unreachable("Cross-family conversion not supported");
+      return PointCodeGenBase<Kind2>();
+      // NOLINTNEXTLINE(readability/braces)
+    } else if constexpr (Kind == PointKind::kEdExtended &&
+                         Kind2 == PointKind::kEdAffine) {
+      return this->ToAffine();
+      // NOLINTNEXTLINE(readability/braces)
+    } else if constexpr (Kind == PointKind::kEdAffine &&
+                         Kind2 == PointKind::kEdExtended) {
+      return this->ToExtended();
     } else if constexpr (Kind2 == PointKind::kAffine) {
       return this->ToAffine();
     } else if constexpr (Kind2 == PointKind::kJacobian) {
@@ -87,6 +114,8 @@ protected:
   friend class zk_dtypes::JacobianPointOperation;
   template <typename, typename>
   friend class zk_dtypes::PointXyzzOperation;
+  template <typename, typename>
+  friend class zk_dtypes::ExtendedPointOperation;
 
   std::array<FieldCodeGen, kNumCoords> ToCoords() const {
     ImplicitLocOpBuilder *b = BuilderContext::GetInstance().Top();
@@ -106,9 +135,12 @@ protected:
     return PointCodeGenBase(fromCoords(*b, value.getType(), coords));
   }
 
-  PointCodeGenBase<PointKind::kAffine>
-  CreateAffinePoint(const std::array<FieldCodeGen, 2> &coords) const {
-    return createPoint<PointKind::kAffine, 2>(coords);
+  auto CreateAffinePoint(const std::array<FieldCodeGen, 2> &coords) const {
+    if constexpr (isEdwards(Kind)) {
+      return createPoint<PointKind::kEdAffine, 2>(coords);
+    } else {
+      return createPoint<PointKind::kAffine, 2>(coords);
+    }
   }
 
   PointCodeGenBase<PointKind::kJacobian>
@@ -121,9 +153,22 @@ protected:
     return createPoint<PointKind::kXYZZ, 4>(coords);
   }
 
-  PointCodeGenBase<PointKind::kAffine>
-  MaybeConvertToAffine(mlir::ValueRange values) const {
-    return PointCodeGenBase<PointKind::kAffine>(values[0]);
+  PointCodeGenBase<PointKind::kEdExtended>
+  CreateExtendedPoint(const std::array<FieldCodeGen, 4> &coords) const {
+    return createPoint<PointKind::kEdExtended, 4>(coords);
+  }
+
+  auto MaybeConvertToAffine(mlir::ValueRange values) const {
+    if constexpr (isEdwards(Kind)) {
+      return PointCodeGenBase<PointKind::kEdAffine>(values[0]);
+    } else {
+      return PointCodeGenBase<PointKind::kAffine>(values[0]);
+    }
+  }
+
+  PointCodeGenBase<PointKind::kEdAffine> &&
+  MaybeConvertToAffine(PointCodeGenBase<PointKind::kEdAffine> &&point) const {
+    return std::move(point);
   }
 
   PointCodeGenBase<PointKind::kJacobian>
@@ -136,6 +181,16 @@ protected:
     return PointCodeGenBase<PointKind::kXYZZ>(values[0]);
   }
 
+  PointCodeGenBase<PointKind::kEdExtended>
+  MaybeConvertToExtended(mlir::ValueRange values) const {
+    return PointCodeGenBase<PointKind::kEdExtended>(values[0]);
+  }
+
+  PointCodeGenBase<PointKind::kEdExtended> &&MaybeConvertToExtended(
+      PointCodeGenBase<PointKind::kEdExtended> &&point) const {
+    return std::move(point);
+  }
+
   Value IsAZero() const {
     Type baseFieldType =
         cast<PointTypeInterface>(value.getType()).getBaseFieldType();
@@ -146,10 +201,22 @@ protected:
 
   FieldCodeGen GetA() const {
     ImplicitLocOpBuilder *b = BuilderContext::GetInstance().Top();
-    auto swAttr = cast<ShortWeierstrassAttr>(
+    auto curveAttr = cast<PointTypeInterface>(value.getType()).getCurveAttr();
+    if (auto swAttr = dyn_cast<ShortWeierstrassAttr>(curveAttr)) {
+      return FieldCodeGen(
+          b->create<field::ConstantOp>(swAttr.getBaseField(), swAttr.getA()));
+    }
+    auto teAttr = cast<TwistedEdwardsAttr>(curveAttr);
+    return FieldCodeGen(
+        b->create<field::ConstantOp>(teAttr.getBaseField(), teAttr.getA()));
+  }
+
+  FieldCodeGen GetD() const {
+    ImplicitLocOpBuilder *b = BuilderContext::GetInstance().Top();
+    auto teAttr = cast<TwistedEdwardsAttr>(
         cast<PointTypeInterface>(value.getType()).getCurveAttr());
     return FieldCodeGen(
-        b->create<field::ConstantOp>(swAttr.getBaseField(), swAttr.getA()));
+        b->create<field::ConstantOp>(teAttr.getBaseField(), teAttr.getD()));
   }
 
   zk_dtypes::ControlFlowOperation<Value> GetCFOperation() const { return {}; }
@@ -164,14 +231,22 @@ protected:
   template <PointKind Kind2>
   PointCodeGenBase<Kind2> createPoint(mlir::ValueRange coords) const {
     Type type;
-    auto curve = cast<ShortWeierstrassAttr>(
-        cast<PointTypeInterface>(value.getType()).getCurveAttr());
-    if constexpr (Kind2 == PointKind::kAffine) {
-      type = AffineType::get(value.getContext(), curve);
-    } else if constexpr (Kind2 == PointKind::kJacobian) {
-      type = JacobianType::get(value.getContext(), curve);
-    } else if constexpr (Kind2 == PointKind::kXYZZ) {
-      type = XYZZType::get(value.getContext(), curve);
+    auto curveAttr = cast<PointTypeInterface>(value.getType()).getCurveAttr();
+    if constexpr (Kind2 == PointKind::kEdAffine) {
+      auto teCurve = cast<TwistedEdwardsAttr>(curveAttr);
+      type = EdAffineType::get(value.getContext(), teCurve);
+    } else if constexpr (Kind2 == PointKind::kEdExtended) {
+      auto teCurve = cast<TwistedEdwardsAttr>(curveAttr);
+      type = EdExtendedType::get(value.getContext(), teCurve);
+    } else {
+      auto swCurve = cast<ShortWeierstrassAttr>(curveAttr);
+      if constexpr (Kind2 == PointKind::kAffine) {
+        type = AffineType::get(value.getContext(), swCurve);
+      } else if constexpr (Kind2 == PointKind::kJacobian) {
+        type = JacobianType::get(value.getContext(), swCurve);
+      } else if constexpr (Kind2 == PointKind::kXYZZ) {
+        type = XYZZType::get(value.getContext(), swCurve);
+      }
     }
     ImplicitLocOpBuilder *b = BuilderContext::GetInstance().Top();
     return PointCodeGenBase<Kind2>(fromCoords(*b, type, coords));
@@ -183,15 +258,20 @@ protected:
 extern template class PointCodeGenBase<PointKind::kAffine>;
 extern template class PointCodeGenBase<PointKind::kJacobian>;
 extern template class PointCodeGenBase<PointKind::kXYZZ>;
+extern template class PointCodeGenBase<PointKind::kEdAffine>;
+extern template class PointCodeGenBase<PointKind::kEdExtended>;
 
 using AffinePointCodeGen = PointCodeGenBase<PointKind::kAffine>;
 using JacobianPointCodeGen = PointCodeGenBase<PointKind::kJacobian>;
 using XYZZPointCodeGen = PointCodeGenBase<PointKind::kXYZZ>;
+using EdAffinePointCodeGen = PointCodeGenBase<PointKind::kEdAffine>;
+using EdExtendedPointCodeGen = PointCodeGenBase<PointKind::kEdExtended>;
 
 class PointCodeGen {
 public:
   using CodeGenType =
-      std::variant<AffinePointCodeGen, JacobianPointCodeGen, XYZZPointCodeGen>;
+      std::variant<AffinePointCodeGen, JacobianPointCodeGen, XYZZPointCodeGen,
+                   EdAffinePointCodeGen, EdExtendedPointCodeGen>;
 
   template <typename T, typename = std::enable_if_t<
                             !std::is_same_v<std::decay_t<T>, FieldCodeGen> &&

--- a/prime_ir/Dialect/EllipticCurve/IR/BUILD.bazel
+++ b/prime_ir/Dialect/EllipticCurve/IR/BUILD.bazel
@@ -84,6 +84,7 @@ prime_ir_cc_library(
         "@zk_dtypes//zk_dtypes:bn254_g1",
         "@zk_dtypes//zk_dtypes:bn254_g2",
         "@zk_dtypes//zk_dtypes:control_flow_operation",
+        "@zk_dtypes//zk_dtypes:ed25519_g1",
     ],
 )
 
@@ -107,6 +108,8 @@ prime_ir_cc_library(
         "@zk_dtypes//zk_dtypes:sw_affine_point_operation",
         "@zk_dtypes//zk_dtypes:sw_jacobian_point_operation",
         "@zk_dtypes//zk_dtypes:sw_point_xyzz_operation",
+        "@zk_dtypes//zk_dtypes:te_affine_point_operation",
+        "@zk_dtypes//zk_dtypes:te_extended_point_operation",
     ],
 )
 

--- a/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveAttributes.cpp
+++ b/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveAttributes.cpp
@@ -126,6 +126,14 @@ TwistedEdwardsAttr::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
   auto dOp = field::FieldOperation::fromUnchecked(d, baseField);
   auto gXOp = field::FieldOperation::fromUnchecked(gX, baseField);
   auto gYOp = field::FieldOperation::fromUnchecked(gY, baseField);
+  if (aOp.isZero()) {
+    emitError() << "twisted Edwards parameter 'a' must be non-zero";
+    return failure();
+  }
+  if (dOp.isZero()) {
+    emitError() << "twisted Edwards parameter 'd' must be non-zero";
+    return failure();
+  }
   // Verify: a * Gx² + Gy² == 1 + d * Gx² * Gy²
   auto gx2 = gXOp.square();
   auto gy2 = gYOp.square();

--- a/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveAttributes.cpp
+++ b/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveAttributes.cpp
@@ -78,4 +78,64 @@ ShortWeierstrassAttr::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
   return success();
 }
 
+// static
+Attribute TwistedEdwardsAttr::parse(AsmParser &parser, Type odsType) {
+  Attribute a, d, gX, gY;
+  Type baseField;
+  if (failed(parser.parseLess()) || failed(parser.parseAttribute(a)) ||
+      failed(parser.parseComma()) || failed(parser.parseAttribute(d)) ||
+      failed(parser.parseComma()) || failed(parser.parseLParen()) ||
+      failed(parser.parseAttribute(gX)) || failed(parser.parseComma()) ||
+      failed(parser.parseAttribute(gY)) || failed(parser.parseRParen()) ||
+      failed(parser.parseGreater()) ||
+      failed(field::parseColonFieldType(parser, baseField)))
+    return nullptr;
+
+  if (failed(field::validateAttribute(parser, baseField, a, "a")) ||
+      failed(field::validateAttribute(parser, baseField, d, "d")) ||
+      failed(field::validateAttribute(parser, baseField, gX, "gX")) ||
+      failed(field::validateAttribute(parser, baseField, gY, "gY")))
+    return nullptr;
+
+  a = field::maybeToMontgomery(baseField, a);
+  d = field::maybeToMontgomery(baseField, d);
+  gX = field::maybeToMontgomery(baseField, gX);
+  gY = field::maybeToMontgomery(baseField, gY);
+
+  return TwistedEdwardsAttr::get(a.getContext(), baseField, cast<TypedAttr>(a),
+                                 cast<TypedAttr>(d), cast<TypedAttr>(gX),
+                                 cast<TypedAttr>(gY));
+}
+
+void TwistedEdwardsAttr::print(AsmPrinter &printer) const {
+  Attribute a = field::maybeToStandard(getBaseField(), getA());
+  Attribute d = field::maybeToStandard(getBaseField(), getD());
+  Attribute gX = field::maybeToStandard(getBaseField(), getGx());
+  Attribute gY = field::maybeToStandard(getBaseField(), getGy());
+
+  printer << '<' << a << ',' << d << ",(" << gX << ',' << gY
+          << ")> : " << getBaseField();
+}
+
+// static
+LogicalResult
+TwistedEdwardsAttr::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
+                           Type baseField, TypedAttr a, TypedAttr d,
+                           TypedAttr gX, TypedAttr gY) {
+  auto aOp = field::FieldOperation::fromUnchecked(a, baseField);
+  auto dOp = field::FieldOperation::fromUnchecked(d, baseField);
+  auto gXOp = field::FieldOperation::fromUnchecked(gX, baseField);
+  auto gYOp = field::FieldOperation::fromUnchecked(gY, baseField);
+  // Verify: a * Gx² + Gy² == 1 + d * Gx² * Gy²
+  auto gx2 = gXOp.square();
+  auto gy2 = gYOp.square();
+  auto one = aOp.getOne();
+  if (aOp * gx2 + gy2 != one + dOp * gx2 * gy2) {
+    emitError() << "a, d, gX, and gY must satisfy the equation "
+                   "a * x² + y² = 1 + d * x² * y²";
+    return failure();
+  }
+  return success();
+}
+
 } // namespace mlir::prime_ir::elliptic_curve

--- a/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveAttributes.td
+++ b/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveAttributes.td
@@ -41,4 +41,22 @@ def EllipticCurve_ShortWeierstrassAttr : EllipticCurve_Attr<"ShortWeierstrass", 
   let hasCustomAssemblyFormat = 1;
   let genVerifyDecl = 1;
 }
+def EllipticCurve_TwistedEdwardsAttr : EllipticCurve_Attr<"TwistedEdwards", "te", [SameTypeOperands]> {
+  let summary = "An attribute representing a twisted Edwards elliptic curve";
+  let description = [{
+    A twisted Edwards curve is defined by the equation a * x² + y² = 1 + d * x² * y²
+    (where a and d are non-zero finite field elements, d is non-square) and a generator
+    point G in the form (x, y). The standard Ed25519 curve uses a = -1.
+
+    Example:
+    ```
+    // a = -1, d = ..., G = (Gx, Gy)
+    #curve = #elliptic_curve.te<-1:i256, d:i256, (Gx:i256, Gy:i256)> : !curve25519_bf
+    ```
+  }];
+  let parameters = (ins Field_AnyFieldType:$baseField, Field_AnyFieldAttr:$a, Field_AnyFieldAttr:$d, Field_AnyFieldAttr:$Gx, Field_AnyFieldAttr:$Gy);
+  let hasCustomAssemblyFormat = 1;
+  let genVerifyDecl = 1;
+}
+
 #endif  // PRIME_IR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVEATTRIBUTES_TD_

--- a/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveTypes.cpp
+++ b/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveTypes.cpp
@@ -34,6 +34,8 @@ namespace mlir::prime_ir::elliptic_curve {
 DEFINE_ELLIPTIC_CURVE_TYPE_INTERFACE_METHODS(Affine, 2);
 DEFINE_ELLIPTIC_CURVE_TYPE_INTERFACE_METHODS(Jacobian, 3);
 DEFINE_ELLIPTIC_CURVE_TYPE_INTERFACE_METHODS(XYZZ, 4);
+DEFINE_ELLIPTIC_CURVE_TYPE_INTERFACE_METHODS(EdAffine, 2);
+DEFINE_ELLIPTIC_CURVE_TYPE_INTERFACE_METHODS(EdExtended, 4);
 
 #undef DEFINE_ELLIPTIC_CURVE_TYPE_INTERFACE_METHODS
 
@@ -82,5 +84,31 @@ TypedAttr XYZZType::createConstantAttrFromValues(ArrayRef<APInt> values) const {
 }
 
 ShapedType XYZZType::overrideShapedType(ShapedType type) const { return type; }
+
+TypedAttr EdAffineType::createConstantAttr(int64_t c) const { return {}; }
+
+TypedAttr
+EdAffineType::createConstantAttrFromValues(ArrayRef<APInt> values) const {
+  return {};
+}
+
+ShapedType EdAffineType::overrideShapedType(ShapedType type) const {
+  return type;
+}
+
+TypedAttr EdExtendedType::createConstantAttr(int64_t c) const {
+  // TODO(chokobole): Implement this.
+  return {};
+}
+
+TypedAttr
+EdExtendedType::createConstantAttrFromValues(ArrayRef<APInt> values) const {
+  // TODO(chokobole): Implement this.
+  return {};
+}
+
+ShapedType EdExtendedType::overrideShapedType(ShapedType type) const {
+  return type;
+}
 
 } // namespace mlir::prime_ir::elliptic_curve

--- a/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveTypes.td
+++ b/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveTypes.td
@@ -113,9 +113,51 @@ def EllipticCurve_XYZZType : EllipticCurve_Type<"XYZZ", "xyzz", [
   let assemblyFormat = "`<` $curve `>`";
 }
 
+def EllipticCurve_EdAffineType : EllipticCurve_Type<"EdAffine", "ed_affine", [
+  MemRefElementTypeInterface,
+  DeclareTypeInterfaceMethods<EllipticCurve_PointTypeInterface>,
+  DeclareTypeInterfaceMethods<ConstantLikeInterface>
+  ]> {
+  let summary = "An affine point on a twisted Edwards curve";
+  let description = [{
+    An affine point (x, y) on a twisted Edwards curve a*x² + y² = 1 + d*x²*y².
+    It must be instantiated with a twisted Edwards curve attribute.
+
+    Example:
+    ```
+    #ed25519 = #elliptic_curve.te<-1:i256, d:i256, (Gx:i256, Gy:i256)> : !curve25519_bf
+    !ed_affine = !elliptic_curve.ed_affine<#ed25519>
+    ```
+  }];
+  let parameters = (ins EllipticCurve_TwistedEdwardsAttr:$curve);
+  let assemblyFormat = "`<` $curve `>`";
+}
+
+def EllipticCurve_EdExtendedType : EllipticCurve_Type<"EdExtended", "ed_extended", [
+  MemRefElementTypeInterface,
+  DeclareTypeInterfaceMethods<EllipticCurve_PointTypeInterface>,
+  DeclareTypeInterfaceMethods<ConstantLikeInterface>
+  ]> {
+  let summary = "An extended point on a twisted Edwards curve";
+  let description = [{
+    An extended point on a twisted Edwards curve in the form (X:Y:Z:T) where
+    x = X/Z, y = Y/Z, T = X*Y/Z (Hisil-Wong-Carter-Dawson 2008). It must be
+    instantiated with a twisted Edwards curve attribute `#elliptic_curve.te`.
+
+    Example:
+    ```
+    #ed25519 = #elliptic_curve.te<-1:i256, d:i256, (Gx:i256, Gy:i256)> : !curve25519_bf
+    !extended = !elliptic_curve.ed_extended<#ed25519>
+    ```
+  }];
+  let parameters = (ins EllipticCurve_TwistedEdwardsAttr:$curve);
+  let assemblyFormat = "`<` $curve `>`";
+}
+
 def PointType : AnyTypeOf<[
     EllipticCurve_AffineType, EllipticCurve_JacobianType,
-    EllipticCurve_XYZZType]>;
+    EllipticCurve_XYZZType, EllipticCurve_EdAffineType,
+    EllipticCurve_EdExtendedType]>;
 
 def AffineLike : TypeOrValueSemanticsContainer<
     EllipticCurve_AffineType, "affine-like">;
@@ -126,7 +168,14 @@ def JacobianLike : TypeOrValueSemanticsContainer<
 def XYZZLike : TypeOrValueSemanticsContainer<
     EllipticCurve_XYZZType, "xyzz-like">;
 
+def EdAffineLike : TypeOrValueSemanticsContainer<
+    EllipticCurve_EdAffineType, "ed-affine-like">;
+
+def EdExtendedLike : TypeOrValueSemanticsContainer<
+    EllipticCurve_EdExtendedType, "ed-extended-like">;
+
 def PointLike : TypeConstraint<Or<[
-    AffineLike.predicate, JacobianLike.predicate, XYZZLike.predicate]>,
-    "affine-like or jacobian-like or xyzz-like">;
+    AffineLike.predicate, JacobianLike.predicate, XYZZLike.predicate,
+    EdAffineLike.predicate, EdExtendedLike.predicate]>,
+    "affine-like or jacobian-like or xyzz-like or ed-affine-like or ed-extended-like">;
 #endif  // PRIME_IR_DIALECT_ELLIPTICCURVE_IR_ELLIPTICCURVETYPES_TD_

--- a/prime_ir/Dialect/EllipticCurve/IR/PointKind.h
+++ b/prime_ir/Dialect/EllipticCurve/IR/PointKind.h
@@ -20,11 +20,35 @@
 
 namespace mlir::prime_ir::elliptic_curve {
 
+// TODO(chokobole): Rename kAffine→kSwAffine, kJacobian→kSwJacobian,
+// kXYZZ→kSwXYZZ (and corresponding MLIR types AffineType→SwAffineType, etc.)
+// for naming consistency with the Ed-prefixed variants. Separate refactor PR.
 enum class PointKind {
   kAffine,
   kJacobian,
   kXYZZ,
+  kEdAffine,
+  kEdExtended,
 };
+
+constexpr bool isEdwards(PointKind kind) {
+  return kind == PointKind::kEdAffine || kind == PointKind::kEdExtended;
+}
+
+constexpr size_t getNumCoords(PointKind kind) {
+  switch (kind) {
+  case PointKind::kAffine:
+    return 2;
+  case PointKind::kJacobian:
+    return 3;
+  case PointKind::kXYZZ:
+    return 4;
+  case PointKind::kEdAffine:
+    return 2;
+  case PointKind::kEdExtended:
+    return 4;
+  }
+}
 
 template <typename Point>
 constexpr PointKind getPointKind() {
@@ -32,9 +56,12 @@ constexpr PointKind getPointKind() {
     return PointKind::kAffine;
   } else if constexpr (zk_dtypes::IsJacobianPoint<Point>) {
     return PointKind::kJacobian;
-  } else {
-    static_assert(zk_dtypes::IsPointXyzz<Point>, "Point must be an xyzz point");
+  } else if constexpr (zk_dtypes::IsPointXyzz<Point>) {
     return PointKind::kXYZZ;
+  } else {
+    static_assert(zk_dtypes::IsExtendedPoint<Point>,
+                  "Point must be an extended point");
+    return PointKind::kEdExtended;
   }
 }
 

--- a/prime_ir/Dialect/EllipticCurve/IR/PointKind.h
+++ b/prime_ir/Dialect/EllipticCurve/IR/PointKind.h
@@ -52,7 +52,10 @@ constexpr size_t getNumCoords(PointKind kind) {
 
 template <typename Point>
 constexpr PointKind getPointKind() {
-  if constexpr (zk_dtypes::IsAffinePoint<Point>) {
+  if constexpr (zk_dtypes::IsAffinePoint<Point> &&
+                Point::Curve::kType == zk_dtypes::CurveType::kTwistedEdwards) {
+    return PointKind::kEdAffine;
+  } else if constexpr (zk_dtypes::IsAffinePoint<Point>) {
     return PointKind::kAffine;
   } else if constexpr (zk_dtypes::IsJacobianPoint<Point>) {
     return PointKind::kJacobian;

--- a/prime_ir/Dialect/EllipticCurve/IR/PointOperation.cpp
+++ b/prime_ir/Dialect/EllipticCurve/IR/PointOperation.cpp
@@ -20,6 +20,8 @@ namespace mlir::prime_ir::elliptic_curve {
 template class PointOperationBase<PointKind::kAffine>;
 template class PointOperationBase<PointKind::kJacobian>;
 template class PointOperationBase<PointKind::kXYZZ>;
+template class PointOperationBase<PointKind::kEdAffine>;
+template class PointOperationBase<PointKind::kEdExtended>;
 
 PointKind PointOperation::getKind() const {
   return std::visit([](const auto &v) -> PointKind { return v.getKind(); },
@@ -45,14 +47,20 @@ PointOperation applyBinaryOp(const PointOperation::OperationType &a,
                              const PointOperation::OperationType &b, F op) {
   return std::visit(
       [&](const auto &lhs, const auto &rhs) -> PointOperation {
-        if constexpr (std::is_same_v<std::decay_t<decltype(lhs)>,
-                                     std::decay_t<decltype(rhs)>>) {
+        using LHS = std::decay_t<decltype(lhs)>;
+        using RHS = std::decay_t<decltype(rhs)>;
+        constexpr bool lhsIsEd = std::is_same_v<LHS, EdAffinePointOperation> ||
+                                 std::is_same_v<LHS, EdExtendedPointOperation>;
+        constexpr bool rhsIsEd = std::is_same_v<RHS, EdAffinePointOperation> ||
+                                 std::is_same_v<RHS, EdExtendedPointOperation>;
+        if constexpr (lhsIsEd != rhsIsEd) {
+          // Cross-family (SW ↔ TE) binary ops are not supported.
+          llvm_unreachable("Cross-family binary op not supported");
+        } else if constexpr (std::is_same_v<LHS, RHS>) {
           return op(lhs, rhs);
           // NOLINTNEXTLINE(readability/braces)
-        } else if constexpr (std::is_same_v<std::decay_t<decltype(lhs)>,
-                                            AffinePointOperation> ||
-                             std::is_same_v<std::decay_t<decltype(rhs)>,
-                                            AffinePointOperation>) {
+        } else if constexpr (std::is_same_v<LHS, AffinePointOperation> ||
+                             std::is_same_v<RHS, AffinePointOperation>) {
           return op(lhs, rhs);
         }
         llvm_unreachable("Unsupported field type in binary operator");
@@ -124,6 +132,10 @@ PointOperation PointOperation::convert(PointKind outputKind) const {
     return convertImpl<PointKind::kJacobian>(operation);
   case PointKind::kXYZZ:
     return convertImpl<PointKind::kXYZZ>(operation);
+  case PointKind::kEdAffine:
+    return convertImpl<PointKind::kEdAffine>(operation);
+  case PointKind::kEdExtended:
+    return convertImpl<PointKind::kEdExtended>(operation);
   }
   llvm_unreachable("Unsupported point kind");
 }

--- a/prime_ir/Dialect/EllipticCurve/IR/PointOperation.h
+++ b/prime_ir/Dialect/EllipticCurve/IR/PointOperation.h
@@ -19,6 +19,7 @@
 #include <array>
 #include <cassert>
 
+#include "llvm/ADT/TypeSwitch.h"
 #include "prime_ir/Dialect/EllipticCurve/IR/EllipticCurveTypes.h"
 #include "prime_ir/Dialect/EllipticCurve/IR/PointKind.h"
 #include "prime_ir/Dialect/EllipticCurve/IR/PointOperationBaseForward.h"
@@ -293,15 +294,20 @@ protected:
 
   bool IsAZero() const { return GetA().isZero(); }
 
-  field::FieldOperation GetA() const {
-    auto curveAttr = pointType.getCurveAttr();
-    if (auto swAttr = dyn_cast<ShortWeierstrassAttr>(curveAttr)) {
-      return field::FieldOperation::fromUnchecked(swAttr.getA(),
-                                                  pointType.getBaseFieldType());
-    }
-    auto teAttr = cast<TwistedEdwardsAttr>(curveAttr);
-    return field::FieldOperation::fromUnchecked(teAttr.getA(),
+  field::FieldOperation
+  getCurveParam(llvm::function_ref<TypedAttr(ShortWeierstrassAttr)> swFn,
+                llvm::function_ref<TypedAttr(TwistedEdwardsAttr)> teFn) const {
+    TypedAttr attr =
+        llvm::TypeSwitch<Attribute, TypedAttr>(pointType.getCurveAttr())
+            .Case<ShortWeierstrassAttr>(swFn)
+            .Case<TwistedEdwardsAttr>(teFn);
+    return field::FieldOperation::fromUnchecked(attr,
                                                 pointType.getBaseFieldType());
+  }
+
+  field::FieldOperation GetA() const {
+    return getCurveParam([](ShortWeierstrassAttr sw) { return sw.getA(); },
+                         [](TwistedEdwardsAttr te) { return te.getA(); });
   }
 
   field::FieldOperation GetD() const {
@@ -311,25 +317,13 @@ protected:
   }
 
   field::FieldOperation GetX() const {
-    auto curveAttr = pointType.getCurveAttr();
-    if (auto swAttr = dyn_cast<ShortWeierstrassAttr>(curveAttr)) {
-      return field::FieldOperation::fromUnchecked(swAttr.getGx(),
-                                                  pointType.getBaseFieldType());
-    }
-    auto teAttr = cast<TwistedEdwardsAttr>(curveAttr);
-    return field::FieldOperation::fromUnchecked(teAttr.getGx(),
-                                                pointType.getBaseFieldType());
+    return getCurveParam([](ShortWeierstrassAttr sw) { return sw.getGx(); },
+                         [](TwistedEdwardsAttr te) { return te.getGx(); });
   }
 
   field::FieldOperation GetY() const {
-    auto curveAttr = pointType.getCurveAttr();
-    if (auto swAttr = dyn_cast<ShortWeierstrassAttr>(curveAttr)) {
-      return field::FieldOperation::fromUnchecked(swAttr.getGy(),
-                                                  pointType.getBaseFieldType());
-    }
-    auto teAttr = cast<TwistedEdwardsAttr>(curveAttr);
-    return field::FieldOperation::fromUnchecked(teAttr.getGy(),
-                                                pointType.getBaseFieldType());
+    return getCurveParam([](ShortWeierstrassAttr sw) { return sw.getGy(); },
+                         [](TwistedEdwardsAttr te) { return te.getGy(); });
   }
 
   zk_dtypes::ControlFlowOperation<bool> GetCFOperation() const { return {}; }

--- a/prime_ir/Dialect/EllipticCurve/IR/PointOperation.h
+++ b/prime_ir/Dialect/EllipticCurve/IR/PointOperation.h
@@ -380,6 +380,9 @@ protected:
     }
   }
 
+  // NOTE: Prime-field-only. Extension-field Edwards curves would need the
+  // same DenseIntElementsAttr path as getShortWeierstrassAttr's else-branch.
+  // Not needed until such a curve is added to zk_dtypes.
   template <typename T>
   static TwistedEdwardsAttr getTwistedEdwardsAttr(MLIRContext *context) {
     using BaseField = typename T::BaseField;

--- a/prime_ir/Dialect/EllipticCurve/IR/PointOperation.h
+++ b/prime_ir/Dialect/EllipticCurve/IR/PointOperation.h
@@ -35,8 +35,11 @@ class PointOperationBase;
 
 namespace zk_dtypes {
 
+// SW PointTraits for kAffine, kJacobian, kXYZZ.
 template <mlir::prime_ir::elliptic_curve::PointKind Kind>
-class PointTraits<mlir::prime_ir::elliptic_curve::PointOperationBase<Kind>> {
+class PointTraits<
+    mlir::prime_ir::elliptic_curve::PointOperationBase<Kind>,
+    std::enable_if_t<!mlir::prime_ir::elliptic_curve::isEdwards(Kind)>> {
 public:
   constexpr static CurveType kType = CurveType::kShortWeierstrass;
 
@@ -49,6 +52,21 @@ public:
   using BaseField = mlir::prime_ir::field::FieldOperation;
 };
 
+// TE PointTraits for kEdAffine, kEdExtended.
+template <mlir::prime_ir::elliptic_curve::PointKind Kind>
+class PointTraits<
+    mlir::prime_ir::elliptic_curve::PointOperationBase<Kind>,
+    std::enable_if_t<mlir::prime_ir::elliptic_curve::isEdwards(Kind)>> {
+public:
+  constexpr static CurveType kType = CurveType::kTwistedEdwards;
+
+  using AffinePoint = mlir::prime_ir::elliptic_curve::PointOperationBase<
+      mlir::prime_ir::elliptic_curve::PointKind::kEdAffine>;
+  using ExtendedPoint = mlir::prime_ir::elliptic_curve::PointOperationBase<
+      mlir::prime_ir::elliptic_curve::PointKind::kEdExtended>;
+  using BaseField = mlir::prime_ir::field::FieldOperation;
+};
+
 } // namespace zk_dtypes
 
 namespace mlir::prime_ir::elliptic_curve {
@@ -57,7 +75,7 @@ template <PointKind Kind>
 class PointOperationBase : public PointOperationSelector<Kind>::template Type<
                                PointOperationBase<Kind>> {
 public:
-  static constexpr size_t kNumCoords = static_cast<size_t>(Kind) + 2;
+  static constexpr size_t kNumCoords = getNumCoords(Kind);
 
   PointOperationBase() = default;
 
@@ -100,11 +118,18 @@ public:
   template <typename T>
   static Type getPointType(MLIRContext *context) {
     if constexpr (zk_dtypes::IsAffinePoint<T>) {
-      return createSpecificPointType<AffineType, T>(context);
+      if constexpr (T::Curve::kType == zk_dtypes::CurveType::kTwistedEdwards) {
+        return createEdPointType<EdAffineType, T>(context);
+      } else {
+        return createSpecificPointType<AffineType, T>(context);
+      }
     } else if constexpr (zk_dtypes::IsJacobianPoint<T>) {
       return createSpecificPointType<JacobianType, T>(context);
-    } else {
+    } else if constexpr (zk_dtypes::IsPointXyzz<T>) {
       return createSpecificPointType<XYZZType, T>(context);
+    } else {
+      static_assert(zk_dtypes::IsExtendedPoint<T>);
+      return createEdPointType<EdExtendedType, T>(context);
     }
   }
 
@@ -161,6 +186,18 @@ public:
   PointOperationBase<Kind2> convert() const {
     if constexpr (Kind == Kind2) {
       return *this;
+    } else if constexpr (isEdwards(Kind) != isEdwards(Kind2)) {
+      // Cross-family conversion (SW ↔ TE) not supported.
+      llvm_unreachable("Cross-family conversion not supported");
+      return PointOperationBase<Kind2>();
+      // NOLINTNEXTLINE(readability/braces)
+    } else if constexpr (Kind == PointKind::kEdExtended &&
+                         Kind2 == PointKind::kEdAffine) {
+      return this->ToAffine();
+      // NOLINTNEXTLINE(readability/braces)
+    } else if constexpr (Kind == PointKind::kEdAffine &&
+                         Kind2 == PointKind::kEdExtended) {
+      return this->ToExtended();
     } else if constexpr (Kind2 == PointKind::kAffine) {
       return this->ToAffine();
     } else if constexpr (Kind2 == PointKind::kJacobian) {
@@ -179,6 +216,8 @@ protected:
   friend class zk_dtypes::JacobianPointOperation;
   template <typename, typename>
   friend class zk_dtypes::PointXyzzOperation;
+  template <typename, typename>
+  friend class zk_dtypes::ExtendedPointOperation;
 
   template <PointKind Kind2>
   friend raw_ostream &operator<<(raw_ostream &os,
@@ -193,11 +232,17 @@ protected:
     return PointOperationBase(c, pointType);
   }
 
-  PointOperationBase<PointKind::kAffine>
+  auto
   CreateAffinePoint(const std::array<field::FieldOperation, 2> &coords) const {
-    auto attr = cast<ShortWeierstrassAttr>(pointType.getCurveAttr());
-    return PointOperationBase<PointKind::kAffine>(
-        coords, AffineType::get(attr.getContext(), attr));
+    if constexpr (isEdwards(Kind)) {
+      auto attr = cast<TwistedEdwardsAttr>(pointType.getCurveAttr());
+      return PointOperationBase<PointKind::kEdAffine>(
+          coords, EdAffineType::get(attr.getContext(), attr));
+    } else {
+      auto attr = cast<ShortWeierstrassAttr>(pointType.getCurveAttr());
+      return PointOperationBase<PointKind::kAffine>(
+          coords, AffineType::get(attr.getContext(), attr));
+    }
   }
 
   PointOperationBase<PointKind::kJacobian> CreateJacobianPoint(
@@ -214,8 +259,20 @@ protected:
         coords, XYZZType::get(attr.getContext(), attr));
   }
 
+  PointOperationBase<PointKind::kEdExtended> CreateExtendedPoint(
+      const std::array<field::FieldOperation, 4> &coords) const {
+    auto attr = cast<TwistedEdwardsAttr>(pointType.getCurveAttr());
+    return PointOperationBase<PointKind::kEdExtended>(
+        coords, EdExtendedType::get(attr.getContext(), attr));
+  }
+
   PointOperationBase<PointKind::kAffine> &&
   MaybeConvertToAffine(PointOperationBase<PointKind::kAffine> &&point) const {
+    return std::move(point);
+  }
+
+  PointOperationBase<PointKind::kEdAffine> &&
+  MaybeConvertToAffine(PointOperationBase<PointKind::kEdAffine> &&point) const {
     return std::move(point);
   }
 
@@ -229,12 +286,50 @@ protected:
     return std::move(point);
   }
 
+  PointOperationBase<PointKind::kEdExtended> &&MaybeConvertToExtended(
+      PointOperationBase<PointKind::kEdExtended> &&point) const {
+    return std::move(point);
+  }
+
   bool IsAZero() const { return GetA().isZero(); }
 
   field::FieldOperation GetA() const {
-    return field::FieldOperation::fromUnchecked(
-        cast<ShortWeierstrassAttr>(pointType.getCurveAttr()).getA(),
-        pointType.getBaseFieldType());
+    auto curveAttr = pointType.getCurveAttr();
+    if (auto swAttr = dyn_cast<ShortWeierstrassAttr>(curveAttr)) {
+      return field::FieldOperation::fromUnchecked(swAttr.getA(),
+                                                  pointType.getBaseFieldType());
+    }
+    auto teAttr = cast<TwistedEdwardsAttr>(curveAttr);
+    return field::FieldOperation::fromUnchecked(teAttr.getA(),
+                                                pointType.getBaseFieldType());
+  }
+
+  field::FieldOperation GetD() const {
+    auto teAttr = cast<TwistedEdwardsAttr>(pointType.getCurveAttr());
+    return field::FieldOperation::fromUnchecked(teAttr.getD(),
+                                                pointType.getBaseFieldType());
+  }
+
+  field::FieldOperation GetX() const {
+    auto curveAttr = pointType.getCurveAttr();
+    if (auto swAttr = dyn_cast<ShortWeierstrassAttr>(curveAttr)) {
+      return field::FieldOperation::fromUnchecked(swAttr.getGx(),
+                                                  pointType.getBaseFieldType());
+    }
+    auto teAttr = cast<TwistedEdwardsAttr>(curveAttr);
+    return field::FieldOperation::fromUnchecked(teAttr.getGx(),
+                                                pointType.getBaseFieldType());
+  }
+
+  field::FieldOperation GetY() const {
+    auto curveAttr = pointType.getCurveAttr();
+    if (auto swAttr = dyn_cast<ShortWeierstrassAttr>(curveAttr)) {
+      return field::FieldOperation::fromUnchecked(swAttr.getGy(),
+                                                  pointType.getBaseFieldType());
+    }
+    auto teAttr = cast<TwistedEdwardsAttr>(curveAttr);
+    return field::FieldOperation::fromUnchecked(teAttr.getGy(),
+                                                pointType.getBaseFieldType());
   }
 
   zk_dtypes::ControlFlowOperation<bool> GetCFOperation() const { return {}; }
@@ -285,9 +380,33 @@ protected:
     }
   }
 
+  template <typename T>
+  static TwistedEdwardsAttr getTwistedEdwardsAttr(MLIRContext *context) {
+    using BaseField = typename T::BaseField;
+    using UnderlyingType = typename BaseField::UnderlyingType;
+
+    auto getParam = [&](auto config_val) {
+      return convertToIntegerAttr(context,
+                                  static_cast<UnderlyingType>(config_val));
+    };
+
+    return TwistedEdwardsAttr::get(
+        context,
+        field::PrimeFieldOperation::getPrimeFieldType<BaseField>(context),
+        getParam(T::Curve::Config::kA.value()),
+        getParam(T::Curve::Config::kD.value()),
+        getParam(T::Curve::Config::kX.value()),
+        getParam(T::Curve::Config::kY.value()));
+  }
+
   template <typename MLIRPointType, typename T>
   static MLIRPointType createSpecificPointType(MLIRContext *context) {
     return MLIRPointType::get(context, getShortWeierstrassAttr<T>(context));
+  }
+
+  template <typename MLIRPointType, typename T>
+  static MLIRPointType createEdPointType(MLIRContext *context) {
+    return MLIRPointType::get(context, getTwistedEdwardsAttr<T>(context));
   }
 
   std::array<field::FieldOperation, kNumCoords> coords;
@@ -304,6 +423,8 @@ raw_ostream &operator<<(raw_ostream &os, const PointOperationBase<Kind> &op) {
 extern template class PointOperationBase<PointKind::kAffine>;
 extern template class PointOperationBase<PointKind::kJacobian>;
 extern template class PointOperationBase<PointKind::kXYZZ>;
+extern template class PointOperationBase<PointKind::kEdAffine>;
+extern template class PointOperationBase<PointKind::kEdExtended>;
 
 extern template raw_ostream &
 operator<<(raw_ostream &os, const PointOperationBase<PointKind::kAffine> &op);
@@ -311,16 +432,24 @@ extern template raw_ostream &
 operator<<(raw_ostream &os, const PointOperationBase<PointKind::kJacobian> &op);
 extern template raw_ostream &
 operator<<(raw_ostream &os, const PointOperationBase<PointKind::kXYZZ> &op);
+extern template raw_ostream &
+operator<<(raw_ostream &os, const PointOperationBase<PointKind::kEdAffine> &op);
+extern template raw_ostream &
+operator<<(raw_ostream &os,
+           const PointOperationBase<PointKind::kEdExtended> &op);
 
 using AffinePointOperation = PointOperationBase<PointKind::kAffine>;
 using JacobianPointOperation = PointOperationBase<PointKind::kJacobian>;
 using XYZZPointOperation = PointOperationBase<PointKind::kXYZZ>;
+using EdAffinePointOperation = PointOperationBase<PointKind::kEdAffine>;
+using EdExtendedPointOperation = PointOperationBase<PointKind::kEdExtended>;
 
 class PointOperation {
 public:
   using OperationType =
       std::variant<AffinePointOperation, JacobianPointOperation,
-                   XYZZPointOperation>;
+                   XYZZPointOperation, EdAffinePointOperation,
+                   EdExtendedPointOperation>;
 
   template <typename T, typename = std::enable_if_t<
                             !std::is_same_v<std::decay_t<T>, PointOperation> &&

--- a/prime_ir/Dialect/EllipticCurve/IR/PointOperationSelector.h
+++ b/prime_ir/Dialect/EllipticCurve/IR/PointOperationSelector.h
@@ -22,6 +22,8 @@
 #include "zk_dtypes/include/elliptic_curve/short_weierstrass/affine_point_operation.h"
 #include "zk_dtypes/include/elliptic_curve/short_weierstrass/jacobian_point_operation.h"
 #include "zk_dtypes/include/elliptic_curve/short_weierstrass/point_xyzz_operation.h"
+#include "zk_dtypes/include/elliptic_curve/twisted_edwards/affine_point_operation.h"
+#include "zk_dtypes/include/elliptic_curve/twisted_edwards/extended_point_operation.h"
 
 namespace mlir::prime_ir::elliptic_curve {
 
@@ -46,6 +48,18 @@ template <>
 struct PointOperationSelector<PointKind::kXYZZ> {
   template <typename Derived>
   using Type = zk_dtypes::PointXyzzOperation<Derived>;
+};
+
+template <>
+struct PointOperationSelector<PointKind::kEdAffine> {
+  template <typename Derived>
+  using Type = zk_dtypes::AffinePointOperation<Derived>;
+};
+
+template <>
+struct PointOperationSelector<PointKind::kEdExtended> {
+  template <typename Derived>
+  using Type = zk_dtypes::ExtendedPointOperation<Derived>;
 };
 
 } // namespace mlir::prime_ir::elliptic_curve

--- a/prime_ir/Dialect/Field/IR/FieldOperation.h
+++ b/prime_ir/Dialect/Field/IR/FieldOperation.h
@@ -159,6 +159,8 @@ private:
   friend class zk_dtypes::JacobianPointOperation;
   template <typename, typename>
   friend class zk_dtypes::PointXyzzOperation;
+  template <typename, typename>
+  friend class zk_dtypes::ExtendedPointOperation;
   friend raw_ostream &operator<<(raw_ostream &os, const FieldOperation &op);
 
   FieldOperation Double() const { return dbl(); }

--- a/prime_ir/Runtime/BUILD.bazel
+++ b/prime_ir/Runtime/BUILD.bazel
@@ -19,5 +19,6 @@ package(default_visibility = ["//visibility:public"])
 exports_files([
     "babybear_defs.mlir",
     "bn254_defs.mlir",
+    "ed25519_defs.mlir",
     "koalabear_defs.mlir",
 ])

--- a/prime_ir/Runtime/ed25519_defs.mlir
+++ b/prime_ir/Runtime/ed25519_defs.mlir
@@ -1,0 +1,27 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// Shared Ed25519 type aliases for MLIR tests.
+
+// ===== Field types =====
+
+// Curve25519 base field: p = 2^255 - 19
+!EdBF = !field.pf<57896044618658097711785492504343953926634992332820282019728792003956564819949:i256>
+
+// ===== Ed25519 EC types (standard) =====
+
+// a = -1 mod p, d = -121665/121666 mod p, G = (Gx, Gy)
+#ed25519 = #elliptic_curve.te<57896044618658097711785492504343953926634992332820282019728792003956564819948:i256, 37095705934669439343138083508754565189542113879843219016388785533085940283555:i256, (15112221349535400772501151409588531511454012693041857206046113283949847762202:i256, 46316835694926478169428394003475163141307993866256225615783033603165251855960:i256)> : !EdBF
+!ed_extended = !elliptic_curve.ed_extended<#ed25519>

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -49,6 +49,14 @@ genrule(
     cmd = "cp $< $@",
 )
 
+# Copy shared Ed25519 type defs into tests/ so LIT %S-relative paths work.
+genrule(
+    name = "ed25519_defs_copy",
+    srcs = ["//prime_ir/Runtime:ed25519_defs.mlir"],
+    outs = ["ed25519_defs.mlir"],
+    cmd = "cp $< $@",
+)
+
 # Bundle together all of the test utilities that are used by tests.
 filegroup(
     name = "test_utilities",
@@ -59,6 +67,7 @@ filegroup(
         "bn254_ec_utils.mlir",
         "default_print_utils.mlir",
         ":bn254_defs.mlir",
+        ":ed25519_defs.mlir",
         ":libruntime_functions.so",
         ":lit.cfg.py",
         "//tools:prime-ir-opt",

--- a/tests/Dialect/EllipticCurve/BUILD.bazel
+++ b/tests/Dialect/EllipticCurve/BUILD.bazel
@@ -53,6 +53,7 @@ prime_ir_cc_test(
         "@com_google_googletest//:gtest_main",
         "@zk_dtypes//zk_dtypes:bn254_g1",
         "@zk_dtypes//zk_dtypes:bn254_g2",
+        "@zk_dtypes//zk_dtypes:ed25519_g1",
     ],
 )
 

--- a/tests/Dialect/EllipticCurve/PointOperationTest.cpp
+++ b/tests/Dialect/EllipticCurve/PointOperationTest.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include "prime_ir/Dialect/EllipticCurve/IR/EllipticCurveDialect.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g1.h"
 #include "zk_dtypes/include/elliptic_curve/bn/bn254/g2.h"
+#include "zk_dtypes/include/elliptic_curve/curve25519/ed25519/g1.h"
 
 namespace mlir::prime_ir::elliptic_curve {
 namespace {
@@ -169,6 +170,70 @@ TYPED_TEST(PointOperationTest, Convert) {
         [](const PointType &a) { return a.ToXyzz(); },
         [](const auto &a) { return a.template convert<PointKind::kXYZZ>(); });
   }
+}
+
+//===----------------------------------------------------------------------===//
+// Ed25519 ExtendedPoint operations
+//===----------------------------------------------------------------------===//
+
+class Ed25519PointOperationTest : public testing::Test {
+public:
+  using Point = zk_dtypes::ed25519::G1ExtendedPoint;
+  static constexpr PointKind Kind = PointKind::kEdExtended;
+  using PointOp = PointOperationBase<Kind>;
+
+  static void SetUpTestSuite() { context.loadDialect<EllipticCurveDialect>(); }
+
+  static MLIRContext context;
+};
+
+MLIRContext Ed25519PointOperationTest::context;
+
+TEST_F(Ed25519PointOperationTest, FromZkDtypeRoundTrip) {
+  auto gen = Point::Generator();
+  auto ptGen = PointOp::fromZkDtype(&context, gen);
+  auto ptGen2 = PointOp::fromZkDtype(&context, gen);
+  EXPECT_EQ(ptGen, ptGen2);
+}
+
+TEST_F(Ed25519PointOperationTest, Add) {
+  auto a = Point::Generator();
+  auto b = Point::Generator();
+  auto ptA = PointOp::fromZkDtype(&context, a);
+  auto ptB = PointOp::fromZkDtype(&context, b);
+  auto result = ptA + ptB;
+  auto expected = PointOp::fromZkDtype(&context, a + b);
+  EXPECT_EQ(result, expected);
+}
+
+TEST_F(Ed25519PointOperationTest, Negate) {
+  auto a = Point::Generator();
+  auto ptA = PointOp::fromZkDtype(&context, a);
+  auto result = -ptA;
+  auto expected = PointOp::fromZkDtype(&context, -a);
+  EXPECT_EQ(result, expected);
+}
+
+TEST_F(Ed25519PointOperationTest, Double) {
+  auto a = Point::Generator();
+  auto ptA = PointOp::fromZkDtype(&context, a);
+  auto result = ptA.dbl();
+  auto expected = PointOp::fromZkDtype(&context, a.Double());
+  EXPECT_EQ(result, expected);
+}
+
+TEST_F(Ed25519PointOperationTest, AddEqualsDouble) {
+  // Edwards unified addition and dedicated doubling produce different
+  // projective representations of the same point. Verify they both match
+  // zk_dtypes' outputs (which are also projectively different).
+  auto g = Point::Generator();
+  auto ptG = PointOp::fromZkDtype(&context, g);
+  auto sum = ptG + ptG;
+  auto dbl = ptG.dbl();
+  auto expectedSum = PointOp::fromZkDtype(&context, g + g);
+  auto expectedDbl = PointOp::fromZkDtype(&context, g.Double());
+  EXPECT_EQ(sum, expectedSum);
+  EXPECT_EQ(dbl, expectedDbl);
 }
 
 } // namespace

--- a/tests/Dialect/EllipticCurve/ed_extended_canonicalize.mlir
+++ b/tests/Dialect/EllipticCurve/ed_extended_canonicalize.mlir
@@ -1,0 +1,61 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// RUN: cat %S/../../ed25519_defs.mlir %s \
+// RUN:   | prime-ir-opt -canonicalize \
+// RUN:   | FileCheck %s -enable-var-scope
+
+// CHECK-LABEL: @test_ed_add_self_is_double
+// CHECK-SAME: (%[[ARG0:.*]]: [[EDEXT:.*]]) -> [[EDEXT]] {
+func.func @test_ed_add_self_is_double(%point: !ed_extended) -> !ed_extended {
+  // CHECK: %[[DOUBLE:.*]] = elliptic_curve.double %[[ARG0]] : [[EDEXT]] -> [[EDEXT]]
+  // CHECK-NOT: elliptic_curve.add
+  // CHECK: return %[[DOUBLE]] : [[EDEXT]]
+  %sum = elliptic_curve.add %point, %point : !ed_extended, !ed_extended -> !ed_extended
+  return %sum : !ed_extended
+}
+
+// CHECK-LABEL: @test_ed_add_after_neg_lhs
+// CHECK-SAME: (%[[ARG0:.*]]: [[EDEXT:.*]], %[[ARG1:.*]]: [[EDEXT]]) -> [[EDEXT]] {
+func.func @test_ed_add_after_neg_lhs(%point1: !ed_extended, %point2: !ed_extended) -> !ed_extended {
+  // CHECK: %[[SUB:.*]] = elliptic_curve.sub %[[ARG1]], %[[ARG0]] : [[EDEXT]], [[EDEXT]] -> [[EDEXT]]
+  // CHECK-NOT: elliptic_curve.add
+  // CHECK-NOT: elliptic_curve.negate
+  // CHECK: return %[[SUB]] : [[EDEXT]]
+  %neg = elliptic_curve.negate %point1 : !ed_extended
+  %sum = elliptic_curve.add %neg, %point2 : !ed_extended, !ed_extended -> !ed_extended
+  return %sum : !ed_extended
+}
+
+// CHECK-LABEL: @test_ed_double_negate
+// CHECK-SAME: (%[[ARG0:.*]]: [[EDEXT:.*]]) -> [[EDEXT]] {
+func.func @test_ed_double_negate(%point: !ed_extended) -> !ed_extended {
+  // CHECK: return %[[ARG0]] : [[EDEXT]]
+  %neg1 = elliptic_curve.negate %point : !ed_extended
+  %neg2 = elliptic_curve.negate %neg1 : !ed_extended
+  return %neg2 : !ed_extended
+}
+
+// CHECK-LABEL: @test_ed_sub_after_neg_rhs
+// CHECK-SAME: (%[[ARG0:.*]]: [[EDEXT:.*]], %[[ARG1:.*]]: [[EDEXT]]) -> [[EDEXT]] {
+func.func @test_ed_sub_after_neg_rhs(%point1: !ed_extended, %point2: !ed_extended) -> !ed_extended {
+  // CHECK: %[[ADD:.*]] = elliptic_curve.add %[[ARG0]], %[[ARG1]] : [[EDEXT]], [[EDEXT]] -> [[EDEXT]]
+  // CHECK-NOT: elliptic_curve.sub
+  // CHECK-NOT: elliptic_curve.negate
+  // CHECK: return %[[ADD]] : [[EDEXT]]
+  %neg = elliptic_curve.negate %point2 : !ed_extended
+  %diff = elliptic_curve.sub %point1, %neg : !ed_extended, !ed_extended -> !ed_extended
+  return %diff : !ed_extended
+}

--- a/tests/Dialect/EllipticCurve/ed_extended_to_field.mlir
+++ b/tests/Dialect/EllipticCurve/ed_extended_to_field.mlir
@@ -1,0 +1,67 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// RUN: cat %S/../../ed25519_defs.mlir %s \
+// RUN:   | prime-ir-opt -elliptic-curve-to-field \
+// RUN:   | FileCheck %s -enable-var-scope
+
+// Test: Edwards extended point addition lowers to field ops.
+// CHECK-LABEL: @test_ed_extended_add
+func.func @test_ed_extended_add(%p1: !ed_extended, %p2: !ed_extended) -> !ed_extended {
+  // CHECK-NOT: elliptic_curve.add
+  // CHECK: field.mul
+  // CHECK: field.add
+  %result = elliptic_curve.add %p1, %p2 : !ed_extended, !ed_extended -> !ed_extended
+  return %result : !ed_extended
+}
+
+// Test: Edwards extended point doubling lowers to field ops.
+// CHECK-LABEL: @test_ed_extended_double
+func.func @test_ed_extended_double(%p1: !ed_extended) -> !ed_extended {
+  // CHECK-NOT: elliptic_curve.double
+  // CHECK: field.mul
+  %result = elliptic_curve.double %p1 : !ed_extended -> !ed_extended
+  return %result : !ed_extended
+}
+
+// Test: Edwards negation negates X and T (coords 0 and 3), not Y (coord 1).
+// CHECK-LABEL: @test_ed_extended_negate
+func.func @test_ed_extended_negate(%p1: !ed_extended) -> !ed_extended {
+  // CHECK-NOT: elliptic_curve.negate
+  // CHECK: elliptic_curve.to_coords
+  // Two negate ops (for X and T)
+  // CHECK: field.negate
+  // CHECK: field.negate
+  // CHECK: elliptic_curve.from_coords
+  %result = elliptic_curve.negate %p1 : !ed_extended
+  return %result : !ed_extended
+}
+
+// Test: Edwards subtraction lowers (via negate + add).
+// CHECK-LABEL: @test_ed_extended_sub
+func.func @test_ed_extended_sub(%p1: !ed_extended, %p2: !ed_extended) -> !ed_extended {
+  // CHECK-NOT: elliptic_curve.sub
+  %result = elliptic_curve.sub %p1, %p2 : !ed_extended, !ed_extended -> !ed_extended
+  return %result : !ed_extended
+}
+
+// Test: Edwards constant point lowers.
+// CHECK-LABEL: @test_ed_extended_constant
+func.func @test_ed_extended_constant() {
+  // CHECK-NOT: elliptic_curve.constant
+  // CHECK: field.constant
+  %gen = elliptic_curve.constant dense<[15112221349535400772501151409588531511454012693041857206046113283949847762202, 46316835694926478169428394003475163141307993866256225615783033603165251855960, 1, 0]> : !ed_extended
+  return
+}

--- a/tests/Dialect/EllipticCurve/ed_extended_to_field.mlir
+++ b/tests/Dialect/EllipticCurve/ed_extended_to_field.mlir
@@ -36,15 +36,14 @@ func.func @test_ed_extended_double(%p1: !ed_extended) -> !ed_extended {
   return %result : !ed_extended
 }
 
-// Test: Edwards negation negates X and T (coords 0 and 3), not Y (coord 1).
+// Test: Edwards negation negates X (coord 0) and T (coord 3), preserving Y and Z.
 // CHECK-LABEL: @test_ed_extended_negate
 func.func @test_ed_extended_negate(%p1: !ed_extended) -> !ed_extended {
   // CHECK-NOT: elliptic_curve.negate
-  // CHECK: elliptic_curve.to_coords
-  // Two negate ops (for X and T)
-  // CHECK: field.negate
-  // CHECK: field.negate
-  // CHECK: elliptic_curve.from_coords
+  // CHECK: [[COORDS:%.*]]:4 = elliptic_curve.to_coords
+  // CHECK: [[NEG_X:%.*]] = field.negate [[COORDS]]#0
+  // CHECK: [[NEG_T:%.*]] = field.negate [[COORDS]]#3
+  // CHECK: elliptic_curve.from_coords [[NEG_X]], [[COORDS]]#1, [[COORDS]]#2, [[NEG_T]]
   %result = elliptic_curve.negate %p1 : !ed_extended
   return %result : !ed_extended
 }
@@ -62,6 +61,7 @@ func.func @test_ed_extended_sub(%p1: !ed_extended, %p2: !ed_extended) -> !ed_ext
 func.func @test_ed_extended_constant() {
   // CHECK-NOT: elliptic_curve.constant
   // CHECK: field.constant
-  %gen = elliptic_curve.constant dense<[15112221349535400772501151409588531511454012693041857206046113283949847762202, 46316835694926478169428394003475163141307993866256225615783033603165251855960, 1, 0]> : !ed_extended
+  // T = Gx * Gy mod p (extended coordinate invariant when Z = 1).
+  %gen = elliptic_curve.constant dense<[15112221349535400772501151409588531511454012693041857206046113283949847762202, 46316835694926478169428394003475163141307993866256225615783033603165251855960, 1, 46827403850823179245072216630277197565144205554125654976674165829533817101731]> : !ed_extended
   return
 }


### PR DESCRIPTION
## Description

Add twisted Edwards curve support to prime-ir's elliptic curve dialect:

- **TwistedEdwardsAttr**: new curve attribute (`a*x² + y² = 1 + d*x²y²`) with parse/print/verify
- **EdExtendedType**: extended coordinates (X, Y, Z, T) with PointTypeInterface
- **PointKind::kEdExtended**: new point kind with SFINAE-split PointTraits for SW vs TE
- **PointOperation + PointCodeGen**: HWCD-2008 add/double/negate via zk_dtypes Ed25519
- **EllipticCurveToField lowering**: Edwards negate (negate X+T, not Y)
- **ed25519_defs.mlir**: runtime definitions for Ed25519 curve
- Bumps zk_dtypes to 30f5c25b67fc (twisted Edwards + Curve25519/Ed25519 support)

25 C++ PointOperation tests (20 SW + 5 Edwards) + 2 LIT tests pass.

## Related Issues/PRs

Depends on fractalyze/zk_dtypes feat/twisted-edwards-curve25519 branch.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline