### PR TITLE
build: cache MemRefDependenceGraph edge lookups by reference

### DIFF
--- a/third_party/llvm-project/affine_dependence_path_lookup_cache.patch
+++ b/third_party/llvm-project/affine_dependence_path_lookup_cache.patch
@@ -1,0 +1,54 @@
+--- a/mlir/lib/Dialect/Affine/Analysis/Utils.cpp
++++ b/mlir/lib/Dialect/Affine/Analysis/Utils.cpp
+@@ -423,16 +423,24 @@
+ // otherwise.
+ bool MemRefDependenceGraph::hasEdge(unsigned srcId, unsigned dstId,
+                                     Value value) const {
+-  if (!outEdges.contains(srcId) || !inEdges.contains(dstId)) {
++  // Cache iterators to avoid re-hashing and (more importantly) to access the
++  // SmallVector<Edge> by reference. `DenseMap::lookup` returns the value by
++  // value; on the hot init path each call would otherwise copy the entire
++  // edge vector and immediately destroy the temporary.
++  auto outIt = outEdges.find(srcId);
++  if (outIt == outEdges.end())
+     return false;
+-  }
+-  bool hasOutEdge = llvm::any_of(outEdges.lookup(srcId), [=](const Edge &edge) {
++  auto inIt = inEdges.find(dstId);
++  if (inIt == inEdges.end())
++    return false;
++  bool hasOutEdge = llvm::any_of(outIt->second, [=](const Edge &edge) {
+     return edge.id == dstId && (!value || edge.value == value);
+   });
+-  bool hasInEdge = llvm::any_of(inEdges.lookup(dstId), [=](const Edge &edge) {
++  if (!hasOutEdge)
++    return false;
++  return llvm::any_of(inIt->second, [=](const Edge &edge) {
+     return edge.id == srcId && (!value || edge.value == value);
+   });
+-  return hasOutEdge && hasInEdge;
+ }
+ 
+ // Adds an edge from node 'srcId' to node 'dstId' for 'value'.
+@@ -494,14 +502,17 @@
+     if (idAndIndex.first == dstId)
+       return true;
+     // Pop and continue if node has no out edges, or if all out edges have
+-    // already been visited.
+-    if (!outEdges.contains(idAndIndex.first) ||
+-        idAndIndex.second == outEdges.lookup(idAndIndex.first).size()) {
++    // already been visited. Use find() so we access the SmallVector<Edge>
++    // by reference — `DenseMap::lookup` returns by value, which on this hot
++    // loop copies the edge vector (and frees the copy) on every iteration.
++    auto outEdgesIt = outEdges.find(idAndIndex.first);
++    if (outEdgesIt == outEdges.end() ||
++        idAndIndex.second == outEdgesIt->second.size()) {
+       worklist.pop_back();
+       continue;
+     }
+     // Get graph edge to traverse.
+-    const Edge edge = outEdges.lookup(idAndIndex.first)[idAndIndex.second];
++    const Edge edge = outEdgesIt->second[idAndIndex.second];
+     // Increment next output edge index for 'idAndIndex'.
+     ++idAndIndex.second;
+     // Add node at 'edge.id' to the worklist. We don't need to consider

--- a/third_party/llvm-project/workspace.bzl
+++ b/third_party/llvm-project/workspace.bzl
@@ -34,6 +34,12 @@ LLVM_PATCHES = [
     # unrolled SIMD-like bodies). affine-loop-fusion hangs at 99% CPU on
     # such inputs. Pending upstream submission.
     "@prime_ir//third_party/llvm-project:affine_loop_fusion_visited_set.patch",
+    # Cache MemRefDependenceGraph edge lookups by-reference in
+    # hasDependencePath / hasEdge. With the visited-set fix above bounding
+    # the DFS, the next dominant cost on dense MDG inputs is DenseMap::lookup
+    # returning SmallVector<Edge> by value on every iteration. Pending
+    # upstream submission.
+    "@prime_ir//third_party/llvm-project:affine_dependence_path_lookup_cache.patch",
     # NOTE(chokobole): Patches for supporting PrimeIR Dialects.
     "@prime_ir//third_party/llvm-project:linalg_type_support.patch",
     "@prime_ir//third_party/llvm-project:tensor_type_support.patch",

--- a/tools/setup_llvm_clone.sh
+++ b/tools/setup_llvm_clone.sh
@@ -48,11 +48,12 @@ fi
 
 patch_dir="$repo_root/third_party/llvm-project"
 shopt -s nullglob
-# List of patches in the order specified in workspace.bzl (lines 23-37)
+# List of patches in the order specified by LLVM_PATCHES in workspace.bzl.
 patches=(
     "$patch_dir/owning_memref_free.patch"
     "$patch_dir/owning_memref_memset.patch"
     "$patch_dir/affine_loop_fusion_visited_set.patch"
+    "$patch_dir/affine_dependence_path_lookup_cache.patch"
     "$patch_dir/linalg_type_support.patch"
     "$patch_dir/tensor_type_support.patch"
     "$patch_dir/vector_type_support.patch"


### PR DESCRIPTION
## Description

`MemRefDependenceGraph::hasDependencePath` and `MemRefDependenceGraph::hasEdge` (in `mlir/lib/Dialect/Affine/Analysis/Utils.cpp`) read the per-node edge list via `outEdges.lookup(K)` / `inEdges.lookup(K)`. `DenseMap::lookup` returns the value (here a `SmallVector<Edge, 2>`) **by value**, so every call copy-constructs the entire edge vector and immediately destroys the temporary.

With the visited-set fix in #323 bounding the DFS, this copy-and-free traffic is the next dominant cost in `affine-loop-fusion` on dense MDGs:
- `hasDependencePath` calls `lookup` **twice** per worklist iteration (once in the `size()` check, once to index the edge).
- `hasEdge` is called from `addEdge` for **every** edge inserted during MDG construction, doing one `lookup` against `outEdges` and one against `inEdges` per call.

The patch switches both functions to `outEdges.find(K)` / `inEdges.find(K)` and accesses the `SmallVector<Edge>` through the iterator by reference. `hasEdge` is also restructured to short-circuit when the out-edge scan misses, so the in-edge `any_of` is skipped on negative lookups. The DFS semantics in `hasDependencePath` are unchanged; the algorithm and visit order are identical.

### Measured impact

Reproducer: the same KoalaBear-width-16 Poseidon2 permute used to motivate #323 (20 trip-16 `affine.for` loops over a shared `%state` memref). Ran `prime-ir-opt -field-to-llvm='vectorize=true specialize-avx=true vector-size=16'` 5 times multi-core on AMD Ryzen 9 9950X:

| Pass | Baseline (n=5) | Patched (n=5) | Δ |
|---|---|---|---|
| **AffineLoopFusion** wall | 21.07s | **9.89s** | **-53%** |
| AffineScalarReplacement wall | 18.06s | 17.88s | unchanged |
| Canonicalizer wall | 2.82s | 2.81s | unchanged |
| **Total** prime-ir-opt wall | 47.17s | **35.95s** | **-24%** |

Output MLIR is byte-identical to the unpatched baseline (`diff -q` says `BYTE-IDENTICAL`). `AffineScalarReplacement` is untouched because it doesn't construct an MDG — the entire wall-time saving is attributable to the targeted change.

Downstream byte-identity tests still pass under `--override_repository=prime_ir=...`:
- `//riscv_witness/chip/collectors/sp1/event_deps:sp1_poseidon2_event_deps_test`
- `//riscv_witness/chip/combined/sp1/v1:poseidon2_test`
- `//riscv_witness/precompiles/computes/sp1:poseidon2_aot_test`

prime-ir LIT suite affine tests still pass:
- `//tests/Dialect/Field:affine`
- `//tests/Dialect/ModArith:affine`

### Top perf frames before / after

`perf record --call-graph=dwarf` baseline shows the by-value pathology:

```
8.18% hasDependencePath
  └─ 4.18% DenseMap::lookup
      └─ 3.66% SmallVector<Edge>::SmallVector(const&)
          └─ 3.29% operator=
              └─ 1.77% __memcpy_avx512
  └─ 1.55% ~SmallVector
      └─ 1.49% free
```

After the patch, those frames disappear (verified by re-running perf on the patched binary).

### Why this isn't fixed upstream first

The bug is present on current LLVM `main` (same LLVM_COMMIT as #323). I plan to send the equivalent fix upstream alongside the visited-set fix; until that lands and we bump the LLVM pin past it, this local patch is the minimal follow-on win after #323. Drop both patches from `LLVM_PATCHES` once the upstream merge SHA is past the pin.

### Follow-on work (out of scope here)

The same `lookup`-returns-by-value pattern still exists at five other call sites in `Utils.cpp` (`getIncomingMemRefAccesses`, `getOutEdgeCount`, `gatherDefiningNodes`, both `outEdges`/`inEdges` reads in `getFusedLoopNestInsertionPoint`, and the `count() > 0` + `operator[]` double-hash pattern in `removeNode`/`updateEdges`/`forEachMemRef*Edge`). They follow the same justification but are smaller wins individually; I'll roll them into the upstream LLVM PR rather than continue iterating on this prime-ir patch.

### Files

- `third_party/llvm-project/affine_dependence_path_lookup_cache.patch` — the 54-line patch itself.
- `third_party/llvm-project/workspace.bzl` — registered in `LLVM_PATCHES` immediately after `affine_loop_fusion_visited_set.patch` (same file, same dialect).
- `tools/setup_llvm_clone.sh` — mirror the same order for the local-clone workflow.

## Related Issues/PRs

Stacks on #323. Upstream LLVM PR to follow, bundling both fixes plus the follow-on call sites above.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline