### PR TITLE
feat(mod_arith): lower wide non-Mersenne mul via Barrett reduction

### DIFF
--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/BUILD.bazel
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/BUILD.bazel
@@ -31,6 +31,7 @@ prime_ir_cc_library(
         "//prime_ir/Dialect/EllipticCurve/IR:EllipticCurve",
         "//prime_ir/Dialect/Field/IR:Field",
         "//prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Inverter:BYInverter",
+        "//prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer:BarrettReducer",
         "//prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer:MontReducer",
         "//prime_ir/Dialect/ModArith/IR:ModArith",
         "//prime_ir/Dialect/TensorExt/IR:TensorExt",

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -46,6 +46,7 @@ limitations under the License.
 #include "prime_ir/Dialect/EllipticCurve/IR/EllipticCurveOps.h"
 #include "prime_ir/Dialect/Field/IR/FieldOps.h"
 #include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Inverter/BYInverter.h"
+#include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BarrettReducer.h"
 #include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithDialect.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithOperation.h"
@@ -1015,6 +1016,22 @@ struct ConvertMul : public OpConversionPattern<MulOp> {
       return success();
     }
 
+    // Barrett path for wide non-Mersenne primes. The Mersenne branch below
+    // (p = 2^k - 1) keeps precedence — its shift+add is faster than Barrett.
+    // Below 64 bits, hardware urem is a single instruction and wins anyway.
+    // The `!modulus.isPowerOf2()` guard is defensive: the type parser rejects
+    // power-of-two moduli today, but if the dialect ever supports binary
+    // fields, their storage is `log2(p)` bits — narrower than
+    // `modulus.getBitWidth()` — which would break the reducer's
+    // `2k == extBitWidth` precondition.
+    if (modulus.getBitWidth() >= 64 && !(modulus + 1).isPowerOf2() &&
+        !modulus.isPowerOf2()) {
+      auto result =
+          b.create<BarrettMulOp>(op.getType(), op.getLhs(), op.getRhs());
+      rewriter.replaceOp(op, result);
+      return success();
+    }
+
     auto cmodExt =
         b.create<arith::ConstantOp>(modulusAttr(op, /*extended=*/true));
     Type wideType = modulusType(op, /*extended=*/true);
@@ -1138,6 +1155,28 @@ struct ConvertMontMul : public BoundMapPattern<MontMulOp> {
     }
 
     Value result = reducer.reduce(lo, hi, /*lazy=*/resBound >= 2);
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+struct ConvertBarrettMul : public OpConversionPattern<BarrettMulOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(BarrettMulOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+
+    ModArithType modType = getResultModArithType(op);
+    if (modType.isMontgomery()) {
+      return op->emitError(
+          "BarrettMulOp with Montgomery type is not supported in "
+          "ModArithToArith conversion");
+    }
+
+    BarrettReducer reducer(b, modType);
+    Value result = reducer.reduce(adaptor.getLhs(), adaptor.getRhs());
     rewriter.replaceOp(op, result);
     return success();
   }
@@ -1492,6 +1531,7 @@ void ModArithToArith::runOnOperation() {
   // Patterns that don't use BoundMap.
   patterns.add<
       // clang-format off
+      ConvertBarrettMul,
       ConvertBitcast,
       ConvertConstant,
       ConvertFromMont,

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BUILD.bazel
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BUILD.bazel
@@ -32,3 +32,17 @@ prime_ir_cc_library(
         "@llvm-project//mlir:TensorDialect",
     ],
 )
+
+prime_ir_cc_library(
+    name = "BarrettReducer",
+    srcs = ["BarrettReducer.cpp"],
+    hdrs = ["BarrettReducer.h"],
+    deps = [
+        "//prime_ir/Dialect/ModArith/IR:ModArith",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+    ],
+)

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BarrettReducer.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BarrettReducer.cpp
@@ -1,0 +1,126 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BarrettReducer.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "prime_ir/Dialect/ModArith/IR/ModArithTypes.h" // IWYU pragma: keep
+
+namespace mlir::prime_ir::mod_arith {
+
+namespace {
+
+// Create a splat constant that works for both static and dynamic tensor
+// shapes. Duplicates the helper in MontReducer.cpp; consolidate once a third
+// reducer needs it.
+Value createSplatConst(ImplicitLocOpBuilder &b, TypedAttr scalarAttr,
+                       ShapedType shapedType, Value shapeRef) {
+  if (shapedType.hasStaticShape()) {
+    return b.create<arith::ConstantOp>(
+        SplatElementsAttr::get(shapedType, scalarAttr));
+  }
+  assert(shapeRef &&
+         "A shape reference value must be provided for dynamic shapes.");
+  Value scalar = b.create<arith::ConstantOp>(scalarAttr);
+  SmallVector<Value> dynamicDims;
+  for (int64_t i = 0; i < shapedType.getRank(); ++i) {
+    if (shapedType.isDynamicDim(i)) {
+      auto idx = b.create<arith::ConstantIndexOp>(i);
+      dynamicDims.push_back(b.create<tensor::DimOp>(shapeRef, idx));
+    }
+  }
+  Value empty = b.create<tensor::EmptyOp>(shapedType, dynamicDims);
+  return b.create<linalg::FillOp>(scalar, empty).getResult(0);
+}
+
+} // namespace
+
+BarrettReducer::BarrettReducer(ImplicitLocOpBuilder &b,
+                               ModArithType modArithType)
+    : b(b), modAttr(modArithType.getModulus()) {
+  BarrettAttr barrettAttr = modArithType.getBarrettAttr();
+  muAttr = barrettAttr.getMu();
+  extBitWidth = barrettAttr.getExtBitWidth();
+}
+
+Value BarrettReducer::createExtModulusConst(Type inputType, Value inputValue) {
+  // Build a 2k-bit-typed copy of the modulus, then splat to shaped if needed.
+  IntegerType extScalar = IntegerType::get(b.getContext(), extBitWidth);
+  IntegerAttr extModAttr =
+      IntegerAttr::get(extScalar, modAttr.getValue().zext(extBitWidth));
+  if (auto shapedType = dyn_cast<ShapedType>(inputType)) {
+    auto shapedExt =
+        cast<ShapedType>(shapedType.cloneWith(std::nullopt, extScalar));
+    return createSplatConst(b, extModAttr, shapedExt, inputValue);
+  }
+  return b.create<arith::ConstantOp>(extModAttr);
+}
+
+Value BarrettReducer::createExtMuConst(Type inputType, Value inputValue) {
+  // muAttr is already typed at extBitWidth; splat if needed.
+  if (auto shapedType = dyn_cast<ShapedType>(inputType)) {
+    auto shapedExt =
+        cast<ShapedType>(shapedType.cloneWith(std::nullopt, muAttr.getType()));
+    return createSplatConst(b, muAttr, shapedExt, inputValue);
+  }
+  return b.create<arith::ConstantOp>(muAttr);
+}
+
+Value BarrettReducer::reduce(Value lhs, Value rhs) {
+  // Compute the 2k-bit storage type from the per-element bit width of the
+  // input. For a shaped input, reshape extScalar onto the input's shape.
+  unsigned k = cast<IntegerType>(getElementTypeOrSelf(lhs)).getWidth();
+  assert(2 * k == extBitWidth &&
+         "BarrettReducer: input bit width must match modulus storage width");
+  (void)k;
+
+  IntegerType extScalar = IntegerType::get(b.getContext(), extBitWidth);
+  Type extType = extScalar;
+  if (auto shapedType = dyn_cast<ShapedType>(lhs.getType()))
+    extType = shapedType.cloneWith(std::nullopt, extScalar);
+
+  // Lift inputs to 2k bits and multiply: prod = a * b < p² ≤ 2^(2k).
+  Value lhsExt = b.create<arith::ExtUIOp>(extType, lhs);
+  Value rhsExt = b.create<arith::ExtUIOp>(extType, rhs);
+  Value prod = b.create<arith::MulIOp>(lhsExt, rhsExt);
+
+  // q' = high_half(prod * mu), i.e. (prod * mu) >> 2k.
+  // Using arith.mului_extended avoids materializing a 4k-bit intermediate;
+  // we keep all arithmetic at 2k bits.
+  Value muConst = createExtMuConst(lhs.getType(), lhs);
+  auto prodMu = b.create<arith::MulUIExtendedOp>(prod, muConst);
+  Value qPrime = prodMu.getHigh();
+
+  // r = prod - q' * p. q' ≤ floor(prod/p), so q' * p < 2^(2k); the narrow
+  // (low-half) multiply suffices. r is in [0, 2p).
+  Value pExt = createExtModulusConst(lhs.getType(), lhs);
+  Value qp = b.create<arith::MulIOp>(qPrime, pExt);
+  Value r = b.create<arith::SubIOp>(prod, qp);
+
+  // Single conditional subtraction: if (r >= p) r -= p.
+  Value cmp = b.create<arith::CmpIOp>(arith::CmpIPredicate::uge, r, pExt);
+  Value rSub = b.create<arith::SubIOp>(r, pExt);
+  Value rCanon = b.create<arith::SelectOp>(cmp, rSub, r);
+
+  // Truncate back to k bits — rCanon is in [0, p) ⊂ [0, 2^k).
+  return b.create<arith::TruncIOp>(lhs.getType(), rCanon);
+}
+
+} // namespace mlir::prime_ir::mod_arith

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BarrettReducer.h
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BarrettReducer.h
@@ -1,0 +1,66 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef PRIME_IR_DIALECT_MODARITH_CONVERSIONS_MODARITHTOARITH_REDUCER_BARRETTREDUCER_H_
+#define PRIME_IR_DIALECT_MODARITH_CONVERSIONS_MODARITHTOARITH_REDUCER_BARRETTREDUCER_H_
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Value.h"
+#include "prime_ir/Dialect/ModArith/IR/ModArithTypes.h" // IWYU pragma: keep
+
+namespace mlir::prime_ir::mod_arith {
+
+// Helper class to perform Barrett reduction.
+// Lowers a modular multiplication `(a * b) mod p` to a sequence of arith
+// operations using a precomputed `mu = floor(2^(2k) / p)`, where `k` is the
+// modulus storage bit width.
+//
+// Algorithm (single conditional subtraction; assumes `a, b < p`):
+//   prod = a * b                       in [0, p²)
+//   q'   = high_half(prod * mu)        ≈ floor(prod / p), in [0, mu]
+//   r    = prod - q' * p               in [0, 2p)
+//   out  = (r >= p) ? r - p : r        in [0, p)
+class BarrettReducer {
+public:
+  // Constructs a BarrettReducer with the given builder and ModArithType.
+  // Extracts the modulus and Barrett parameters from the type.
+  explicit BarrettReducer(ImplicitLocOpBuilder &b, ModArithType modArithType);
+
+  // Lowers `(lhs * rhs) mod p` to arith ops and returns the canonical result
+  // (a value of `modArithType`'s storage type in `[0, p)`).
+  // Precondition: `lhs` and `rhs` are canonical (`< p`).
+  Value reduce(Value lhs, Value rhs);
+
+private:
+  // Creates an extended-width constant for the modulus, broadcasting to a
+  // shaped type when `inputType` is shaped. `inputValue` is used to recover
+  // runtime dims for dynamic-shaped tensors (mirrors MontReducer).
+  Value createExtModulusConst(Type inputType, Value inputValue = {});
+
+  // Creates an extended-width constant for `mu`, broadcasting to a shaped
+  // type when `inputType` is shaped.
+  Value createExtMuConst(Type inputType, Value inputValue = {});
+
+  ImplicitLocOpBuilder &b;
+  IntegerAttr modAttr;
+  IntegerAttr muAttr;
+  unsigned extBitWidth;
+};
+
+} // namespace mlir::prime_ir::mod_arith
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#endif // PRIME_IR_DIALECT_MODARITH_CONVERSIONS_MODARITHTOARITH_REDUCER_BARRETTREDUCER_H_

--- a/prime_ir/Dialect/ModArith/IR/ModArithAttributes.cpp
+++ b/prime_ir/Dialect/ModArith/IR/ModArithAttributes.cpp
@@ -138,6 +138,38 @@ MontgomeryAttrStorage::construct(AttributeStorageAllocator &allocator,
 
 } // namespace detail
 
+IntegerAttr BarrettAttr::getModulus() const { return getImpl()->modulus; }
+IntegerAttr BarrettAttr::getMu() const { return getImpl()->mu; }
+unsigned BarrettAttr::getExtBitWidth() const {
+  return 2 * getModulus().getType().getIntOrFloatBitWidth();
+}
+
+namespace detail {
+
+// static
+BarrettAttrStorage *
+BarrettAttrStorage::construct(AttributeStorageAllocator &allocator,
+                              KeyTy &&key) {
+  IntegerAttr modAttr = key;
+  APInt modulus = modAttr.getValue();
+  unsigned k = modulus.getBitWidth();
+  unsigned extW = 2 * k;
+
+  // mu = floor(2^(2k) / p). The numerator 2^(2k) does not fit in extW bits,
+  // so work in (extW + 1) bits and truncate. `mu` itself is at most k + 1
+  // bits, which fits in the extW-bit type used at the conversion site.
+  APInt twoToTwoK = APInt::getOneBitSet(extW + 1, extW);
+  APInt pExt = modulus.zext(extW + 1);
+  APInt muVal = twoToTwoK.udiv(pExt).trunc(extW);
+  auto extType = IntegerType::get(modAttr.getContext(), extW);
+  IntegerAttr muAttr = IntegerAttr::get(extType, muVal);
+
+  return new (allocator.allocate<BarrettAttrStorage>())
+      BarrettAttrStorage(std::move(modAttr), std::move(muAttr));
+}
+
+} // namespace detail
+
 IntegerAttr BYAttr::getModulus() const { return getImpl()->modulus; }
 IntegerAttr BYAttr::getDivsteps() const { return getImpl()->divsteps; }
 IntegerAttr BYAttr::getMInv() const { return getImpl()->mInv; }

--- a/prime_ir/Dialect/ModArith/IR/ModArithAttributes.h
+++ b/prime_ir/Dialect/ModArith/IR/ModArithAttributes.h
@@ -57,6 +57,27 @@ struct MontgomeryAttrStorage : public AttributeStorage {
   SmallVector<IntegerAttr> invTwoPowers;
 };
 
+struct BarrettAttrStorage : public AttributeStorage {
+  using KeyTy = IntegerAttr;
+
+  BarrettAttrStorage(IntegerAttr modulus, IntegerAttr mu)
+      : modulus(std::move(modulus)), mu(std::move(mu)) {}
+
+  KeyTy getAsKey() const { return KeyTy(modulus); }
+
+  bool operator==(const KeyTy &key) const { return key == KeyTy(modulus); }
+
+  static llvm::hash_code hashKey(const KeyTy &key) {
+    return llvm::hash_combine(key);
+  }
+
+  static BarrettAttrStorage *construct(AttributeStorageAllocator &allocator,
+                                       KeyTy &&key);
+
+  IntegerAttr modulus;
+  IntegerAttr mu;
+};
+
 struct BYAttrStorage : public AttributeStorage {
   using KeyTy = IntegerAttr;
 

--- a/prime_ir/Dialect/ModArith/IR/ModArithAttributes.td
+++ b/prime_ir/Dialect/ModArith/IR/ModArithAttributes.td
@@ -51,6 +51,30 @@ def ModArith_MontgomeryAttr : ModArith_Attr<"Montgomery", "montgomery"> {
   let genStorageClass = 0;
 }
 
+def ModArith_BarrettAttr : ModArith_Attr<"Barrett", "barrett"> {
+  let summary = "An attribute with precomputed Barrett reduction parameters";
+  let description = [{
+    This attribute contains the precomputed Barrett reduction parameter
+    `mu = floor(2^(2k) / p)` where `k` is the modulus storage bit-width.
+    `mu` is used by Barrett's reduction step `q ≈ floor(x * mu / 2^(2k))`,
+    producing an approximate quotient for the modular reduction of `x` by `p`
+    when `x < p²`.
+  }];
+  let parameters = (ins "IntegerAttr":$modulus);
+  let extraClassDeclaration = [{
+    // Returns `mu = floor(2^(2k) / p)`, typed as i(2k) so it can be used
+    // directly as a constant in the extended-width multiplication.
+    IntegerAttr getMu() const;
+    // Returns the extended bit width `2 * k`, where `k` is the modulus
+    // storage bit width. This is the type width used for the wide product
+    // `a * b` and the wide intermediate `prod * mu` (after shifting right
+    // by `2k`).
+    unsigned getExtBitWidth() const;
+  }];
+  let assemblyFormat = "`<`$modulus`>`";
+  let genStorageClass = 0;
+}
+
 def ModArith_BYAttr : ModArith_Attr<"BY", "by"> {
   let summary = "An attribute with precomputed Bernstein-Yang inverse parameters";
   let description = [{

--- a/prime_ir/Dialect/ModArith/IR/ModArithOps.cpp
+++ b/prime_ir/Dialect/ModArith/IR/ModArithOps.cpp
@@ -642,6 +642,12 @@ void MontMulOp::inferResultRanges(ArrayRef<ConstantIntRanges> /*argRanges*/,
   setLazyRedcRange(getResult(), setResultRange);
 }
 
+void BarrettMulOp::inferResultRanges(ArrayRef<ConstantIntRanges> /*argRanges*/,
+                                     SetIntRangeFn setResultRange) {
+  // Barrett reduction returns the canonical residue in [0, p).
+  setCanonicalRange(getResult(), setResultRange);
+}
+
 ParseResult ConstantOp::parse(OpAsmParser &parser, OperationState &result) {
   SmallVector<APInt> parsedInts;
   Type parsedType;

--- a/prime_ir/Dialect/ModArith/IR/ModArithOps.td
+++ b/prime_ir/Dialect/ModArith/IR/ModArithOps.td
@@ -337,4 +337,24 @@ def ModArith_MontMulOp : ModArith_BinaryOp<"mont_mul", [Commutative]> {
   let hasFolder = 1;
 }
 
+def ModArith_BarrettMulOp : ModArith_BinaryOp<"barrett_mul", [Commutative]> {
+  let summary = "Modular multiplication via Barrett reduction";
+  let description = [{
+    Computes `a * b mod q` using Barrett's reduction. Both operands and the
+    result are in the standard (non-Montgomery) domain. The lowering uses a
+    precomputed `mu = floor(2^(2k) / q)` (where `k` is the modulus storage
+    bit-width) to approximate the quotient, followed by a single conditional
+    subtraction.
+
+    Inputs are assumed to be canonical representatives (`< q`); under that
+    assumption the post-Barrett residue is in `[0, 2q)` and a single
+    conditional subtraction suffices to canonicalize it.
+
+    Example:
+    ```
+    %r = mod_arith.barrett_mul %a, %b : !mod_arith.int<...:i256>
+    ```
+  }];
+}
+
 #endif  // PRIME_IR_DIALECT_MODARITH_IR_MODARITHOPS_TD_

--- a/prime_ir/Dialect/ModArith/IR/ModArithTypes.td
+++ b/prime_ir/Dialect/ModArith/IR/ModArithTypes.td
@@ -82,6 +82,9 @@ def ModArith_ModArithType : ModArith_Type<"ModArith", "int", [
     BYAttr getBYAttr() const {
       return BYAttr::get(getContext(), getModulus());
     }
+    BarrettAttr getBarrettAttr() const {
+      return BarrettAttr::get(getContext(), getModulus());
+    }
     IntegerType getStorageType() const {
       APInt mod = getModulus().getValue();
       if (mod.isPowerOf2()) {

--- a/tests/Dialect/ModArith/barrett_mul.mlir
+++ b/tests/Dialect/ModArith/barrett_mul.mlir
@@ -1,0 +1,166 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// RUN: prime-ir-opt -mod-arith-to-arith -split-input-file %s | FileCheck %s -enable-var-scope
+
+// p64 = 2^64 - 59 (largest 64-bit prime). Chosen to exercise the
+// "modulus uses every bit of storage" case where mu fits in k+1 bits.
+// mu = floor(2^128 / p64) = 18446744073709551675.
+!Zp64 = !mod_arith.int<18446744073709551557 : i64>
+!Zp64v = tensor<4x!Zp64>
+
+// CHECK-LABEL: @test_lower_barrett_mul_scalar
+// CHECK-SAME: (%[[LHS:.*]]: i64, %[[RHS:.*]]: i64) -> i64
+func.func @test_lower_barrett_mul_scalar(%lhs : !Zp64, %rhs : !Zp64) -> !Zp64 {
+  // CHECK-NOT: mod_arith.barrett_mul
+  // CHECK-DAG: %[[L:.*]] = arith.extui %[[LHS]] : i64 to i128
+  // CHECK-DAG: %[[R:.*]] = arith.extui %[[RHS]] : i64 to i128
+  // CHECK: %[[PROD:.*]] = arith.muli %[[L]], %[[R]] : i128
+  // CHECK: %[[MU:.*]] = arith.constant 18446744073709551675 : i128
+  // CHECK: %{{.*}}, %[[Q:.*]] = arith.mului_extended %[[PROD]], %[[MU]] : i128
+  // CHECK: %[[P:.*]] = arith.constant 18446744073709551557 : i128
+  // CHECK: %[[QP:.*]] = arith.muli %[[Q]], %[[P]] : i128
+  // CHECK: %[[R0:.*]] = arith.subi %[[PROD]], %[[QP]] : i128
+  // CHECK: %[[CMP:.*]] = arith.cmpi uge, %[[R0]], %[[P]] : i128
+  // CHECK: %[[SUB:.*]] = arith.subi %[[R0]], %[[P]] : i128
+  // CHECK: %[[SEL:.*]] = arith.select %[[CMP]], %[[SUB]], %[[R0]] : i128
+  // CHECK: %[[OUT:.*]] = arith.trunci %[[SEL]] : i128 to i64
+  // CHECK: return %[[OUT]] : i64
+  %res = mod_arith.barrett_mul %lhs, %rhs : !Zp64
+  return %res : !Zp64
+}
+
+// -----
+
+!Zp64 = !mod_arith.int<18446744073709551557 : i64>
+!Zp64v = tensor<4x!Zp64>
+
+// Shaped variant: same lowering, but constants are dense splats over the
+// element shape and arith ops act on tensor<4xi128>.
+// CHECK-LABEL: @test_lower_barrett_mul_vec
+// CHECK-SAME: (%[[LHS:.*]]: tensor<4xi64>, %[[RHS:.*]]: tensor<4xi64>) -> tensor<4xi64>
+func.func @test_lower_barrett_mul_vec(%lhs : !Zp64v, %rhs : !Zp64v) -> !Zp64v {
+  // CHECK-NOT: mod_arith.barrett_mul
+  // CHECK-DAG: %[[L:.*]] = arith.extui %[[LHS]] : tensor<4xi64> to tensor<4xi128>
+  // CHECK-DAG: %[[R:.*]] = arith.extui %[[RHS]] : tensor<4xi64> to tensor<4xi128>
+  // CHECK: %[[PROD:.*]] = arith.muli %[[L]], %[[R]] : tensor<4xi128>
+  // CHECK: %[[MU:.*]] = arith.constant dense<18446744073709551675> : tensor<4xi128>
+  // CHECK: %{{.*}}, %[[Q:.*]] = arith.mului_extended %[[PROD]], %[[MU]] : tensor<4xi128>
+  // CHECK: %[[P:.*]] = arith.constant dense<18446744073709551557> : tensor<4xi128>
+  // CHECK: arith.muli %[[Q]], %[[P]] : tensor<4xi128>
+  // CHECK: arith.cmpi uge
+  // CHECK: arith.subi
+  // CHECK: arith.select
+  // CHECK: %[[OUT:.*]] = arith.trunci %{{.*}} : tensor<4xi128> to tensor<4xi64>
+  // CHECK: return %[[OUT]] : tensor<4xi64>
+  %res = mod_arith.barrett_mul %lhs, %rhs : !Zp64v
+  return %res : !Zp64v
+}
+
+// -----
+
+// BN254 base field — i256. Just check that the lowering structure is the
+// same Barrett shape; the literal value of mu is large and brittle to spell.
+!Zbn = !mod_arith.int<21888242871839275222246405745257275088696311157297823662689037894645226208583 : i256>
+
+// CHECK-LABEL: @test_lower_barrett_mul_bn254
+// CHECK-SAME: (%[[LHS:.*]]: i256, %[[RHS:.*]]: i256) -> i256
+func.func @test_lower_barrett_mul_bn254(%lhs : !Zbn, %rhs : !Zbn) -> !Zbn {
+  // CHECK-NOT: mod_arith.barrett_mul
+  // CHECK: arith.extui %[[LHS]] : i256 to i512
+  // CHECK: arith.extui %[[RHS]] : i256 to i512
+  // CHECK: arith.muli %{{.*}}, %{{.*}} : i512
+  // CHECK: arith.mului_extended %{{.*}}, %{{.*}} : i512
+  // CHECK: arith.muli %{{.*}}, %{{.*}} : i512
+  // CHECK: arith.subi %{{.*}}, %{{.*}} : i512
+  // CHECK: arith.cmpi uge, %{{.*}}, %{{.*}} : i512
+  // CHECK: arith.select
+  // CHECK: arith.trunci %{{.*}} : i512 to i256
+  %res = mod_arith.barrett_mul %lhs, %rhs : !Zbn
+  return %res : !Zbn
+}
+
+// -----
+
+// Dispatch test: a generic mod_arith.mul on a wide non-Mersenne modulus
+// must lower via Barrett, NOT via the software-urem fallback. The
+// distinguishing signal is arith.mului_extended (Barrett's `q' = high half`)
+// vs arith.remui (the urem fallback).
+!Zp64 = !mod_arith.int<18446744073709551557 : i64>
+
+// CHECK-LABEL: @test_lower_mul_dispatches_to_barrett
+func.func @test_lower_mul_dispatches_to_barrett(%lhs : !Zp64, %rhs : !Zp64) -> !Zp64 {
+  // CHECK-NOT: mod_arith.mul
+  // CHECK-NOT: arith.remui
+  // CHECK: arith.mului_extended
+  %res = mod_arith.mul %lhs, %rhs : !Zp64
+  return %res : !Zp64
+}
+
+// -----
+
+// Gate test: a small (i32) modulus must NOT take the Barrett path because
+// hardware urem on i32 is a single instruction. Expect arith.remui to remain.
+!Zp32 = !mod_arith.int<65537 : i32>
+
+// CHECK-LABEL: @test_lower_mul_small_modulus_uses_urem
+func.func @test_lower_mul_small_modulus_uses_urem(%lhs : !Zp32, %rhs : !Zp32) -> !Zp32 {
+  // CHECK-NOT: mod_arith.mul
+  // CHECK-NOT: arith.mului_extended
+  // CHECK: arith.remui
+  %res = mod_arith.mul %lhs, %rhs : !Zp32
+  return %res : !Zp32
+}
+
+// -----
+
+// Regression guard: a Mersenne-shaped modulus (p = 2^k - 1) — even when
+// stored in a >= 64-bit type — must keep using the cheaper shift+and+add
+// specialization rather than dispatching to Barrett.
+!ZpMersenne = !mod_arith.int<2147483647 : i64>
+
+// CHECK-LABEL: @test_lower_mul_mersenne_stays_specialized
+func.func @test_lower_mul_mersenne_stays_specialized(%lhs : !ZpMersenne, %rhs : !ZpMersenne) -> !ZpMersenne {
+  // CHECK-NOT: mod_arith.mul
+  // CHECK-NOT: arith.mului_extended
+  // CHECK-NOT: arith.remui
+  // CHECK: arith.shrui
+  // CHECK: arith.andi
+  // CHECK: arith.addi
+  %res = mod_arith.mul %lhs, %rhs : !ZpMersenne
+  return %res : !ZpMersenne
+}
+
+// -----
+
+// Regression guard: Montgomery-typed mul still goes to mod_arith.mont_mul,
+// not Barrett. After lowering both are gone; we check that the result type
+// uses Montgomery-shaped lowering by looking for the REDC tail (subi+minui
+// or cmpi+select on the modulus constant). The salient negative signal is
+// `arith.mului_extended` of the prod with a Barrett `mu` constant — Mont's
+// arith.mului_extended is on (a, b) directly, not on (a*b, mu).
+!ZpMont = !mod_arith.int<18446744073709551557 : i64, true>
+
+// CHECK-LABEL: @test_lower_mul_mont_type_uses_mont
+func.func @test_lower_mul_mont_type_uses_mont(%lhs : !ZpMont, %rhs : !ZpMont) -> !ZpMont {
+  // CHECK-NOT: mod_arith.mul
+  // CHECK-NOT: mod_arith.mont_mul
+  // CHECK-NOT: mod_arith.barrett_mul
+  // Mont REDC produces a single mului_extended of the operands themselves
+  // (not of the wide product), and never extends to a 2k-bit wide type.
+  // CHECK-NOT: arith.extui {{.*}} : i64 to i128
+  %res = mod_arith.mul %lhs, %rhs : !ZpMont
+  return %res : !ZpMont
+}


### PR DESCRIPTION
## Description

The existing `ConvertMul` fall-through emits `arith.remui` for any modulus that
isn't Montgomery-typed, Mersenne-shaped, or a recognized constant RHS. On wide
primes (BN254 i256, BLS12-381 i384) `remui` materializes a software-`urem` call.

This change adds Barrett reduction as a first-class lowering in the
mod_arith → arith conversion:

- `BarrettAttr` (keyed by modulus, parallel to `MontgomeryAttr` / `BYAttr`)
  precomputes `mu = floor(2^(2k) / p)` once per `ModArithType`.
- `mod_arith.barrett_mul` is added as a new op, mirroring the
  `mod_arith.mont_mul` shape so `ConvertMul` has a clean two-step dispatch:
  pick the right reduction op first, lower it second.
- `BarrettReducer` (under `Reducer/`, parallel to `MontReducer`) emits the
  reduction sequence using `arith.mului_extended` to take the high half of
  `prod * mu`. This avoids a 4k-bit intermediate type — all arithmetic stays
  at 2k bits, where LLVM's wide-int lowering is already exercised by the
  Mersenne and `urem` paths.
- For canonical inputs (`a, b < p`) Barrett's residue is in `[0, 2p)`, so a
  single conditional subtraction canonicalizes the result. The proof matches
  the `mod_arith.barrett_reduce` spec in google/heir's ModArith dialect
  ([lib/Dialect/ModArith/IR/ModArithOps.td#L204](https://github.com/google/heir/blob/4056e0821348d9979191de6fb863661400d8bbcb/lib/Dialect/ModArith/IR/ModArithOps.td#L204)).

Dispatch gate in `ConvertMul`: `bitWidth >= 64 && !(p+1).isPowerOf2()`. Small
(i32) moduli stay on hardware `remui` because it's a single instruction;
Mersenne shape keeps the cheaper shift+add specialization.

## Microbench (downstream)

Measured one-shot mul in `riscv_witness/precompiles/computes/sp1` with this
prime_ir bumped (`clang -O2`, best-of-3, 1024×256 pairs):

| Curve | urem (before) | Mont hybrid | **Barrett (this PR)** | Barrett vs Mont |
|---|---|---|---|---|
| BLS12-381 i384 | 6984 ns | 191.5 ns | **89.8 ns** | **0.47×** (Mont 2.13× slower) |
| BN254 i256 | 2960 ns | 74.4 ns | **44.0 ns** | **0.59×** (Mont 1.69× slower) |

Correctness: byte-identical output vs the Mont reference on 64 random pairs
(`memcmp` parity check inside the microbench).

## Test plan

`tests/Dialect/ModArith/barrett_mul.mlir` covers:
- Scalar + tensor lowering shape on i64 and BN254 i256
- `mod_arith.mul` dispatch crossover to Barrett at `bitWidth >= 64`
- Regression guards: small (i32) modulus stays on `remui`; Mersenne shape stays
  on shift+add; Montgomery-typed mul stays on `mont_mul`

Full `bazel test //prime_ir/... //tests/...` is green (one pre-existing slow
EllipticCurve runner times out the same way on plain `origin/main`).

## Related Issues/PRs

Followup landing: bump prime_ir pin in stablehlo / consumers, then strip `!PFm`
wrapping from the four one-shot `*_fp_mul` / `*_fp2_mul` compute kernels in
riscv-witness so they pick up the Barrett path directly.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline
