### PR TITLE
feat(field): extend `to_mont` known-bit cover with `arith.subi(c1, bit)` boolean-NOT idiom

### DIFF
--- a/prime_ir/Dialect/Field/IR/FieldOps.cpp
+++ b/prime_ir/Dialect/Field/IR/FieldOps.cpp
@@ -2119,6 +2119,19 @@ bool isProvablyOneBit(Value value, int depth) {
         return isProvablyOneBit(op.getLhs(), depth + 1) &&
                isProvablyOneBit(op.getRhs(), depth + 1);
       })
+      .Case<arith::SubIOp>([depth](arith::SubIOp op) {
+        // `subi(1, x) = 1 - x ∈ {0, 1}` iff `x ∈ {0, 1}`. The boolean-NOT
+        // idiom written as `c1 - bit` (vs `xor(bit, c1)`) survives MLIR
+        // canonicalize, so we cover it here. Other lhs constants do not
+        // fold: `subi(0, bit) ∈ {0, -1}` (negation), `subi(c, bit)` for
+        // c > 1 grows above 1. Asymmetric — only the lhs-is-1 form qualifies.
+        APInt cst;
+        if (!matchPattern(op.getLhs(), m_ConstantInt(&cst)))
+          return false;
+        if (!cst.isOne())
+          return false;
+        return isProvablyOneBit(op.getRhs(), depth + 1);
+      })
       .Case<arith::ExtUIOp>([depth](arith::ExtUIOp op) {
         return isProvablyOneBit(op.getIn(), depth + 1);
       })

--- a/tests/Dialect/Field/field_canonicalize.mlir
+++ b/tests/Dialect/Field/field_canonicalize.mlir
@@ -1466,6 +1466,62 @@ func.func @test_to_mont_of_opaque_int_no_fold(%arg0: i32) -> !PF251m {
   return %fmnt : !PF251m
 }
 
+// `subi(%c1, %bit) = 1 - bit` is boolean NOT written in subtraction form —
+// `1 - 0 = 1`, `1 - 1 = 0`. MLIR canonicalize does not rewrite this to
+// `xori(%bit, %c1)`, so the bit-source recognizer must cover it directly.
+// CHECK-LABEL: @test_to_mont_of_subi_one_minus_bit_folds
+// CHECK-SAME: (%[[ARG:.*]]: i1) -> [[TM:.*]] {
+func.func @test_to_mont_of_subi_one_minus_bit_folds(%arg0: i1) -> !PF251m {
+  // CHECK-NOT: field.to_mont
+  // CHECK: field.bitcast {{.*}} : i32 -> [[TM]]
+  %c1 = arith.constant 1 : i32
+  %bit = arith.extui %arg0 : i1 to i32
+  %neg = arith.subi %c1, %bit : i32
+  %fstd = field.bitcast %neg : i32 -> !PF251
+  %fmnt = field.to_mont %fstd : !PF251m
+  return %fmnt : !PF251m
+}
+
+// `subi(%c2, %bit)` is `∈ {1, 2}`, not `{0, 1}`. The fold must NOT fire.
+// CHECK-LABEL: @test_to_mont_of_subi_two_minus_bit_no_fold
+// CHECK-SAME: (%[[ARG:.*]]: i1) -> [[TM:.*]] {
+func.func @test_to_mont_of_subi_two_minus_bit_no_fold(%arg0: i1) -> !PF251m {
+  // CHECK: field.to_mont
+  %c2 = arith.constant 2 : i32
+  %bit = arith.extui %arg0 : i1 to i32
+  %v = arith.subi %c2, %bit : i32
+  %fstd = field.bitcast %v : i32 -> !PF251
+  %fmnt = field.to_mont %fstd : !PF251m
+  return %fmnt : !PF251m
+}
+
+// `subi(%bit, %c1)` is `∈ {-1, 0}`, not `{0, 1}` — the lhs must be the
+// constant 1, not the rhs (asymmetric; mirrors the `xori(c1, bit)` /
+// `xori(bit, c1)` symmetry vs the `subi` non-symmetry).
+// CHECK-LABEL: @test_to_mont_of_subi_bit_minus_one_no_fold
+// CHECK-SAME: (%[[ARG:.*]]: i1) -> [[TM:.*]] {
+func.func @test_to_mont_of_subi_bit_minus_one_no_fold(%arg0: i1) -> !PF251m {
+  // CHECK: field.to_mont
+  %c1 = arith.constant 1 : i32
+  %bit = arith.extui %arg0 : i1 to i32
+  %v = arith.subi %bit, %c1 : i32
+  %fstd = field.bitcast %v : i32 -> !PF251
+  %fmnt = field.to_mont %fstd : !PF251m
+  return %fmnt : !PF251m
+}
+
+// `subi(%c1, %opaque)` has unbounded range — the rhs must also be bit.
+// CHECK-LABEL: @test_to_mont_of_subi_one_minus_opaque_no_fold
+// CHECK-SAME: (%[[ARG:.*]]: i32) -> [[TM:.*]] {
+func.func @test_to_mont_of_subi_one_minus_opaque_no_fold(%arg0: i32) -> !PF251m {
+  // CHECK: field.to_mont
+  %c1 = arith.constant 1 : i32
+  %v = arith.subi %c1, %arg0 : i32
+  %fstd = field.bitcast %v : i32 -> !PF251
+  %fmnt = field.to_mont %fstd : !PF251m
+  return %fmnt : !PF251m
+}
+
 //===----------------------------------------------------------------------===//
 // BitcastOp constant folding
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## Summary

Extends the `field.to_mont` 1-bit-operand canonicalize cover (added in
#319) to recognise the `c1 - bit` form of boolean-NOT, in addition to
the `xor(bit, c1)` form #319 already covers.

Without this case, real-world MLIR producers that emit `is_zero(x) → 1 -
is_nonzero(x)` (e.g. riscv-witness's `is_zero_word_operation` filler)
leave the `field.to_mont` op un-folded — MLIR's built-in `arith`
canonicalize does **not** rewrite `subi(c1, x)` to `xori(x, c1)` (only
`subi(x, x) → 0` and `subi(x, 0) → x` are folded), so the bit-source
recogniser has to learn the shape directly.

## Why asymmetric

`subi(a, b)` only stays in `{0, 1}` for `lhs = 1`:

| a | b | `subi(a, b)` | in `{0, 1}`? |
|---|---|--------------|----|
| 1 | 0 |  1 | ✓ |
| 1 | 1 |  0 | ✓ |
| 0 | 0 |  0 | ✓ (degenerate) |
| 0 | 1 | -1 | ✗ — rules out `lhs = 0` |
| 2 | 0 |  2 | ✗ — rules out `lhs > 1` |

So `lhs` must be the constant `1`, and `rhs` must be provably 1-bit.
The symmetric AndI cover (either operand being a bit is enough) does
**not** generalise here — `subi(bit, c1) ∈ {-1, 0}` and `subi(bit_a,
bit_b) ∈ {-1, 0, 1}` both leave the `{0, 1}` invariant.

## Validation

- 4 new lit tests in `field_canonicalize.mlir`:
  - `test_to_mont_of_subi_one_minus_bit_folds` — positive
  - `test_to_mont_of_subi_two_minus_bit_no_fold` — lhs > 1 rejected
  - `test_to_mont_of_subi_bit_minus_one_no_fold` — lhs not constant rejected
  - `test_to_mont_of_subi_one_minus_opaque_no_fold` — rhs not bit rejected
- Full `tests/Dialect/Field/` lit suite (69 tests): PASS.
- Cross-checked downstream in riscv-witness2 with `--override_repository`:
  `load_half_test`, `addw_test`, `keccak_permute_flags_test` byte-identical
  to the in-repo `field-bit-to-mont-fold` baseline.

## Test plan

- [x] `bazel test //tests/Dialect/Field/...`
- [x] Downstream byte-id on the three filler tests listed above
- [ ] (post-merge) bump prime_ir pin in riscv-witness2 and drop the in-repo
  `field_bit_to_mont_fold` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
