### PR TITLE
chore: add GitHub issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-spec-driven-task.yml
+++ b/.github/ISSUE_TEMPLATE/01-spec-driven-task.yml
@@ -1,0 +1,119 @@
+name: "Spec-driven task"
+description: |
+  Issue created from a `/spec-driven-development` session. Bundles the spec,
+  the multi-PR plan, and relevant local knowledge so any agent or human can
+  pick the work up.
+title: "<type>(<area>): <one-line summary>"
+labels: ["area:spec-driven"]
+type: Task
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: Conventional-commit type. Drives version bump policy on merge.
+      options:
+        - feat
+        - fix
+        - perf
+        - refactor
+        - test
+        - chore
+        - ci
+        - docs
+        - build
+        - style
+    validations:
+      required: true
+
+  - type: input
+    id: area
+    attributes:
+      label: Area
+      description: Conventional-commit scope. Examples — `dialect`, `pass`, `codegen`, `lowering`.
+      placeholder: pass
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why does this exist? What problem does it solve, what motivated the spec?
+    validations:
+      required: true
+
+  - type: textarea
+    id: spec
+    attributes:
+      label: Spec
+      description: |
+        Full spec body from `/spec-driven-development`. Behavior, acceptance
+        criteria, non-goals. Inline the content here — don't link to a local
+        file that the reviewer cannot open.
+    validations:
+      required: true
+
+  - type: textarea
+    id: plan
+    attributes:
+      label: Plan
+      description: |
+        Checkbox task list, one row per planned PR. GitHub renders the
+        completion ratio in the issue header.
+      value: |
+        - [ ] PR1: …
+        - [ ] PR2: …
+    validations:
+      required: true
+
+  - type: textarea
+    id: downstream_impact
+    attributes:
+      label: Downstream impact
+      description: |
+        PrimeIR is the IR that zkx lowers through and that riscv-witness
+        consumes. Which downstream stages does this dialect/pass/codegen change
+        affect? Note IR-contract or lowering-output changes consumers must
+        absorb. Leave blank if purely internal.
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproducer (include when Type = fix)
+      description: |
+        Minimum commands or input that reproduce the bug. Use `bazel test` /
+        lit invocations, not built binary paths. Prefix file inputs with `$PWD`.
+        Leave blank for non-fix tasks.
+      render: shell
+
+  - type: textarea
+    id: knowledge
+    attributes:
+      label: Relevant knowledge
+      description: |
+        Excerpts from personal memory and links into the team wiki so other
+        agents can pick this up without your local `~/.claude/` directory.
+        Sanitize home paths, scratch dirs, and session IDs before pasting.
+      placeholder: |
+        - [[wiki/page-name]] — one-line hook
+        - Personal memo excerpt: "…"
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: |
+        Issue number or full URL of the tracking / parent issue this
+        work belongs to, if any. Same-repo form: `#1234`. Cross-repo
+        form: `https://github.com/<owner>/<repo>/issues/1234`. The
+        /workflow:create-issue skill registers the sub-issue link
+        automatically when filed via the CLI.
+      placeholder: "#1234 or https://github.com/<owner>/<repo>/issues/1234"
+
+  - type: input
+    id: milestone
+    attributes:
+      label: Milestone (if multi-PR)
+      description: "Milestone name to attach. Convention — `<area>: <feature> v<n>`."
+      placeholder: "pass: barrett-mul lowering v1"

--- a/.github/ISSUE_TEMPLATE/02-prime-ir-bug.yml
+++ b/.github/ISSUE_TEMPLATE/02-prime-ir-bug.yml
@@ -1,0 +1,69 @@
+name: "PrimeIR bug"
+description: |
+  A bug in PrimeIR itself — a dialect op verifier, a pass that miscompiles or
+  mis-folds, a bad lowering to LLVM, a crash, or a perf cliff, observed while
+  building or testing PrimeIR directly (not surfaced through a downstream
+  consumer — use the downstream-bug template for that).
+title: "fix(<area>): <symptom>"
+labels: ["area:prime-ir"]
+type: Bug
+body:
+  - type: textarea
+    id: symptom
+    attributes:
+      label: Symptom
+      description: |
+        What you see — failed verifier, wrong constant fold, miscompiled
+        lowering, crash in a pass, perf cliff.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproducer
+      description: |
+        Minimum commands. Use `bazel test` / lit (`prime-opt`) invocations, not
+        built binary paths. Prefix file inputs with `$PWD`.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: diagnostic
+    attributes:
+      label: Captured diagnostic
+      description: |
+        IR before/after the failing pass (`prime-opt` dump), the verifier
+        error, a stack trace, or a flamegraph hotspot. Do not link to scratch
+        paths or home-directory artifacts the reviewer cannot open.
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: |
+        Issue number or full URL of the tracking / parent issue this
+        work belongs to, if any. Same-repo form: `#1234`. Cross-repo
+        form: `https://github.com/<owner>/<repo>/issues/1234`. The
+        /workflow:create-issue skill registers the sub-issue link
+        automatically when filed via the CLI.
+      placeholder: "#1234 or https://github.com/<owner>/<repo>/issues/1234"
+
+  - type: input
+    id: milestone
+    attributes:
+      label: Milestone
+      description: |
+        Existing milestone name to attach this issue to. The
+        /workflow:create-issue skill checks the milestone exists
+        before applying it.
+      placeholder: "e.g. <area>: <feature> v<n>"
+
+  - type: textarea
+    id: knowledge
+    attributes:
+      label: Relevant knowledge
+      description: |
+        Wiki links to related prior bugs, design notes, personal memo excerpts.
+        Strip session IDs and absolute home paths.

--- a/.github/ISSUE_TEMPLATE/03-downstream-bug.yml
+++ b/.github/ISSUE_TEMPLATE/03-downstream-bug.yml
@@ -1,0 +1,114 @@
+name: "Downstream bug (zkx / riscv-witness …)"
+description: |
+  A downstream consumer of PrimeIR hit a bug — wrong lowering output, a missing
+  op/feature, an IR-contract break, or a perf regression — while compiling its
+  own workload. File this so the PrimeIR owner can reproduce without the
+  consumer's environment. Once root-caused it often becomes a PrimeIR bug; the
+  point of this template is to capture the consumer-side provenance the
+  maintainer doesn't have.
+title: "fix(<area>): <symptom> hit by <consumer>"
+labels: ["area:downstream"]
+type: Bug
+body:
+  - type: dropdown
+    id: consumer
+    attributes:
+      label: Consumer
+      description: Which downstream project hit this?
+      options:
+        - zkx
+        - riscv-witness
+        - other (note in title)
+    validations:
+      required: true
+
+  - type: input
+    id: downstream_commit
+    attributes:
+      label: Downstream commit
+      description: |
+        Where the issue was observed — paste a permalink to the consumer's
+        commit/file (carries the repo + SHA), or a bare SHA.
+      placeholder: https://github.com/<org>/<repo>/commit/ce1bcfbb
+    validations:
+      required: true
+
+  - type: input
+    id: prime_ir_sha
+    attributes:
+      label: PrimeIR commit / pin SHA
+      description: Which PrimeIR revision was the consumer building against?
+      placeholder: e.g. 1a2b3c4d
+    validations:
+      required: true
+
+  - type: textarea
+    id: workload
+    attributes:
+      label: Workload
+      description: |
+        What IR was the consumer lowering when it broke? The dialect ops, the
+        field/curve, the target (CPU/GPU) — enough to narrow the surface.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproducer
+      description: |
+        Minimum commands or input that reproduce the issue, ideally reduced to a
+        PrimeIR-only `.mlir` case. Use `bazel test` / lit, not built binary
+        paths. Prefix file inputs with `$PWD`.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: suspected_area
+    attributes:
+      label: Suspected PrimeIR area (optional)
+      description: If you have a hunch where the root cause lives, name the dialect op / pass / lowering.
+      placeholder: "e.g. modarith barrett lowering, field constant folding"
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: |
+        Issue number or full URL of the tracking / parent issue this
+        work belongs to, if any. Same-repo form: `#1234`. Cross-repo
+        form: `https://github.com/<owner>/<repo>/issues/1234`. The
+        /workflow:create-issue skill registers the sub-issue link
+        automatically when filed via the CLI.
+      placeholder: "#1234 or https://github.com/<owner>/<repo>/issues/1234"
+
+  - type: input
+    id: milestone
+    attributes:
+      label: Milestone
+      description: |
+        Existing milestone name to attach this issue to. The
+        /workflow:create-issue skill checks the milestone exists
+        before applying it.
+      placeholder: "e.g. <area>: <feature> v<n>"
+
+  - type: textarea
+    id: knowledge
+    attributes:
+      label: Relevant knowledge (optional)
+      description: Wiki links or excerpts that contextualize the bug. Strip home paths and session IDs.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+# Controls the issue chooser experience. Disable blank issues so contributors
+# always pick a structured template — keeps downstream automation (/handle-issue,
+# milestone/project assignment) able to rely on the labels and required fields.
+blank_issues_enabled: false
+
+contact_links:
+  - name: Discussion / open-ended question
+    url: https://github.com/fractalyze/prime-ir/discussions
+    about: For design questions, RFCs, or anything not actionable as a single task.


### PR DESCRIPTION
Structured issue intake for PrimeIR — three categories plus chooser config.

Templates:
- `01-spec-driven-task` — spec + multi-PR plan + downstream impact (zkx / riscv-witness)
- `02-prime-ir-bug` — bug in PrimeIR itself (verifier / fold / lowering); lit + `prime-opt` diagnostics
- `03-downstream-bug` — bug surfaced by a consumer (zkx / riscv-witness), with consumer-side provenance

Disables blank issues; routes open-ended questions to Discussions. Modeled on the riscv-witness / zkx template set.

Follow-up: the referenced labels (`area:spec-driven`, `area:prime-ir`, `area:downstream`, `type:fix`) must exist in the repo for GitHub to auto-apply them.