### PR TITLE
fix(field): fold bitcast of constant operand into typed constant

### DIFF
--- a/prime_ir/Dialect/Field/IR/FieldOps.cpp
+++ b/prime_ir/Dialect/Field/IR/FieldOps.cpp
@@ -332,10 +332,33 @@ Operation *FieldDialect::materializeConstant(OpBuilder &builder,
   if (auto boolAttr = dyn_cast<BoolAttr>(value)) {
     return builder.create<arith::ConstantOp>(loc, boolAttr);
   } else if (auto denseElementsAttr = dyn_cast<DenseIntElementsAttr>(value)) {
+    auto elementType = getElementTypeOrSelf(type);
     if (!isa<PrimeFieldType, BinaryFieldType, ExtensionFieldType>(
-            getElementTypeOrSelf(type))) {
+            elementType)) {
       // This could be a folding result of CmpOp.
       return builder.create<arith::ConstantOp>(loc, denseElementsAttr);
+    }
+    // For ExtensionFieldType, parseFieldConstant requires the value attribute
+    // shape to be [type.getShape()..., efType.getAttrShape()...] for tensor
+    // types and [efType.getAttrShape()...] for scalar types. Reject
+    // pass-through attributes (e.g. from a bitcast fold) that don't match;
+    // the fold framework then reverts and leaves the bitcast in place for
+    // field-to-llvm to lower as a runtime memref reinterpret.
+    if (auto efType = dyn_cast<ExtensionFieldType>(elementType)) {
+      SmallVector<int64_t> expectedShape;
+      if (auto shapedType = dyn_cast<ShapedType>(type)) {
+        if (!shapedType.hasRank()) {
+          return nullptr;
+        }
+        expectedShape.append(shapedType.getShape().begin(),
+                             shapedType.getShape().end());
+      }
+      auto towerDims = efType.getAttrShape();
+      expectedShape.append(towerDims.begin(), towerDims.end());
+      if (denseElementsAttr.getType().getShape() !=
+          ArrayRef<int64_t>(expectedShape)) {
+        return nullptr;
+      }
     }
   }
   return ConstantOp::materialize(builder, value, type, loc);

--- a/prime_ir/Dialect/ModArith/IR/ModArithOps.cpp
+++ b/prime_ir/Dialect/ModArith/IR/ModArithOps.cpp
@@ -333,18 +333,7 @@ Operation *ModArithDialect::materializeConstant(OpBuilder &builder,
 }
 
 OpFoldResult BitcastOp::fold(FoldAdaptor adaptor) {
-  OpFoldResult result = foldBitcast(*this, adaptor);
-  if (result)
-    return result;
-
-  // Fold constant bitcast.
-  // Bitcasting a constant is a no-op since only the type interpretation
-  // changes, not the underlying data.
-  if (isa_and_present<IntegerAttr>(adaptor.getInput()) ||
-      isa_and_present<DenseIntElementsAttr>(adaptor.getInput())) {
-    return adaptor.getInput();
-  }
-  return {};
+  return foldBitcast(*this, adaptor);
 }
 
 LogicalResult BitcastOp::canonicalize(BitcastOp op, PatternRewriter &rewriter) {

--- a/prime_ir/Utils/BitcastOpUtils.h
+++ b/prime_ir/Utils/BitcastOpUtils.h
@@ -117,7 +117,7 @@ OpFoldResult foldBitcast(BitcastOpT op,
   } else if (auto denseAttr =
                  dyn_cast_if_present<DenseIntElementsAttr>(input)) {
     auto outputShaped = dyn_cast<ShapedType>(outputType);
-    if (outputShaped &&
+    if (outputShaped && outputShaped.hasRank() &&
         denseAttr.getType().getShape() == outputShaped.getShape()) {
       return denseAttr;
     }

--- a/prime_ir/Utils/BitcastOpUtils.h
+++ b/prime_ir/Utils/BitcastOpUtils.h
@@ -74,6 +74,13 @@ LogicalResult canonicalizeBitcast(BitcastOpT op, PatternRewriter &rewriter) {
 // This function performs common bitcast folding optimizations:
 // 1. Fold bitcast with same input and output types
 // 2. Fold bitcast(bitcast(x)) -> x when final type matches original type
+// 3. Fold bitcast of a constant operand into a constant of the output type
+//    (raw bits preserved). Gated on the input attribute's shape matching
+//    the output type's shape directly so the dialect's materializeConstant
+//    hook can stamp it without reshape. Holds for IntegerType / PrimeField
+//    / BinaryField / ModArith outputs but NOT for ExtensionField, whose
+//    field.constant value attribute carries tower dimensions appended to
+//    the type's shape.
 //
 // Template parameters:
 // - BitcastOpT: The bitcast operation type (e.g., field::BitcastOp,
@@ -95,6 +102,24 @@ OpFoldResult foldBitcast(BitcastOpT op,
   if (auto inputBitcast = op.getInput().template getDefiningOp<BitcastOpT>()) {
     if (inputBitcast.getInput().getType() == op.getOutput().getType()) {
       return inputBitcast.getInput();
+    }
+  }
+
+  // Fold bitcast of a constant operand. BitcastOp::verify already enforces
+  // matching storage widths, so the raw bits are reinterpretable without
+  // conversion.
+  Attribute input = adaptor.getInput();
+  Type outputType = op.getOutput().getType();
+  if (auto intAttr = dyn_cast_if_present<IntegerAttr>(input)) {
+    if (!isa<ShapedType>(outputType)) {
+      return intAttr;
+    }
+  } else if (auto denseAttr =
+                 dyn_cast_if_present<DenseIntElementsAttr>(input)) {
+    auto outputShaped = dyn_cast<ShapedType>(outputType);
+    if (outputShaped &&
+        denseAttr.getType().getShape() == outputShaped.getShape()) {
+      return denseAttr;
     }
   }
 

--- a/tests/Dialect/Field/field_canonicalize.mlir
+++ b/tests/Dialect/Field/field_canonicalize.mlir
@@ -1317,3 +1317,76 @@ func.func @test_add_of_to_mont_mixed_no_fold(%arg0: !PF17, %arg1: !PF17m) -> !PF
   %1 = field.add %0, %arg1 : !PF17m
   return %1 : !PF17m
 }
+
+//===----------------------------------------------------------------------===//
+// BitcastOp constant folding
+//===----------------------------------------------------------------------===//
+
+// Tensor: bitcast(arith.constant : tensor<2xi32>) -> tensor<2x!PF17> folds to
+// a single field.constant of the same raw bits.
+// CHECK-LABEL: @test_bitcast_from_int_to_pf_fold
+// CHECK-SAME: () -> [[T:.*]] {
+func.func @test_bitcast_from_int_to_pf_fold() -> tensor<2x!PF17> {
+  // CHECK: %[[C:.*]] = field.constant dense<[2, 3]> : [[T]]
+  // CHECK-NOT: field.bitcast
+  // CHECK: return %[[C]] : [[T]]
+  %0 = arith.constant dense<[2, 3]> : tensor<2xi32>
+  %1 = field.bitcast %0 : tensor<2xi32> -> tensor<2x!PF17>
+  return %1 : tensor<2x!PF17>
+}
+
+// Reverse direction: bitcast(field.constant : tensor<2x!PF17>) -> tensor<2xi32>
+// folds to an arith.constant with the same raw bits.
+// CHECK-LABEL: @test_bitcast_from_pf_to_int_fold
+// CHECK-SAME: () -> [[T:.*]] {
+func.func @test_bitcast_from_pf_to_int_fold() -> tensor<2xi32> {
+  // CHECK: %[[C:.*]] = arith.constant dense<[2, 3]> : [[T]]
+  // CHECK-NOT: field.bitcast
+  // CHECK: return %[[C]] : [[T]]
+  %0 = field.constant dense<[2, 3]> : tensor<2x!PF17>
+  %1 = field.bitcast %0 : tensor<2x!PF17> -> tensor<2xi32>
+  return %1 : tensor<2xi32>
+}
+
+// Scalar IntegerAttr operand: bitcast(arith.constant : i32) -> !PF17 folds to
+// a scalar field.constant.
+// CHECK-LABEL: @test_bitcast_scalar_int_to_pf_fold
+// CHECK-SAME: () -> [[T:.*]] {
+func.func @test_bitcast_scalar_int_to_pf_fold() -> !PF17 {
+  // CHECK: %[[C:.*]] = field.constant 5 : [[T]]
+  // CHECK-NOT: field.bitcast
+  // CHECK: return %[[C]] : [[T]]
+  %0 = arith.constant 5 : i32
+  %1 = field.bitcast %0 : i32 -> !PF17
+  return %1 : !PF17
+}
+
+// Mont-encoded target: the materialized field.constant stores the input
+// attribute's raw bits — no canonical->Mont conversion at fold time.
+// CHECK-LABEL: @test_bitcast_int_to_pf_mont_fold
+// CHECK-SAME: () -> [[T:.*]] {
+func.func @test_bitcast_int_to_pf_mont_fold() -> tensor<2x!PF17m> {
+  // CHECK: %[[C:.*]] = field.constant dense<[2, 3]> : [[T]]
+  // CHECK-NOT: field.bitcast
+  // CHECK: return %[[C]] : [[T]]
+  %0 = arith.constant dense<[2, 3]> : tensor<2xi32>
+  %1 = field.bitcast %0 : tensor<2xi32> -> tensor<2x!PF17m>
+  return %1 : tensor<2x!PF17m>
+}
+
+// Extension-field target: the constant fold MUST NOT fire because the
+// field.constant attribute for tensor<Mx!EF<DxBase>> is shaped [M, D, ...]
+// (tower dims appended), not the bitcast's flat [M*D*...]. A pass-through
+// fold would produce an ill-formed constant. The bitcast must remain so
+// field-to-llvm can lower it as a runtime memref reinterpret.
+!EF2_17 = !field.ef<2x!PF17, 11:i32>
+// CHECK-LABEL: @test_bitcast_int_to_ef_no_fold
+// CHECK-SAME: () -> [[T:.*]] {
+func.func @test_bitcast_int_to_ef_no_fold() -> tensor<1x!EF2_17> {
+  // CHECK: %[[C:.*]] = arith.constant dense<[2, 3]> : tensor<2xi32>
+  // CHECK: %[[BC:.*]] = field.bitcast %[[C]] : tensor<2xi32> -> [[T]]
+  // CHECK: return %[[BC]] : [[T]]
+  %0 = arith.constant dense<[2, 3]> : tensor<2xi32>
+  %1 = field.bitcast %0 : tensor<2xi32> -> tensor<1x!EF2_17>
+  return %1 : tensor<1x!EF2_17>
+}

--- a/tests/Dialect/Field/field_canonicalize.mlir
+++ b/tests/Dialect/Field/field_canonicalize.mlir
@@ -1390,3 +1390,21 @@ func.func @test_bitcast_int_to_ef_no_fold() -> tensor<1x!EF2_17> {
   %1 = field.bitcast %0 : tensor<2xi32> -> tensor<1x!EF2_17>
   return %1 : tensor<1x!EF2_17>
 }
+
+// Element-wise EF where input and output shapes coincidentally agree:
+// `tensor<1xi64>` and `tensor<1x!EF2_17>` both have shape [1] and 64 bits
+// total. The template's shape gate matches, so the fold tries to materialize
+// `field.constant dense<...> : tensor<1x!EF2_17>` with attribute shape [1]
+// — but field.constant for EF requires attribute shape [1, 2] (tower dims
+// appended). FieldDialect::materializeConstant detects the mismatch and
+// returns nullptr, reverting the fold so the bitcast stays for field-to-llvm.
+// CHECK-LABEL: @test_bitcast_element_wise_int_to_ef_no_fold
+// CHECK-SAME: () -> [[T:.*]] {
+func.func @test_bitcast_element_wise_int_to_ef_no_fold() -> tensor<1x!EF2_17> {
+  // CHECK: %[[C:.*]] = arith.constant dense<42> : tensor<1xi64>
+  // CHECK: %[[BC:.*]] = field.bitcast %[[C]] : tensor<1xi64> -> [[T]]
+  // CHECK: return %[[BC]] : [[T]]
+  %0 = arith.constant dense<42> : tensor<1xi64>
+  %1 = field.bitcast %0 : tensor<1xi64> -> tensor<1x!EF2_17>
+  return %1 : tensor<1x!EF2_17>
+}


### PR DESCRIPTION
## Description

`field::BitcastOp::fold` was missing the constant-operand case that
`mod_arith::BitcastOp::fold` already handled inline, so a
`field.bitcast(arith.constant : tensor<NxiW>) : tensor<Nx!pf>` chain survived
canonicalization with the bitcast unfolded. This blocked downstream constant
propagation through prime_ir, which in turn forced fractalyze/stablehlo#71 to
add a temporary lift-side fast-path emitting `field.constant` directly from
`stablehlo.bitcast_convert(stablehlo.constant)`.

This PR moves the constant-fold case into the shared `foldBitcast` template in
`prime_ir/Utils/BitcastOpUtils.h` so both `field` and `mod_arith` pick it up
from one place, then collapses `mod_arith::BitcastOp::fold` to a one-line
delegate. The fold returns the input attribute as-is and lets the dialect's
`materializeConstant` hook stamp it with the output type — `BitcastOp::verify`
already enforces matching storage widths, so the raw bits are reinterpretable
without conversion.

A shape gate skips `ExtensionFieldType` outputs whose `field.constant` value
attribute carries tower dimensions appended to the shape — for example,
`tensor<1x!field.ef<3x!field.ef<2x!field.pf<7>, 6>, 2>>` requires attribute
shape `[1, 3, 2]`, not the flat `[6]` that a `tensor<6xi32>` operand would
supply. Without the gate, the materialized constant fails verification, as
caught by `bitcast_roundtrip_runner` during full-suite testing.

New lit tests in `tests/Dialect/Field/field_canonicalize.mlir` cover:

- `bitcast(arith.constant) : tensor<NxiW> -> tensor<Nx!pf>` folds
- `bitcast(field.constant) : tensor<Nx!pf> -> tensor<NxiW>` folds
- scalar `IntegerAttr` operand folds
- Mont-encoded `!pf` target preserves raw bits (no canonical→Mont conversion
  at fold time)
- `!field.ef` target does NOT fold (regression guard for the shape gate;
  surfaced by `bitcast_roundtrip_runner` during initial testing)

Note on the proposed implementation in #317: that snippet builds a new
`DenseElementsAttr::getFromRawBuffer` of the output type. This PR takes a
simpler path — return the input attribute and let `materializeConstant` do the
type stamping — because (a) it works uniformly for scalar `IntegerAttr` and
shaped `DenseIntElementsAttr`, (b) it mirrors `mod_arith::BitcastOp::fold`'s
existing pattern, and (c) it doesn't add a raw-buffer dependency on the input
attribute kind. The shape gate is the only piece needed to avoid the EF
attribute-shape pitfall.

## Related Issues/PRs

Fixes #317. Unblocks the cleanup of the temporary lift-side fast-path in
`StablehloToPrimeIR::ConvertFieldBitcastConvert` (fractalyze/stablehlo#71).

## Test plan

- [x] \`bazel test //tests/Dialect/Field/... //tests/Dialect/ModArith/...\` —
  all 69 tests PASS (was 67/69 before the shape gate; \`bitcast_runner\` +
  \`bitcast_roundtrip_runner\` regressed without it)
- [x] \`bazel test //tests/...\` — all relevant tests PASS; the only failure
  is \`pairing_check_4pairs_runner\` hitting the hard 900s timeout (unrelated;
  sibling \`pairing_check_runner\` with 1 pairing took 677s, so 4 pairings
  exceeding 900s under load is expected and pre-existing — no recent commits
  touch this test or its lowering path)
- [x] pre-commit clean (clang-format, cpplint, codespell, EOF fixer)

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline