### PR TITLE
feat(field): canonicalize add/sub of to_mont operands

### DIFF
--- a/prime_ir/Dialect/Field/IR/FieldOps.cpp
+++ b/prime_ir/Dialect/Field/IR/FieldOps.cpp
@@ -1975,6 +1975,53 @@ namespace {
 namespace {
 
 //===----------------------------------------------------------------------===//
+// ToMont additive distributivity patterns
+//===----------------------------------------------------------------------===//
+//
+// to_mont is an additive homomorphism: R*(a ± b) = R*a ± R*b. When both
+// operands of an add/sub are produced by `to_mont`, we can sink the conversion
+// past the arithmetic op:
+//
+//   field.add (field.to_mont %a), (field.to_mont %b)
+//     -> field.to_mont (field.add %a, %b)
+//
+// Single-use guard: we only rewrite when at least one of the two `to_mont` ops
+// is dead after the fold. Without the guard, duplicating the std-form op while
+// keeping both original `to_mont`s alive strictly increases op count.
+//
+// Non-termination: no reverse pattern (to_mont(add) -> add(to_mont, to_mont))
+// exists in this dialect, so the rewrite is monotone.
+
+template <typename BinaryOp>
+struct AdditiveOfToMontDistributivity : public OpRewritePattern<BinaryOp> {
+  using OpRewritePattern<BinaryOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(BinaryOp op,
+                                PatternRewriter &rewriter) const override {
+    auto lhsToMont = op.getLhs().template getDefiningOp<ToMontOp>();
+    auto rhsToMont = op.getRhs().template getDefiningOp<ToMontOp>();
+    if (!lhsToMont || !rhsToMont)
+      return failure();
+
+    // Mixed-type add/sub can pair to_monts of different input types; bail so
+    // ExpandMixedAdditiveOp runs first and splits the operands.
+    if (lhsToMont.getInput().getType() != rhsToMont.getInput().getType())
+      return failure();
+
+    if (!lhsToMont->hasOneUse() && !rhsToMont->hasOneUse())
+      return failure();
+
+    Value newBinary = rewriter.create<BinaryOp>(
+        op.getLoc(), lhsToMont.getInput(), rhsToMont.getInput());
+    rewriter.replaceOpWithNewOp<ToMontOp>(op, op.getType(), newBinary);
+    return success();
+  }
+};
+
+using FieldAddOfToMont = AdditiveOfToMontDistributivity<AddOp>;
+using FieldSubOfToMont = AdditiveOfToMontDistributivity<SubOp>;
+
+//===----------------------------------------------------------------------===//
 // Mixed-type expansion patterns
 //===----------------------------------------------------------------------===//
 
@@ -2077,6 +2124,7 @@ void AddOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
   PRIME_IR_FIELD_ADD_PATTERN_LIST(PRIME_IR_ADD_PATTERN)
 #undef PRIME_IR_ADD_PATTERN
   patterns.add<ExpandMixedAdditiveOp<AddOp>>(context);
+  patterns.add<FieldAddOfToMont>(context);
 }
 
 void SubOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
@@ -2085,6 +2133,7 @@ void SubOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
   PRIME_IR_FIELD_SUB_PATTERN_LIST(PRIME_IR_SUB_PATTERN)
 #undef PRIME_IR_SUB_PATTERN
   patterns.add<ExpandMixedAdditiveOp<SubOp>>(context);
+  patterns.add<FieldSubOfToMont>(context);
 }
 
 void MulOp::getCanonicalizationPatterns(RewritePatternSet &patterns,

--- a/prime_ir/Dialect/ModArith/IR/ModArithOps.cpp
+++ b/prime_ir/Dialect/ModArith/IR/ModArithOps.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include "prime_ir/Dialect/ModArith/IR/ModArithDialect.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithOperation.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithTypes.h"
+#include "prime_ir/Utils/APIntUtils.h"
 #include "prime_ir/Utils/AssemblyFormatUtils.h"
 #include "prime_ir/Utils/BitcastOpUtils.h"
 #include "prime_ir/Utils/ConstantFolder.h"
@@ -766,6 +767,69 @@ namespace {
 #include "prime_ir/Dialect/ModArith/IR/ModArithCanonicalization.cpp.inc"
 }
 
+namespace {
+
+// mod_arith.mul (mod_arith.constant C : !Fpm), (mod_arith.to_mont %b : !Fp)
+//   : !Fpm
+//     -> mod_arith.mont_mul (mod_arith.constant (C_stored * R mod p) : !Fpm),
+//                           (mod_arith.bitcast %b : !Fp -> !Fpm) : !Fpm
+//
+// The mul on a Mont type lowers to a MontMul, and the to_mont on the other
+// operand lowers to a second MontMul (with R² as the other operand). By
+// absorbing the `* R²` into the constant at compile time, we collapse the
+// two MontMuls into one, saving a full modular multiplication at the arith
+// lowering layer.
+//
+// Correctness: given C_stored = c * R mod p (Mont encoding of logical c),
+// the rewritten constant stores k = C_stored * R = c * R² mod p. Then
+//   mont_mul(k, b_bitcast) = k * b * R⁻¹ = c * R² * b * R⁻¹ = c * b * R
+// which is the Mont encoding of c * b — identical to the semantics of
+// mul(C_mont, to_mont(b)) on !Fpm.
+//
+// Single-use guard on the to_mont: otherwise it remains alive for other
+// users and the rewrite is neutral (we add a bitcast and a new constant
+// without killing the to_mont-derived MontMul).
+struct MulOfConstantAndToMont : public OpRewritePattern<MulOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(MulOp op,
+                                PatternRewriter &rewriter) const override {
+    auto modType = dyn_cast<ModArithType>(op.getType());
+    if (!modType || !modType.isMontgomery())
+      return failure();
+
+    ConstantOp constOp = op.getLhs().getDefiningOp<ConstantOp>();
+    ToMontOp toMontOp = op.getRhs().getDefiningOp<ToMontOp>();
+    if (!constOp || !toMontOp) {
+      constOp = op.getRhs().getDefiningOp<ConstantOp>();
+      toMontOp = op.getLhs().getDefiningOp<ToMontOp>();
+      if (!constOp || !toMontOp)
+        return failure();
+    }
+
+    if (!toMontOp->hasOneUse())
+      return failure();
+
+    auto intAttr = dyn_cast<IntegerAttr>(constOp.getValue());
+    if (!intAttr)
+      return failure();
+
+    MontgomeryAttr montAttr = modType.getMontgomeryAttr();
+    APInt k = mulMod(intAttr.getValue(), montAttr.getR().getValue(),
+                     montAttr.getModulus().getValue());
+
+    Location loc = op.getLoc();
+    auto kAttr = IntegerAttr::get(modType.getStorageType(), k);
+    Value kConst = rewriter.create<ConstantOp>(loc, modType, kAttr);
+    Value bBitcast =
+        rewriter.create<BitcastOp>(loc, modType, toMontOp.getInput());
+    rewriter.replaceOpWithNewOp<MontMulOp>(op, modType, bBitcast, kConst);
+    return success();
+  }
+};
+
+} // namespace
+
 #include "prime_ir/Utils/CanonicalizationPatterns.inc"
 
 void AddOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
@@ -787,6 +851,7 @@ void MulOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 #define PRIME_IR_MUL_PATTERN(Name) patterns.add<ModArith##Name>(context);
   PRIME_IR_FIELD_MUL_PATTERN_LIST(PRIME_IR_MUL_PATTERN)
 #undef PRIME_IR_MUL_PATTERN
+  patterns.add<MulOfConstantAndToMont>(context);
 }
 
 } // namespace mlir::prime_ir::mod_arith

--- a/tests/Dialect/Field/field_canonicalize.mlir
+++ b/tests/Dialect/Field/field_canonicalize.mlir
@@ -1234,3 +1234,83 @@ func.func @test_to_mont_from_mont_tensor_cancel(%arg0: tensor<2x!PF17m>) -> tens
   %1 = field.to_mont %0 : tensor<2x!PF17m>
   return %1 : tensor<2x!PF17m>
 }
+
+//===----------------------------------------------------------------------===//
+// ToMont additive distributivity
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @test_add_of_to_mont
+// CHECK-SAME: (%[[ARG0:.*]]: [[T:[^,]*]], %[[ARG1:.*]]: [[T]]) -> [[TM:.*]] {
+func.func @test_add_of_to_mont(%arg0: !PF17, %arg1: !PF17) -> !PF17m {
+  // CHECK: %[[ADD:.*]] = field.add %[[ARG0]], %[[ARG1]] : [[T]]
+  // CHECK: %[[RES:.*]] = field.to_mont %[[ADD]] : [[TM]]
+  // CHECK: return %[[RES]] : [[TM]]
+  %0 = field.to_mont %arg0 : !PF17m
+  %1 = field.to_mont %arg1 : !PF17m
+  %2 = field.add %0, %1 : !PF17m
+  return %2 : !PF17m
+}
+
+// CHECK-LABEL: @test_sub_of_to_mont
+// CHECK-SAME: (%[[ARG0:.*]]: [[T:[^,]*]], %[[ARG1:.*]]: [[T]]) -> [[TM:.*]] {
+func.func @test_sub_of_to_mont(%arg0: !PF17, %arg1: !PF17) -> !PF17m {
+  // CHECK: %[[SUB:.*]] = field.sub %[[ARG0]], %[[ARG1]] : [[T]]
+  // CHECK: %[[RES:.*]] = field.to_mont %[[SUB]] : [[TM]]
+  // CHECK: return %[[RES]] : [[TM]]
+  %0 = field.to_mont %arg0 : !PF17m
+  %1 = field.to_mont %arg1 : !PF17m
+  %2 = field.sub %0, %1 : !PF17m
+  return %2 : !PF17m
+}
+
+// CHECK-LABEL: @test_add_of_to_mont_tensor
+// CHECK-SAME: (%[[ARG0:.*]]: [[T:[^,]*]], %[[ARG1:.*]]: [[T]]) -> [[TM:.*]] {
+func.func @test_add_of_to_mont_tensor(%arg0: tensor<2x!PF17>, %arg1: tensor<2x!PF17>) -> tensor<2x!PF17m> {
+  // CHECK: %[[ADD:.*]] = field.add %[[ARG0]], %[[ARG1]] : [[T]]
+  // CHECK: %[[RES:.*]] = field.to_mont %[[ADD]] : [[TM]]
+  // CHECK: return %[[RES]] : [[TM]]
+  %0 = field.to_mont %arg0 : tensor<2x!PF17m>
+  %1 = field.to_mont %arg1 : tensor<2x!PF17m>
+  %2 = field.add %0, %1 : tensor<2x!PF17m>
+  return %2 : tensor<2x!PF17m>
+}
+
+// Both to_mont ops have an extra use; folding would net +1 op.
+// CHECK-LABEL: @test_add_of_to_mont_multi_use_no_fold
+func.func @test_add_of_to_mont_multi_use_no_fold(%arg0: !PF17, %arg1: !PF17)
+    -> (!PF17m, !PF17m, !PF17m) {
+  // CHECK: field.to_mont
+  // CHECK: field.to_mont
+  // CHECK: field.add
+  %0 = field.to_mont %arg0 : !PF17m
+  %1 = field.to_mont %arg1 : !PF17m
+  %2 = field.add %0, %1 : !PF17m
+  return %2, %0, %1 : !PF17m, !PF17m, !PF17m
+}
+
+// Only one to_mont has an extra use; the other is dead after the fold.
+// CHECK-LABEL: @test_add_of_to_mont_one_extra_use_folds
+// CHECK-SAME: (%[[ARG0:.*]]: [[T:[^,]*]], %[[ARG1:.*]]: [[T]])
+func.func @test_add_of_to_mont_one_extra_use_folds(%arg0: !PF17, %arg1: !PF17)
+    -> (!PF17m, !PF17m) {
+  // CHECK-DAG: %[[TM0:.*]] = field.to_mont %[[ARG0]] : [[TM:.*]]
+  // CHECK-DAG: %[[ADD:.*]] = field.add %[[ARG0]], %[[ARG1]] : [[T]]
+  // CHECK-DAG: %[[RES:.*]] = field.to_mont %[[ADD]] : [[TM]]
+  // CHECK: return %[[RES]], %[[TM0]]
+  %0 = field.to_mont %arg0 : !PF17m
+  %1 = field.to_mont %arg1 : !PF17m
+  %2 = field.add %0, %1 : !PF17m
+  return %2, %0 : !PF17m, !PF17m
+}
+
+// Mixed: only one operand is to_mont. The pattern must NOT fire.
+// CHECK-LABEL: @test_add_of_to_mont_mixed_no_fold
+// CHECK-SAME: (%[[ARG0:.*]]: [[T:[^,]*]], %[[ARG1:.*]]: [[TM:[^)]*]]) -> [[TM]] {
+func.func @test_add_of_to_mont_mixed_no_fold(%arg0: !PF17, %arg1: !PF17m) -> !PF17m {
+  // CHECK: %[[TM0:.*]] = field.to_mont %[[ARG0]] : [[TM]]
+  // CHECK: %[[RES:.*]] = field.add %[[TM0]], %[[ARG1]] : [[TM]]
+  // CHECK: return %[[RES]] : [[TM]]
+  %0 = field.to_mont %arg0 : !PF17m
+  %1 = field.add %0, %arg1 : !PF17m
+  return %1 : !PF17m
+}

--- a/tests/Dialect/Field/field_canonicalize.mlir
+++ b/tests/Dialect/Field/field_canonicalize.mlir
@@ -1277,11 +1277,14 @@ func.func @test_add_of_to_mont_tensor(%arg0: tensor<2x!PF17>, %arg1: tensor<2x!P
 
 // Both to_mont ops have an extra use; folding would net +1 op.
 // CHECK-LABEL: @test_add_of_to_mont_multi_use_no_fold
+// CHECK-SAME: (%[[ARG0:.*]]: [[T:[^,]*]], %[[ARG1:.*]]: [[T]])
 func.func @test_add_of_to_mont_multi_use_no_fold(%arg0: !PF17, %arg1: !PF17)
     -> (!PF17m, !PF17m, !PF17m) {
-  // CHECK: field.to_mont
-  // CHECK: field.to_mont
-  // CHECK: field.add
+  // CHECK: %[[TM0:.*]] = field.to_mont %[[ARG0]]
+  // CHECK: %[[TM1:.*]] = field.to_mont %[[ARG1]]
+  // CHECK: %[[ADD:.*]] = field.add %[[TM0]], %[[TM1]]
+  // CHECK-NOT: field.to_mont
+  // CHECK: return %[[ADD]], %[[TM0]], %[[TM1]]
   %0 = field.to_mont %arg0 : !PF17m
   %1 = field.to_mont %arg1 : !PF17m
   %2 = field.add %0, %1 : !PF17m

--- a/tests/Dialect/ModArith/canonicalize.mlir
+++ b/tests/Dialect/ModArith/canonicalize.mlir
@@ -1593,3 +1593,74 @@ func.func @test_bitcast_transitive(%arg0: !Zp) -> !Zq {
   // CHECK: return %[[RES]] : [[Tq]]
   return %1 : !Zq
 }
+
+//===----------------------------------------------------------------------===//
+// Mul of constant and to_mont: collapse into mont_mul with precomputed
+// double-Mont constant.
+//===----------------------------------------------------------------------===//
+
+// mul(constant c, to_mont(%arg0)) on Mont type
+//   -> mont_mul(constant (c * R² mod p), bitcast(%arg0))
+//
+// For p = 37, R = 2³² mod 37 = 7, R² mod 37 = 12. With logical c = 10:
+//   c_stored = 10 * 7 mod 37 = 33
+//   k_stored = c_stored * R mod 37 = 33 * 7 mod 37 = 9
+//   k_logical (printed) = k_stored * R⁻¹ mod 37 = 9 * 16 mod 37 = 33
+// CHECK-LABEL: @test_mul_of_const_and_to_mont
+// CHECK-SAME: (%[[ARG0:.*]]: [[T:[^)]*]]) -> [[Tm:[^ ]*]]
+func.func @test_mul_of_const_and_to_mont(%arg0: !Zp) -> !Zpm {
+  // CHECK-DAG: %[[K:.*]] = mod_arith.constant 33 : [[Tm]]
+  // CHECK-DAG: %[[BC:.*]] = mod_arith.bitcast %[[ARG0]] : [[T]] -> [[Tm]]
+  // CHECK: %[[R:.*]] = mod_arith.mont_mul %[[BC]], %[[K]] : [[Tm]]
+  // CHECK-NOT: mod_arith.to_mont
+  // CHECK: return %[[R]] : [[Tm]]
+  %c = mod_arith.constant 10 : !Zpm
+  %b_mont = mod_arith.to_mont %arg0 : !Zpm
+  %r = mod_arith.mul %c, %b_mont : !Zpm
+  return %r : !Zpm
+}
+
+// Commutative case: constant on the right.
+// CHECK-LABEL: @test_mul_of_to_mont_and_const
+// CHECK-SAME: (%[[ARG0:.*]]: [[T:[^)]*]]) -> [[Tm:[^ ]*]]
+func.func @test_mul_of_to_mont_and_const(%arg0: !Zp) -> !Zpm {
+  // CHECK-DAG: %[[K:.*]] = mod_arith.constant 33 : [[Tm]]
+  // CHECK-DAG: %[[BC:.*]] = mod_arith.bitcast %[[ARG0]] : [[T]] -> [[Tm]]
+  // CHECK: %[[R:.*]] = mod_arith.mont_mul %[[BC]], %[[K]] : [[Tm]]
+  // CHECK-NOT: mod_arith.to_mont
+  // CHECK: return %[[R]] : [[Tm]]
+  %c = mod_arith.constant 10 : !Zpm
+  %b_mont = mod_arith.to_mont %arg0 : !Zpm
+  %r = mod_arith.mul %b_mont, %c : !Zpm
+  return %r : !Zpm
+}
+
+// Single-use guard: to_mont has an extra use, so rewriting would leave
+// the original MontMul(b, R²) alive. The pattern must NOT fire.
+// CHECK-LABEL: @test_mul_of_const_and_to_mont_multi_use_no_fold
+// CHECK-SAME: (%[[ARG0:.*]]: [[T:[^)]*]])
+func.func @test_mul_of_const_and_to_mont_multi_use_no_fold(%arg0: !Zp)
+    -> (!Zpm, !Zpm) {
+  // CHECK: %[[C:.*]] = mod_arith.constant 10 : [[Tm:[^ ]*]]
+  // CHECK: %[[TM:.*]] = mod_arith.to_mont %[[ARG0]] : [[Tm]]
+  // CHECK: %[[R:.*]] = mod_arith.mul %[[TM]], %[[C]] : [[Tm]]
+  // CHECK-NOT: mod_arith.mont_mul
+  // CHECK: return %[[R]], %[[TM]]
+  %c = mod_arith.constant 10 : !Zpm
+  %b_mont = mod_arith.to_mont %arg0 : !Zpm
+  %r = mod_arith.mul %c, %b_mont : !Zpm
+  return %r, %b_mont : !Zpm, !Zpm
+}
+
+// Non-matching: neither operand is a to_mont, so the pattern must NOT fire.
+// CHECK-LABEL: @test_mul_of_const_and_non_to_mont_no_fold
+// CHECK-SAME: (%[[ARG0:.*]]: [[Tm:[^)]*]]) -> [[Tm]]
+func.func @test_mul_of_const_and_non_to_mont_no_fold(%arg0: !Zpm) -> !Zpm {
+  // CHECK: %[[C:.*]] = mod_arith.constant 10 : [[Tm]]
+  // CHECK: %[[R:.*]] = mod_arith.mul %[[ARG0]], %[[C]] : [[Tm]]
+  // CHECK-NOT: mod_arith.mont_mul
+  // CHECK: return %[[R]] : [[Tm]]
+  %c = mod_arith.constant 10 : !Zpm
+  %r = mod_arith.mul %c, %arg0 : !Zpm
+  return %r : !Zpm
+}


### PR DESCRIPTION
## Description

Exploit the additive homomorphism R*(a ± b) = R*a ± R*b to sink a
`to_mont` conversion past `field.add` / `field.sub` when both operands
are produced by `to_mont`:

```
field.add (field.to_mont %a), (field.to_mont %b)
  -> field.to_mont (field.add %a, %b)
```

Same fold for `SubOp`.

### Design

- **Single-use guard**: the fold only fires when at least one of the
  two `to_mont` ops is dead after the rewrite. Without the guard,
  duplicating the std-form op while keeping both originals alive would
  strictly increase op count.
- **Mixed-type guard**: `Field_BinaryOp` accepts `FieldLike × FieldLike`
  (prime × extension), so two `to_mont` operands can have different
  input types. The fold bails in that case so `ExpandMixedAdditiveOp`
  splits the operands first.
- **Scope**: registered directly in `AddOp`/`SubOp::getCanonicalizationPatterns`
  next to `ExpandMixedAdditiveOp<>` rather than via
  `PRIME_IR_FIELD_*_DISTRIBUTIVITY_PATTERN_LIST`, since that macro list
  is consumed by the ModArith dialect too and there is no current
  ModArith consumer for this fold.
- **Monotonicity**: no reverse pattern (`to_mont(add) -> add(to_mont, to_mont)`)
  exists in the dialect; the greedy driver cannot cycle.

### Test

`tests/Dialect/Field/field_canonicalize.mlir` — 6 FileCheck fixtures:
- scalar add positive / scalar sub positive / tensor positive
- multi-use guard (does not fire)
- partial single-use (does fire)
- mixed operand (does not fire)

Full `//tests/Dialect/Field/... //tests/Dialect/ModArith/...` (69 tests) passes.

## Related Issues/PRs

Surfaced by riscv-witness's `chip.is_zero` + `chip.is_nonzero` pair
canonicalize work (upcoming PR): that pair bridges to Field form as
`field.sub %one, %to_mont(nonzero)`, and this fold is what collapses
the redundant `to_mont` chain once the pair canonicalize lands.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline