### PR TITLE
build: add visited set to MLIR hasDependencePath

### DIFF
--- a/third_party/llvm-project/affine_loop_fusion_visited_set.patch
+++ b/third_party/llvm-project/affine_loop_fusion_visited_set.patch
@@ -1,0 +1,26 @@
+--- a/mlir/lib/Dialect/Affine/Analysis/Utils.cpp
++++ b/mlir/lib/Dialect/Affine/Analysis/Utils.cpp
+@@ -480,6 +480,13 @@
+   SmallVector<std::pair<unsigned, unsigned>, 4> worklist;
+   worklist.push_back({srcId, 0});
+   Operation *dstOp = getNode(dstId)->op;
++  // Track nodes already pushed onto the worklist. The MDG is a DAG (edges
++  // respect program order), but without a visited set this DFS enumerates
++  // every path from 'srcId' to every reachable node — exponential in the
++  // number of diamond merges. With many independent memref accesses on the
++  // same buffer (e.g. fully-unrolled SIMD-like bodies), this is fatal.
++  DenseSet<unsigned> visited;
++  visited.insert(srcId);
+   // Run DFS traversal to see if 'dstId' is reachable from 'srcId'.
+   while (!worklist.empty()) {
+     auto &idAndIndex = worklist.back();
+@@ -501,7 +508,8 @@
+     // nodes that are "after" dstId in the containing block; one can't have a
+     // path to `dstId` from any of those nodes.
+     bool afterDst = dstOp->isBeforeInBlock(getNode(edge.id)->op);
+-    if (!afterDst && edge.id != idAndIndex.first)
++    if (!afterDst && edge.id != idAndIndex.first &&
++        visited.insert(edge.id).second)
+       worklist.push_back({edge.id, 0});
+   }
+   return false;

--- a/third_party/llvm-project/workspace.bzl
+++ b/third_party/llvm-project/workspace.bzl
@@ -28,6 +28,12 @@ LLVM_PATCHES = [
     # TODO(chokobole): Remove owning_memref_memset.patch once we upgrade the version of LLVM.
     # See https://github.com/llvm/llvm-project/pull/158200
     "@prime_ir//third_party/llvm-project:owning_memref_memset.patch",
+    # Add visited set to MemRefDependenceGraph::hasDependencePath. Without it
+    # the DFS path search enumerates every path through the MDG, which is
+    # exponential when many memref ops touch the same buffer (e.g. fully
+    # unrolled SIMD-like bodies). affine-loop-fusion hangs at 99% CPU on
+    # such inputs. Pending upstream submission.
+    "@prime_ir//third_party/llvm-project:affine_loop_fusion_visited_set.patch",
     # NOTE(chokobole): Patches for supporting PrimeIR Dialects.
     "@prime_ir//third_party/llvm-project:linalg_type_support.patch",
     "@prime_ir//third_party/llvm-project:tensor_type_support.patch",

--- a/tools/setup_llvm_clone.sh
+++ b/tools/setup_llvm_clone.sh
@@ -52,6 +52,7 @@ shopt -s nullglob
 patches=(
     "$patch_dir/owning_memref_free.patch"
     "$patch_dir/owning_memref_memset.patch"
+    "$patch_dir/affine_loop_fusion_visited_set.patch"
     "$patch_dir/linalg_type_support.patch"
     "$patch_dir/tensor_type_support.patch"
     "$patch_dir/vector_type_support.patch"


### PR DESCRIPTION
## Description

`MemRefDependenceGraph::hasDependencePath` (in `mlir/lib/Dialect/Affine/Analysis/Utils.cpp`) performs a DFS with an explicit worklist but **no visited set**. The MDG is a DAG (edges respect program order), so every diamond merge re-enumerates the paths through it — worst case O(2^V) in node count. With many independent memref accesses on the same buffer (e.g. fully-unrolled SIMD-like bodies that load and store from one `%state` memref between several `affine.for` loops), `affine-loop-fusion` hangs at 99% CPU indefinitely inside this function.

The patch adds a `DenseSet<unsigned>` tracking nodes already pushed to the worklist, converting the worst case to O(V+E). Behavior on inputs the pass already handled is preserved — the search still returns `true` exactly when at least one path existed.

### Reproducer

A KoalaBear-width-16 Poseidon2 permute lowered with 20 trip-16 `affine.for` loops carrying inlined `monty_reduce`, with ~1500 scalar `affine.load`/`affine.store` ops interleaved on the same `%state` memref, produced ≥120s wall (killed by timeout) at 99% CPU. With the visited set added, the same input lowers in ~28s; `affine-loop-fusion` itself drops from ∞ to ~5s; output contains the expected `vector<16xi64>` SIMD on the int-round body.

A standalone consumer (riscv-witness Poseidon2 v1 AOT) verifies the patched binary delivers bit-identical output to the scalar reference and runs ~1.5× faster on PermuteCanonical microbench (CPU governor noise; absolute v1 ns/iter consistently below scalar across all trials).

### Why this isn't fixed upstream first

The bug is present on current LLVM `main` as of 2026-05-21 (verified via raw source fetch). I plan to send the equivalent fix upstream; until that lands and we bump the LLVM pin past it, this local patch is the minimal unblock for affine-loop-fusion on the IR shapes we generate. Drop this file from `LLVM_PATCHES` once the upstream merge SHA is past the pin.

### Files

- `third_party/llvm-project/affine_loop_fusion_visited_set.patch` — the 25-line patch itself.
- `third_party/llvm-project/workspace.bzl` — registered in `LLVM_PATCHES` after `owning_memref_memset.patch`.
- `tools/setup_llvm_clone.sh` — mirror the same order for the local-clone workflow.

## Related Issues/PRs

None on the prime-ir side. Upstream LLVM PR to follow.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline