### PR TITLE
feat(field): add DenseElementTypeInterface to field/EC element types

### DIFF
--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/Pippengers.cpp
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/MSM/Pippengers/Pippengers.cpp
@@ -76,7 +76,7 @@ Pippengers::Pippengers(Value scalarsIn, Value points, Type outputType,
                       .getResult()
                 : scalarsIn;
 
-  size_t scalarBitWidth = scalarFieldType.getStorageBitWidth();
+  size_t scalarBitWidth = scalarFieldType.getTypeSizeInBits();
   bitsPerWindow =
       windowBits > 0
           ? windowBits

--- a/prime_ir/Dialect/EllipticCurve/IR/BUILD.bazel
+++ b/prime_ir/Dialect/EllipticCurve/IR/BUILD.bazel
@@ -68,6 +68,7 @@ prime_ir_cc_library(
         "//prime_ir/Dialect/Field/IR:Field",
         "//prime_ir/Dialect/ModArith/IR:ModArith",
         "//prime_ir/Dialect/Poly/IR:Poly",
+        "//prime_ir/IR:DenseElementBytes",
         "//prime_ir/Utils:AssemblyFormatUtils",
         "//prime_ir/Utils:CanonicalizationPatterns",
         "//prime_ir/Utils:ConstantFolder",

--- a/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveOps.cpp
+++ b/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveOps.cpp
@@ -74,7 +74,7 @@ LogicalResult verifyPointCoordTypes(OpType op, Type pointType, Type coordType) {
                << "output must have the same montgomery form as the "
                   "base field of input";
     } else if (auto intType = dyn_cast<IntegerType>(coordType)) {
-      if (intType.getWidth() != pfType.getStorageBitWidth())
+      if (intType.getWidth() != pfType.getTypeSizeInBits())
         return op.emitError()
                << "output must have the same bitwidth as the base "
                   "field of input";

--- a/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveTypes.cpp
+++ b/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveTypes.cpp
@@ -16,8 +16,10 @@ limitations under the License.
 #include "prime_ir/Dialect/EllipticCurve/IR/EllipticCurveTypes.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "prime_ir/Dialect/EllipticCurve/IR/EllipticCurveOps.h"
 #include "prime_ir/Dialect/Field/IR/FieldTypes.h"
+#include "prime_ir/IR/DenseElementBytes.h"
 
 namespace mlir::prime_ir::elliptic_curve {
 
@@ -110,5 +112,82 @@ EdExtendedType::createConstantAttrFromValues(ArrayRef<APInt> values) const {
 ShapedType EdExtendedType::overrideShapedType(ShapedType type) const {
   return type;
 }
+
+//===----------------------------------------------------------------------===//
+// DenseElementTypeInterface lets `tensor<Nx!Point>` store one point per element
+// (numCoords × baseFieldStorageBits, little-endian) instead of exploding to a
+// storage-int `tensor<Nxnum_coordsxiN>` with an extra coordinate dimension — so
+// a point constant's value attribute keeps the same shape as its result type.
+// It supplies the per-element byte width MLIR's dense machinery needs; without
+// it that path is `llvm_unreachable` (UB in release).
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+unsigned baseFieldStorageBits(Type baseField) {
+  if (auto pf = dyn_cast<field::PrimeFieldType>(baseField))
+    return pf.getTypeSizeInBits();
+  if (auto ef = dyn_cast<field::ExtensionFieldType>(baseField))
+    return ef.getTypeSizeInBits();
+  if (auto bf = dyn_cast<field::BinaryFieldType>(baseField))
+    return bf.getTypeSizeInBits();
+  llvm_unreachable("Unsupported EC base field type");
+}
+
+size_t pointDenseElementBitSize(unsigned numCoords, Type baseField) {
+  return numCoords * baseFieldStorageBits(baseField);
+}
+
+Attribute pointConvertToAttribute(unsigned numCoords, Type baseField,
+                                  ::llvm::ArrayRef<char> rawData) {
+  unsigned baseBits = baseFieldStorageBits(baseField);
+  unsigned baseBytes = (baseBits + 7) / 8;
+  if (rawData.size() != numCoords * baseBytes)
+    return {};
+
+  auto intTy = IntegerType::get(baseField.getContext(), baseBits);
+  auto tensorTy =
+      RankedTensorType::get({static_cast<int64_t>(numCoords)}, intTy);
+  return DenseIntElementsAttr::get(
+      tensorTy, prime_ir::coeffsFromRawBytes(
+                    DenseElementsAttr::getFromRawBuffer(tensorTy, rawData),
+                    baseBits, numCoords));
+}
+
+::llvm::LogicalResult
+pointConvertFromAttribute(unsigned numCoords, Type baseField, Attribute attr,
+                          ::llvm::SmallVectorImpl<char> &result) {
+  auto denseAttr = dyn_cast<DenseIntElementsAttr>(attr);
+  if (!denseAttr)
+    return ::llvm::failure();
+  if (denseAttr.getNumElements() != static_cast<int64_t>(numCoords))
+    return ::llvm::failure();
+  unsigned baseBytes = (baseFieldStorageBits(baseField) + 7) / 8;
+  for (const APInt &v : denseAttr.getValues<APInt>()) {
+    auto bytes = prime_ir::apintLowBytes(v, baseBytes);
+    result.append(bytes.begin(), bytes.end());
+  }
+  return ::llvm::success();
+}
+} // namespace
+
+#define DEFINE_EC_DENSE_ELEMENT_TYPE_INTERFACE(TYPE, N)                        \
+  size_t TYPE##Type::getDenseElementBitSize() const {                          \
+    return pointDenseElementBitSize(N, getBaseFieldType());                    \
+  }                                                                            \
+  Attribute TYPE##Type::convertToAttribute(::llvm::ArrayRef<char> rawData)     \
+      const {                                                                  \
+    return pointConvertToAttribute(N, getBaseFieldType(), rawData);            \
+  }                                                                            \
+  ::llvm::LogicalResult TYPE##Type::convertFromAttribute(                      \
+      Attribute attr, ::llvm::SmallVectorImpl<char> &result) const {           \
+    return pointConvertFromAttribute(N, getBaseFieldType(), attr, result);     \
+  }
+
+DEFINE_EC_DENSE_ELEMENT_TYPE_INTERFACE(Affine, 2)
+DEFINE_EC_DENSE_ELEMENT_TYPE_INTERFACE(Jacobian, 3)
+DEFINE_EC_DENSE_ELEMENT_TYPE_INTERFACE(XYZZ, 4)
+
+#undef DEFINE_EC_DENSE_ELEMENT_TYPE_INTERFACE
 
 } // namespace mlir::prime_ir::elliptic_curve

--- a/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveTypes.td
+++ b/prime_ir/Dialect/EllipticCurve/IR/EllipticCurveTypes.td
@@ -53,7 +53,8 @@ def EllipticCurve_PointTypeInterface : TypeInterface<"PointTypeInterface"> {
 def EllipticCurve_AffineType : EllipticCurve_Type<"Affine", "affine", [
   MemRefElementTypeInterface,
   DeclareTypeInterfaceMethods<EllipticCurve_PointTypeInterface>,
-  DeclareTypeInterfaceMethods<ConstantLikeInterface>
+  DeclareTypeInterfaceMethods<ConstantLikeInterface>,
+  DeclareTypeInterfaceMethods<DenseElementTypeInterface>
   ]> {
   let summary = "An affine point within an elliptic curve";
   let description = [{
@@ -73,7 +74,8 @@ def EllipticCurve_AffineType : EllipticCurve_Type<"Affine", "affine", [
 def EllipticCurve_JacobianType : EllipticCurve_Type<"Jacobian", "jacobian", [
   MemRefElementTypeInterface,
   DeclareTypeInterfaceMethods<EllipticCurve_PointTypeInterface>,
-  DeclareTypeInterfaceMethods<ConstantLikeInterface>
+  DeclareTypeInterfaceMethods<ConstantLikeInterface>,
+  DeclareTypeInterfaceMethods<DenseElementTypeInterface>
   ]> {
   let summary = "A jacobian point within an elliptic curve";
   let description = [{
@@ -94,7 +96,8 @@ def EllipticCurve_JacobianType : EllipticCurve_Type<"Jacobian", "jacobian", [
 def EllipticCurve_XYZZType : EllipticCurve_Type<"XYZZ", "xyzz", [
   MemRefElementTypeInterface,
   DeclareTypeInterfaceMethods<EllipticCurve_PointTypeInterface>,
-  DeclareTypeInterfaceMethods<ConstantLikeInterface>
+  DeclareTypeInterfaceMethods<ConstantLikeInterface>,
+  DeclareTypeInterfaceMethods<DenseElementTypeInterface>
   ]> {
   let summary = "A xyzz point within an elliptic curve";
   let description = [{

--- a/prime_ir/Dialect/EllipticCurve/IR/KnownCurves.cpp
+++ b/prime_ir/Dialect/EllipticCurve/IR/KnownCurves.cpp
@@ -161,7 +161,7 @@ field::ExtensionFieldType buildBN254Fp12Type(MLIRContext *ctx,
   // the type manually.
   auto fp6Type = buildBN254Fp6Type(ctx, isMontgomery);
   auto storageType = fp6Type.getBasePrimeField().getStorageType();
-  unsigned bitWidth = fp6Type.getBasePrimeField().getStorageBitWidth();
+  unsigned bitWidth = fp6Type.getBasePrimeField().getTypeSizeInBits();
 
   // Non-residue: v = (0, 1, 0) in Fp6 = (c₀, c₁, c₂) where cᵢ ∈ Fp2.
   // Flattened to 6 prime field values: [c₀₀, c₀₁, c₁₀, c₁₁, c₂₀, c₂₁]

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/BUILD.bazel
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/BUILD.bazel
@@ -81,6 +81,7 @@ prime_ir_cc_library(
         "//prime_ir/Dialect/Field/IR:Field",
         "//prime_ir/Dialect/ModArith/IR:ModArith",
         "//prime_ir/Dialect/TensorExt/IR:TensorExt",
+        "//prime_ir/IR:Attributes",
         "//prime_ir/Utils:BitSerialAlgorithm",
         "//prime_ir/Utils:BuilderContext",
         "//prime_ir/Utils:ConversionUtils",

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/ExtensionFieldCodeGen.h
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/ExtensionFieldCodeGen.h
@@ -190,7 +190,7 @@ public:
     if constexpr (N == 4) {
       auto efType = cast<ExtensionFieldType>(value.getType());
       auto pfType = efType.getBasePrimeField();
-      unsigned limbNums = (pfType.getStorageBitWidth() + 63) / 64;
+      unsigned limbNums = (pfType.getTypeSizeInBits() + 63) / 64;
       return (limbNums > 1) ? zk_dtypes::ExtensionFieldMulAlgorithm::kToomCook
                             : zk_dtypes::ExtensionFieldMulAlgorithm::kKaratsuba;
     }
@@ -201,7 +201,7 @@ public:
     if constexpr (N == 4) {
       auto efType = cast<ExtensionFieldType>(value.getType());
       auto pfType = efType.getBasePrimeField();
-      unsigned limbNums = (pfType.getStorageBitWidth() + 63) / 64;
+      unsigned limbNums = (pfType.getTypeSizeInBits() + 63) / 64;
       // kCustom saves 1 mul, 1 add, 2 doubles vs Karatsuba for quartic square.
       return (limbNums > 1) ? zk_dtypes::ExtensionFieldMulAlgorithm::kToomCook
                             : zk_dtypes::ExtensionFieldMulAlgorithm::kCustom;

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldToModArith.cpp
@@ -46,6 +46,7 @@ limitations under the License.
 #include "prime_ir/Dialect/ModArith/IR/ModArithOps.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithTypes.h"
 #include "prime_ir/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "prime_ir/IR/Attributes.h"
 #include "prime_ir/Utils/BitSerialAlgorithm.h"
 #include "prime_ir/Utils/BuilderContext.h"
 #include "prime_ir/Utils/ConversionUtils.h"
@@ -76,7 +77,7 @@ static bool shouldUseFieldAOTRuntime(Operation *op, Type fieldType,
   if (!efType)
     return false;
   unsigned degree = efType.getDegreeOverPrime();
-  unsigned primeBits = efType.getBasePrimeField().getStorageBitWidth();
+  unsigned primeBits = efType.getBasePrimeField().getTypeSizeInBits();
   if (degree < 2)
     return false;
   bool expensive = degree >= 4 || primeBits > 64;
@@ -174,7 +175,9 @@ struct ConvertConstant : public OpConversionPattern<ConstantOp> {
 
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
-    // Case 1: Prime field constants (scalar or tensor)
+    // Case 1: Prime field constants (scalar or tensor). The PF value attr is
+    // already storage-int (IntegerAttr / DenseIntElementsAttr), which is what
+    // mod_arith.constant expects.
     if (auto pfType =
             dyn_cast<PrimeFieldType>(getElementTypeOrSelf(op.getType()))) {
       auto cval = mod_arith::ConstantOp::create(
@@ -199,7 +202,9 @@ struct ConvertConstant : public OpConversionPattern<ConstantOp> {
           typeConverter->convertType(efType.getBasePrimeField()));
       unsigned degree = efType.getDegreeOverPrime();
 
-      auto denseAttr = cast<DenseIntElementsAttr>(op.getValueAttr());
+      auto denseAttr =
+          cast<DenseIntElementsAttr>(prime_ir::maybeConvertPrimeIRToBuiltinAttr(
+              cast<DenseElementsAttr>(op.getValueAttr())));
       auto allValues = denseAttr.getValues<APInt>();
 
       // Create a flattened prime field tensor constant

--- a/prime_ir/Dialect/Field/IR/BUILD.bazel
+++ b/prime_ir/Dialect/Field/IR/BUILD.bazel
@@ -79,6 +79,8 @@ prime_ir_cc_library(
         ":types_inc_gen",
         "//prime_ir/Dialect/EllipticCurve/IR:PointOperationBaseForward",
         "//prime_ir/Dialect/ModArith/IR:ModArith",
+        "//prime_ir/IR:Attributes",
+        "//prime_ir/IR:DenseElementBytes",
         "//prime_ir/Utils:AssemblyFormatUtils",
         "//prime_ir/Utils:BitcastOpUtils",
         "//prime_ir/Utils:CanonicalizationPatterns",

--- a/prime_ir/Dialect/Field/IR/ExtensionFieldOperation.h
+++ b/prime_ir/Dialect/Field/IR/ExtensionFieldOperation.h
@@ -61,7 +61,7 @@ struct BaseFieldBitWidth;
 template <>
 struct BaseFieldBitWidth<PrimeFieldOperation> {
   static unsigned get(ExtensionFieldType efType) {
-    return cast<PrimeFieldType>(efType.getBaseField()).getStorageBitWidth();
+    return cast<PrimeFieldType>(efType.getBaseField()).getTypeSizeInBits();
   }
 };
 
@@ -69,7 +69,7 @@ template <size_t M, typename InnerBaseT>
 struct BaseFieldBitWidth<ExtensionFieldOperation<M, InnerBaseT>> {
   static unsigned get(ExtensionFieldType efType) {
     // For tower extensions, get the bit width from the underlying prime field
-    return efType.getBasePrimeField().getStorageBitWidth();
+    return efType.getBasePrimeField().getTypeSizeInBits();
   }
 };
 // Helper to detect if a zk_dtypes field type is a prime field or extension
@@ -643,7 +643,7 @@ private:
     } else if constexpr (N == 2) {
       auto baseFieldType = cast<PrimeFieldType>(efType.getBaseField());
       // Heuristic: custom squaring when n² > 2n + C
-      unsigned limbNums = (baseFieldType.getStorageBitWidth() + 63) / 64;
+      unsigned limbNums = (baseFieldType.getTypeSizeInBits() + 63) / 64;
       if (limbNums * N >= 2) {
         return zk_dtypes::ExtensionFieldMulAlgorithm::kCustom2;
       }
@@ -651,14 +651,14 @@ private:
     } else if constexpr (N == 3) {
       auto baseFieldType = cast<PrimeFieldType>(efType.getBaseField());
       // Heuristic: custom squaring when n² > 4n
-      unsigned limbNums = (baseFieldType.getStorageBitWidth() + 63) / 64;
+      unsigned limbNums = (baseFieldType.getTypeSizeInBits() + 63) / 64;
       if (limbNums * N >= 4) {
         return zk_dtypes::ExtensionFieldMulAlgorithm::kCustom;
       }
       return zk_dtypes::ExtensionFieldMulAlgorithm::kKaratsuba;
     } else if constexpr (N == 4) {
       auto baseFieldType = cast<PrimeFieldType>(efType.getBaseField());
-      unsigned limbNums = (baseFieldType.getStorageBitWidth() + 63) / 64;
+      unsigned limbNums = (baseFieldType.getTypeSizeInBits() + 63) / 64;
       // kCustom saves 1 mul, 1 add, 2 doubles vs Karatsuba for quartic square.
       // ToomCook only for multi-limb fields.
       return (limbNums > 1) ? zk_dtypes::ExtensionFieldMulAlgorithm::kToomCook
@@ -673,7 +673,7 @@ private:
       return zk_dtypes::ExtensionFieldMulAlgorithm::kKaratsuba;
     } else if constexpr (N == 4) {
       auto baseFieldType = cast<PrimeFieldType>(efType.getBaseField());
-      unsigned limbNums = (baseFieldType.getStorageBitWidth() + 63) / 64;
+      unsigned limbNums = (baseFieldType.getTypeSizeInBits() + 63) / 64;
       return (limbNums > 1) ? zk_dtypes::ExtensionFieldMulAlgorithm::kToomCook
                             : zk_dtypes::ExtensionFieldMulAlgorithm::kKaratsuba;
     } else {
@@ -684,7 +684,7 @@ private:
   BaseFieldT CreateConstBaseField(int64_t x) const {
     if constexpr (kIsTower) {
       auto baseEfType = cast<ExtensionFieldType>(efType.getBaseField());
-      APInt value(efType.getBasePrimeField().getStorageBitWidth(), x);
+      APInt value(efType.getBasePrimeField().getTypeSizeInBits(), x);
       return BaseFieldT::fromUnchecked(value, baseEfType);
     } else {
       auto baseFieldType = cast<PrimeFieldType>(efType.getBaseField());

--- a/prime_ir/Dialect/Field/IR/FieldOps.cpp
+++ b/prime_ir/Dialect/Field/IR/FieldOps.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include "prime_ir/Dialect/Field/IR/FieldOperation.h"
 #include "prime_ir/Dialect/Field/IR/FieldTypes.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithTypes.h"
+#include "prime_ir/IR/Attributes.h"
 #include "prime_ir/Utils/AssemblyFormatUtils.h"
 #include "prime_ir/Utils/BitcastOpUtils.h"
 #include "prime_ir/Utils/ConstantFolder.h"
@@ -258,20 +259,34 @@ ParseResult parseFieldConstant(OpAsmParser &parser, OperationState &result) {
 
   auto shapedType = cast<ShapedType>(parsedType);
   auto elementType = getElementTypeOrSelf(parsedType);
+
+  auto applyMontPerCoeff = [&](PrimeFieldType pfType,
+                               MutableArrayRef<APInt> ints) {
+    auto modArithType = mod_arith::ModArithType::get(
+        pfType.getContext(), pfType.getModulus(), /*isMontgomery=*/false);
+    for (APInt &v : ints)
+      v = mod_arith::ModArithOperation::fromUnchecked(v, modArithType).toMont();
+  };
+
   if (auto pfType = dyn_cast<PrimeFieldType>(elementType)) {
+    if (pfType.isMontgomery())
+      applyMontPerCoeff(pfType, parsedInts);
+    SmallVector<APInt> adjustedInts;
+    adjustedInts.reserve(parsedInts.size());
+    for (const APInt &val : parsedInts)
+      adjustedInts.push_back(
+          val.zextOrTrunc(pfType.getStorageType().getWidth()));
     auto denseElementsAttr = DenseIntElementsAttr::get(
-        shapedType.clone(pfType.getStorageType()), parsedInts);
-    result.addAttribute("value", maybeToMontgomery(pfType, denseElementsAttr));
+        shapedType.clone(pfType.getStorageType()), adjustedInts);
+    result.addAttribute("value", denseElementsAttr);
     result.addTypes(parsedType);
     return success();
   }
   if (auto bfType = dyn_cast<BinaryFieldType>(elementType)) {
-    // Adjust each APInt to the correct bitwidth for binary field storage
     SmallVector<APInt> adjustedInts;
     adjustedInts.reserve(parsedInts.size());
-    for (const APInt &val : parsedInts) {
+    for (const APInt &val : parsedInts)
       adjustedInts.push_back(val.zextOrTrunc(bfType.getBitWidth()));
-    }
     auto denseElementsAttr = DenseIntElementsAttr::get(
         shapedType.clone(bfType.getStorageType()), adjustedInts);
     result.addAttribute("value", denseElementsAttr);
@@ -279,14 +294,23 @@ ParseResult parseFieldConstant(OpAsmParser &parser, OperationState &result) {
     return success();
   }
   if (auto efType = dyn_cast<ExtensionFieldType>(elementType)) {
-    auto pfType = efType.getBasePrimeField();
-    // For tensor<Nx!EF{d}>, the attribute shape is [N, towerDims...].
-    auto towerDims = efType.getAttrShape();
-    SmallVector<int64_t> attrShape(shapedType.getShape());
-    attrShape.append(towerDims.begin(), towerDims.end());
-    auto attrType = RankedTensorType::get(attrShape, pfType.getStorageType());
-    auto denseElementsAttr = DenseIntElementsAttr::get(attrType, parsedInts);
-    result.addAttribute("value", maybeToMontgomery(efType, denseElementsAttr));
+    PrimeFieldType pfType = efType.getBasePrimeField();
+    if (efType.isMontgomery())
+      applyMontPerCoeff(pfType, parsedInts);
+    unsigned primeBytes = (pfType.getTypeSizeInBits() + 7) / 8;
+    unsigned degree = efType.getDegreeOverPrime();
+    SmallVector<APInt> packedInts;
+    // Splat input: replicate the scalar across `degree` coeffs so the
+    // packed bytes equal one EF element's worth. getFromRawBuffer treats
+    // one element's bytes as a splat.
+    if (parsedInts.size() == 1 && degree > 1) {
+      packedInts.assign(degree, parsedInts[0]);
+    } else {
+      packedInts.assign(parsedInts.begin(), parsedInts.end());
+    }
+    auto bytes = packAPIntsLE(packedInts, primeBytes);
+    result.addAttribute("value",
+                        DenseElementsAttr::getFromRawBuffer(shapedType, bytes));
     result.addTypes(parsedType);
     return success();
   }
@@ -308,13 +332,14 @@ ParseResult parseOptionalFieldConstant(OpAsmParser &parser,
   // caller's pre-existing error stays surfaced. On success, parseFieldConstant
   // emits no diagnostics, so the buffer is empty and dropping is a no-op.
   llvm::SmallVector<mlir::Diagnostic, 2> captured;
-  mlir::ScopedDiagnosticHandler scope(
-      parser.getContext(), [&](mlir::Diagnostic &diag) {
-        captured.emplace_back(std::move(diag));
-        return mlir::success();
-      });
+  mlir::ScopedDiagnosticHandler scope(parser.getContext(),
+                                      [&](mlir::Diagnostic &diag) {
+                                        captured.emplace_back(std::move(diag));
+                                        return mlir::success();
+                                      });
 
-  if (succeeded(parseFieldConstant(parser, result))) return success();
+  if (succeeded(parseFieldConstant(parser, result)))
+    return success();
 
   // Restore: rewind the token stream and roll back any attributes / result
   // types parseFieldConstant added before failing.
@@ -351,10 +376,44 @@ ConstantOp ConstantOp::materialize(OpBuilder &builder, Attribute value,
       auto scalarAttr = DenseIntElementsAttr::get(tensorType, coeffs);
       return ConstantOp::create(builder, loc, type, scalarAttr);
     }
+    if (auto shapedTy = dyn_cast<ShapedType>(type)) {
+      // PF/BF: a scalar carries implicit-splat semantics; store as a
+      // storage-int DenseIntElementsAttr splat matching the result shape.
+      auto storageType =
+          isa<PrimeFieldType>(elementType)
+              ? cast<PrimeFieldType>(elementType).getStorageType()
+              : cast<BinaryFieldType>(elementType).getStorageType();
+      auto splatAttr = DenseIntElementsAttr::get(
+          shapedTy.clone(storageType),
+          intAttr.getValue().zextOrTrunc(storageType.getWidth()));
+      return ConstantOp::create(builder, loc, type, splatAttr);
+    }
     return ConstantOp::create(builder, loc, type, intAttr);
   }
-  return ConstantOp::create(builder, loc, type,
-                            cast<DenseIntElementsAttr>(value));
+  // Fold results may arrive as storage-int-typed DenseElementsAttr. For an EF
+  // result, promote to the field-typed view. A storage-int splat holds one
+  // prime int; an EF element is `degree` primes, so replicate before retyping.
+  if (auto dense = dyn_cast<DenseElementsAttr>(value)) {
+    auto shapedTy = dyn_cast<ShapedType>(type);
+    if (auto efType = dyn_cast<ExtensionFieldType>(elementType);
+        efType && shapedTy && dense.getType() != shapedTy) {
+      ArrayRef<char> raw = dense.getRawData();
+      unsigned degree = efType.getDegreeOverPrime();
+      DenseElementsAttr promoted;
+      if (dense.isSplat() && degree > 1) {
+        SmallVector<char> expanded;
+        expanded.reserve(degree * raw.size());
+        for (unsigned i = 0; i < degree; ++i)
+          expanded.append(raw.begin(), raw.end());
+        promoted = DenseElementsAttr::getFromRawBuffer(shapedTy, expanded);
+      } else {
+        promoted = DenseElementsAttr::getFromRawBuffer(shapedTy, raw);
+      }
+      return ConstantOp::create(builder, loc, type, promoted);
+    }
+    return ConstantOp::create(builder, loc, type, dense);
+  }
+  return ConstantOp::create(builder, loc, type, cast<ElementsAttr>(value));
 }
 
 Operation *FieldDialect::materializeConstant(OpBuilder &builder,
@@ -404,19 +463,37 @@ void ConstantOp::print(OpAsmPrinter &p) {
 
   Type type = getType();
   Type elementType = getElementTypeOrSelf(type);
-  Attribute value = maybeToStandard(elementType, getValue());
+  Attribute value = getValue();
 
-  // Scalar EF constants are stored as DenseIntElementsAttr, but the parser
-  // expects list syntax [c₀, c₁, ...] rather than dense<[c₀, c₁, ...]>.
+  // Scalar EF: stored as DenseIntElementsAttr at tower shape. Parser
+  // expects bracketed coeff list, not dense<[...]>.
   if (!isa<ShapedType>(type) && isa<ExtensionFieldType>(elementType)) {
-    auto denseAttr = cast<DenseIntElementsAttr>(value);
+    auto denseAttr =
+        cast<DenseIntElementsAttr>(maybeToStandard(elementType, value));
     p << "[";
     llvm::interleaveComma(denseAttr.getValues<APInt>(), p,
                           [&](const APInt &v) { p << v; });
     p << "]";
-  } else {
-    p.printAttributeWithoutType(value);
+    p << " : ";
+    p.printType(type);
+    return;
   }
+
+  // Tensor EF: value is field-typed; reinterpret its bytes as the storage-int
+  // tower so MLIR's built-in dense<...> printer can format it (tower-nested,
+  // round-trips through parseFieldConstant). A splat holds one EF element's
+  // bytes (degree primes); replicate to a full row first.
+  if (isa<ShapedType>(type) && isa<ExtensionFieldType>(elementType)) {
+    Attribute storageInt = prime_ir::maybeConvertPrimeIRToBuiltinAttr(
+        cast<DenseElementsAttr>(value));
+    p.printAttributeWithoutType(maybeToStandard(elementType, storageInt));
+    p << " : ";
+    p.printType(type);
+    return;
+  }
+
+  Attribute scalar = maybeToStandard(elementType, value);
+  p.printAttributeWithoutType(scalar);
   p << " : ";
   p.printType(type);
 }
@@ -442,7 +519,7 @@ struct CmpConstantFolderConfig {
   using NativeInputType = APInt;
   using NativeOutputType = bool;
   using ScalarAttr = IntegerAttr;
-  using TensorAttr = DenseIntElementsAttr;
+  using TensorAttr = DenseElementsAttr;
 };
 
 class PrimeFieldCmpConstantFolder
@@ -462,6 +539,12 @@ public:
                              ArrayRef<bool> values) const final {
     return DenseIntElementsAttr::get(type.clone(IntegerType::get(context, 1)),
                                      values);
+  }
+
+  SmallVector<APInt, 0> extractValues(DenseElementsAttr attr) const final {
+    int64_t total = attr.getType().getNumElements();
+    auto v = coeffsFromRawBytes(attr, pfType.getTypeSizeInBits(), total);
+    return SmallVector<APInt, 0>(v.begin(), v.end());
   }
 
   bool operate(const APInt &a, const APInt &b) const final {
@@ -495,7 +578,7 @@ struct ExtFieldCmpConstantFolderConfig {
   using NativeInputType = SmallVector<APInt>;
   using NativeOutputType = bool;
   using ScalarAttr = DenseIntElementsAttr;
-  using TensorAttr = DenseIntElementsAttr;
+  using TensorAttr = DenseElementsAttr;
 };
 
 class ExtensionFieldCmpConstantFolder
@@ -641,7 +724,7 @@ bool BitcastOp::areCastCompatible(TypeRange inputs, TypeRange outputs) {
     // Calculate bitwidth for each element type
     unsigned inputBitWidth;
     if (auto efType = dyn_cast<ExtensionFieldType>(inputElementType)) {
-      inputBitWidth = efType.getStorageBitWidth();
+      inputBitWidth = efType.getTypeSizeInBits();
     } else if (auto maType =
                    dyn_cast<mod_arith::ModArithType>(inputElementType)) {
       inputBitWidth = mod_arith::getIntOrModArithBitWidth(maType);
@@ -651,7 +734,7 @@ bool BitcastOp::areCastCompatible(TypeRange inputs, TypeRange outputs) {
 
     unsigned outputBitWidth;
     if (auto efType = dyn_cast<ExtensionFieldType>(outputElementType)) {
-      outputBitWidth = efType.getStorageBitWidth();
+      outputBitWidth = efType.getTypeSizeInBits();
     } else if (auto maType =
                    dyn_cast<mod_arith::ModArithType>(outputElementType)) {
       outputBitWidth = mod_arith::getIntOrModArithBitWidth(maType);
@@ -724,12 +807,12 @@ bool BitcastOp::areCastCompatible(TypeRange inputs, TypeRange outputs) {
   // Case 4: extension field <-> integer bitcast (same storage bitwidth)
   if (auto inputEF = dyn_cast<ExtensionFieldType>(inputElementType)) {
     if (auto outputInt = dyn_cast<IntegerType>(outputElementType)) {
-      return inputEF.getStorageBitWidth() == outputInt.getWidth();
+      return inputEF.getTypeSizeInBits() == outputInt.getWidth();
     }
   }
   if (auto inputInt = dyn_cast<IntegerType>(inputElementType)) {
     if (auto outputEF = dyn_cast<ExtensionFieldType>(outputElementType)) {
-      return inputInt.getWidth() == outputEF.getStorageBitWidth();
+      return inputInt.getWidth() == outputEF.getTypeSizeInBits();
     }
   }
 
@@ -779,7 +862,7 @@ LogicalResult BitcastOp::verify() {
 
     auto getElementBitWidth = [](Type t) -> unsigned {
       if (auto ef = dyn_cast<ExtensionFieldType>(t))
-        return ef.getStorageBitWidth();
+        return ef.getTypeSizeInBits();
       return getIntOrPrimeFieldBitWidth(t);
     };
 
@@ -865,7 +948,13 @@ OpFoldResult BitcastOp::fold(FoldAdaptor adaptor) {
   if (dyn_cast_if_present<IntegerAttr>(adaptor.getInput()) &&
       isa<ExtensionFieldType>(getOutput().getType()))
     return {};
-  return foldBitcast(*this, adaptor);
+  // An EF field.constant stores a field-typed dense value; reinterpret its
+  // bytes as the storage-int tower so they cast to the output type. PF/BF and
+  // non-field constants are already storage-int.
+  Attribute input = adaptor.getInput();
+  if (auto dense = dyn_cast_if_present<DenseElementsAttr>(input))
+    input = prime_ir::maybeConvertPrimeIRToBuiltinAttr(dense);
+  return foldBitcast(*this, adaptor, input);
 }
 
 LogicalResult BitcastOp::canonicalize(BitcastOp op, PatternRewriter &rewriter) {
@@ -970,14 +1059,14 @@ struct PrimeFieldConstantFolderConfig {
   using NativeInputType = APInt;
   using NativeOutputType = APInt;
   using ScalarAttr = IntegerAttr;
-  using TensorAttr = DenseIntElementsAttr;
+  using TensorAttr = DenseElementsAttr;
 };
 
 struct ExtensionFieldConstantFolderConfig {
   using NativeInputType = SmallVector<APInt>;
   using NativeOutputType = SmallVector<APInt>;
   using ScalarAttr = DenseIntElementsAttr;
-  using TensorAttr = DenseIntElementsAttr;
+  using TensorAttr = DenseElementsAttr;
 };
 
 struct BinaryFieldConstantFolderConfig {
@@ -1001,8 +1090,17 @@ public:
 
   OpFoldResult getTensorAttr(ShapedType type,
                              ArrayRef<APInt> values) const final {
-    return DenseIntElementsAttr::get(type.clone(pfType.getStorageType()),
-                                     values);
+    unsigned primeBytes = (pfType.getTypeSizeInBits() + 7) / 8;
+    auto bytes = packAPIntsLE(values, primeBytes);
+    return DenseElementsAttr::getFromRawBuffer(type, bytes);
+  }
+
+  // Walk per-prime-coeff APInts from a tensor constant (field-typed or
+  // storage-int-typed). Bytes are bit-identical between the two forms.
+  SmallVector<APInt, 0> extractValues(DenseElementsAttr attr) const final {
+    int64_t total = attr.getType().getNumElements();
+    auto v = coeffsFromRawBytes(attr, pfType.getTypeSizeInBits(), total);
+    return SmallVector<APInt, 0>(v.begin(), v.end());
   }
 
 protected:
@@ -1031,18 +1129,36 @@ public:
 
   OpFoldResult getTensorAttr(ShapedType type,
                              ArrayRef<SmallVector<APInt>> values) const final {
-    // Flatten all coefficient vectors into a single vector
-    SmallVector<APInt> flattenedValues;
-    for (const auto &coeffs : values) {
-      flattenedValues.append(coeffs.begin(), coeffs.end());
-    }
-    // Create result attribute with shape [tensor_dims..., towerDims...]
+    SmallVector<APInt> flat;
+    for (const auto &coeffs : values)
+      flat.append(coeffs.begin(), coeffs.end());
     PrimeFieldType pfType = efType.getBasePrimeField();
-    auto towerDims = efType.getAttrShape();
-    SmallVector<int64_t> attrShape(type.getShape());
-    attrShape.append(towerDims.begin(), towerDims.end());
-    auto attrType = RankedTensorType::get(attrShape, pfType.getStorageType());
-    return DenseIntElementsAttr::get(attrType, flattenedValues);
+    unsigned primeBytes = (pfType.getTypeSizeInBits() + 7) / 8;
+    auto bytes = packAPIntsLE(flat, primeBytes);
+    return DenseElementsAttr::getFromRawBuffer(type, bytes);
+  }
+
+  // Walk raw bytes and group per-degree coeffs for tensor EF constants.
+  SmallVector<SmallVector<APInt>, 0>
+  extractValues(DenseElementsAttr attr) const final {
+    PrimeFieldType pfType = efType.getBasePrimeField();
+    unsigned degree = efType.getDegreeOverPrime();
+    // Count field elements from the op's field type, not the attribute. A
+    // legacy storage-int constant covers each EF element with `degree`
+    // coefficient slots, so `attr.getType().getNumElements()` would overcount
+    // by `degree`; the field type carries the true element count.
+    int64_t numElems =
+        isa<ShapedType>(type) ? cast<ShapedType>(type).getNumElements() : 1;
+    auto flat =
+        coeffsFromRawBytes(attr, pfType.getTypeSizeInBits(), numElems * degree);
+    SmallVector<SmallVector<APInt>, 0> grouped;
+    grouped.reserve(numElems);
+    for (int64_t i = 0; i < numElems; ++i) {
+      SmallVector<APInt> coeffs(flat.begin() + i * degree,
+                                flat.begin() + (i + 1) * degree);
+      grouped.push_back(std::move(coeffs));
+    }
+    return grouped;
   }
 
 protected:
@@ -1113,41 +1229,32 @@ public:
         fn(FieldOperation::fromUnchecked(coeffs, inputEfType)));
   }
 
-  // Override foldScalar to dispatch to foldTensor when dealing with tensors.
-  // This is needed because for extension fields, ScalarAttr == TensorAttr ==
-  // DenseIntElementsAttr, so the generic fold() always calls foldScalar.
+  // For EF, ScalarAttr (DenseIntElementsAttr) only describes the scalar EF
+  // cover (tensor<degree x i_pf>); tensor EF lives in TensorAttr
+  // (DenseElementsAttr<tensor<...x!EF>>). Dispatch scalar-shape attrs to
+  // the actual scalar fold and shaped attrs to foldTensor.
   OpFoldResult foldScalar(DenseIntElementsAttr attr) const override {
-    if (isa<ShapedType>(this->type)) {
-      return foldTensor(attr);
+    if (isa<ShapedType>(this->type) && isa<ShapedType>(attr.getType()) &&
+        cast<ShapedType>(attr.getType()).getRank() > 1) {
+      // Legacy storage-int tensor EF (rank = tensor dims + tower dims).
+      return foldTensor(cast<DenseElementsAttr>(attr));
     }
-    // Actual scalar folding: use default implementation
     return this->getScalarAttr(operate(this->getNativeInput(attr)));
   }
 
-  // Override foldTensor to handle extension field tensor constants properly.
-  OpFoldResult foldTensor(DenseIntElementsAttr attr) const override {
-    unsigned degree = this->efType.getDegreeOverPrime();
-    auto inputValues = attr.getValues<APInt>();
-    size_t numElements = inputValues.size();
-
-    if (numElements % degree != 0) {
-      return {};
-    }
-
-    SmallVector<SmallVector<APInt>> results;
-    results.reserve(numElements / degree);
-
-    for (size_t i = 0; i < numElements; i += degree) {
-      SmallVector<APInt> coeffs(inputValues.begin() + i,
-                                inputValues.begin() + i + degree);
-      results.push_back(operate(coeffs));
-    }
-
+  OpFoldResult foldTensor(DenseElementsAttr attr) const override {
     auto shapedType = dyn_cast<ShapedType>(this->type);
-    if (!shapedType) {
+    if (!shapedType)
       return {};
-    }
-    return this->getTensorAttr(shapedType, results);
+    auto inputs = this->extractValues(attr);
+    if (inputs.empty())
+      return {};
+    SmallVector<SmallVector<APInt>, 0> results;
+    results.reserve(inputs.size());
+    for (const auto &coeffs : inputs)
+      results.push_back(operate(coeffs));
+    SmallVector<SmallVector<APInt>> resultsCopy(results.begin(), results.end());
+    return this->getTensorAttr(shapedType, resultsCopy);
   }
 
 private:
@@ -1232,41 +1339,26 @@ public:
     return BaseDelegate::foldScalar(rhs);
   }
 
-  // Override foldTensor to handle extension field tensor constants properly.
-  OpFoldResult foldTensor(DenseIntElementsAttr lhsAttr,
-                          DenseIntElementsAttr rhsAttr) const override {
-    unsigned degree = this->efType.getDegreeOverPrime();
-    auto lhsValues = lhsAttr.getValues<APInt>();
-    auto rhsValues = rhsAttr.getValues<APInt>();
-    size_t numElements = lhsValues.size();
-
-    if (numElements != rhsValues.size() || numElements % degree != 0) {
-      return {};
-    }
-
-    SmallVector<SmallVector<APInt>> results;
-    results.reserve(numElements / degree);
-
-    for (size_t i = 0; i < numElements; i += degree) {
-      SmallVector<APInt> lhsCoeffs(lhsValues.begin() + i,
-                                   lhsValues.begin() + i + degree);
-      SmallVector<APInt> rhsCoeffs(rhsValues.begin() + i,
-                                   rhsValues.begin() + i + degree);
-      results.push_back(operate(lhsCoeffs, rhsCoeffs));
-    }
-
+  OpFoldResult foldTensor(DenseElementsAttr lhsAttr,
+                          DenseElementsAttr rhsAttr) const override {
     auto shapedType = dyn_cast<ShapedType>(this->type);
-    if (!shapedType) {
+    if (!shapedType)
       return {};
-    }
-    return this->getTensorAttr(shapedType, results);
+    auto lhsGroups = this->extractValues(lhsAttr);
+    auto rhsGroups = this->extractValues(rhsAttr);
+    if (lhsGroups.size() != rhsGroups.size() || lhsGroups.empty())
+      return {};
+    SmallVector<SmallVector<APInt>, 0> results;
+    results.reserve(lhsGroups.size());
+    for (size_t i = 0; i < lhsGroups.size(); ++i)
+      results.push_back(operate(lhsGroups[i], rhsGroups[i]));
+    SmallVector<SmallVector<APInt>> resultsCopy(results.begin(), results.end());
+    return this->getTensorAttr(shapedType, resultsCopy);
   }
 
-  // Override single-arg foldTensor for special case optimizations.
-  // Subclasses (Additive/Multiplicative) will override with specific logic.
-  OpFoldResult foldTensor(DenseIntElementsAttr rhs) const override {
-    return {};
-  }
+  // Single-arg foldTensor: subclasses (Additive/Multiplicative) override with
+  // identity-fold logic.
+  OpFoldResult foldTensor(DenseElementsAttr rhs) const override { return {}; }
 
 protected:
   Op *const op;
@@ -1349,11 +1441,13 @@ public:
   }
 
   // Fold additive identity: x + 0 = x
-  OpFoldResult foldTensor(DenseIntElementsAttr rhs) const override {
-    auto rhsValues = rhs.getValues<APInt>();
-    // If all elements are zero, return lhs (x + 0 = x)
-    // NOLINTNEXTLINE(whitespace/newline)
-    if (llvm::all_of(rhsValues, [](const APInt &v) { return v.isZero(); })) {
+  OpFoldResult foldTensor(DenseElementsAttr rhs) const override {
+    auto groups = this->extractValues(rhs);
+    if (groups.empty())
+      return {};
+    if (llvm::all_of(groups, [](const SmallVector<APInt> &g) {
+          return llvm::all_of(g, [](const APInt &v) { return v.isZero(); });
+        })) {
       return this->op->getOperand(0);
     }
     return {};
@@ -1387,42 +1481,23 @@ public:
   }
 
   // Fold multiplicative identities: x * 0 = 0, x * 1 = x
-  OpFoldResult foldTensor(DenseIntElementsAttr rhs) const override {
-    auto rhsValues = rhs.getValues<APInt>();
-    unsigned degree = this->efType.getDegreeOverPrime();
-    size_t numElements = rhsValues.size();
-
-    if (numElements % degree != 0) {
+  OpFoldResult foldTensor(DenseElementsAttr rhs) const override {
+    auto groups = this->extractValues(rhs);
+    if (groups.empty())
       return {};
-    }
-
-    // Check if all extension field elements are zero or one
-    bool allZeros = true;
-    bool allOnes = true;
-
-    for (size_t i = 0; i < numElements; i += degree) {
-      SmallVector<APInt> coeffs(rhsValues.begin() + i,
-                                rhsValues.begin() + i + degree);
-      if (!isZero(coeffs)) {
+    bool allZeros = true, allOnes = true;
+    for (const auto &g : groups) {
+      if (!isZero(g))
         allZeros = false;
-      }
-      if (!isOne(coeffs)) {
+      if (!isOne(g))
         allOnes = false;
-      }
-      if (!allZeros && !allOnes) {
-        break; // Early exit if neither condition holds
-      }
+      if (!allZeros && !allOnes)
+        break;
     }
-
-    // x * 0 = 0, return rhs
-    if (allZeros) {
+    if (allZeros)
       return this->op->getOperand(1);
-    }
-    // x * 1 = x, return lhs
-    if (allOnes) {
+    if (allOnes)
       return this->op->getOperand(0);
-    }
-
     return {};
   }
 
@@ -1560,12 +1635,11 @@ OpFoldResult foldMixedBinaryOp(Op *op, typename Op::FoldAdaptor adaptor,
     return DenseIntElementsAttr::get(tensorType, flatCoeffs);
   }
 
-  // Tensor operands: fold element-wise. This loop runs at compile time and
-  // iterates over every element, but it only fires when both operands are
-  // constants — in practice these are small hand-written literals, not large
-  // tensors.
-  auto lhsDense = dyn_cast<DenseIntElementsAttr>(lhsAttr);
-  auto rhsDense = dyn_cast<DenseIntElementsAttr>(rhsAttr);
+  // Tensor operands: fold element-wise. Walks raw bytes so both legacy
+  // storage-int (DenseIntElementsAttr) and new field-typed
+  // (DenseElementsAttr<tensor<...x!T>>) constants work.
+  auto lhsDense = dyn_cast<DenseElementsAttr>(lhsAttr);
+  auto rhsDense = dyn_cast<DenseElementsAttr>(rhsAttr);
   if (!lhsDense || !rhsDense)
     return {};
 
@@ -1576,23 +1650,22 @@ OpFoldResult foldMixedBinaryOp(Op *op, typename Op::FoldAdaptor adaptor,
 
   unsigned lhsDeg = lhsFti.getDegreeOverPrime();
   unsigned rhsDeg = rhsFti.getDegreeOverPrime();
-  auto lhsVals = lhsDense.getValues<APInt>();
-  auto rhsVals = rhsDense.getValues<APInt>();
-  if (lhsVals.size() % lhsDeg != 0 || rhsVals.size() % rhsDeg != 0)
-    return {};
-  unsigned numElems = lhsVals.size() / lhsDeg;
-  if (numElems != rhsVals.size() / rhsDeg)
+  PrimeFieldType pfType = efType.getBasePrimeField();
+  unsigned primeBits = pfType.getTypeSizeInBits();
+  // Count field elements from the op's result type. A legacy storage-int
+  // constant's attr shape covers each element with its coefficient slots, so
+  // the two operands' `getNumElements()` disagree across differing degrees
+  // (e.g. EF deg-2 vs base PF); the result type carries the true count.
+  unsigned numElems = cast<ShapedType>(op->getType()).getNumElements();
+  auto lhsVals = coeffsFromRawBytes(lhsDense, primeBits, numElems * lhsDeg);
+  auto rhsVals = coeffsFromRawBytes(rhsDense, primeBits, numElems * rhsDeg);
+  if (lhsVals.empty() || rhsVals.empty())
     return {};
 
-  auto intType = lhsDense.getElementType();
+  auto intType = pfType.getStorageType();
 
-  // Extract the i-th field element as a TypedAttr suitable for
-  // FieldOperation::fromUnchecked (IntegerAttr for PF, DenseIntElementsAttr
-  // for EF).
-  auto extractElem = [intType](DenseIntElementsAttr dense, unsigned deg,
-                               unsigned idx,
+  auto extractElem = [intType](ArrayRef<APInt> vals, unsigned deg, unsigned idx,
                                FieldTypeInterface fti) -> TypedAttr {
-    auto vals = dense.getValues<APInt>();
     if (deg == 1)
       return IntegerAttr::get(intType, vals[idx]);
     SmallVector<APInt> coeffs;
@@ -1605,21 +1678,18 @@ OpFoldResult foldMixedBinaryOp(Op *op, typename Op::FoldAdaptor adaptor,
   SmallVector<APInt> resultCoeffs;
   for (unsigned i = 0; i < numElems; ++i) {
     auto lhsOp = FieldOperation::fromUnchecked(
-        extractElem(lhsDense, lhsDeg, i, lhsFti), lhsElemType);
+        extractElem(lhsVals, lhsDeg, i, lhsFti), lhsElemType);
     auto rhsOp = FieldOperation::fromUnchecked(
-        extractElem(rhsDense, rhsDeg, i, rhsFti), rhsElemType);
+        extractElem(rhsVals, rhsDeg, i, rhsFti), rhsElemType);
     SmallVector<APInt> elemCoeffs =
         static_cast<SmallVector<APInt>>(fn(lhsOp, rhsOp));
     resultCoeffs.append(elemCoeffs);
   }
 
-  auto storageType = efType.getBasePrimeField().getStorageType();
   auto resultShapedType = cast<ShapedType>(op->getType());
-  auto towerShape = efType.getAttrShape();
-  SmallVector<int64_t> attrShape(resultShapedType.getShape());
-  attrShape.append(towerShape.begin(), towerShape.end());
-  auto resultType = RankedTensorType::get(attrShape, storageType);
-  return DenseIntElementsAttr::get(resultType, resultCoeffs);
+  unsigned primeBytes = (pfType.getTypeSizeInBits() + 7) / 8;
+  auto bytes = packAPIntsLE(resultCoeffs, primeBytes);
+  return DenseElementsAttr::getFromRawBuffer(resultShapedType, bytes);
 }
 
 template <typename Op, typename Func>
@@ -1939,9 +2009,16 @@ bool compareWithOffset(Attribute attr, Value val, uint32_t offset,
                        Predicate pred) {
   Type elementType = getElementTypeOrSelf(val.getType());
 
-  // Guard DRR patterns against mixed-type ops: a DenseElementsAttr paired with
-  // a scalar PF value means the constant is an EF value. DRR patterns would
-  // produce a PF result instead of the required EF result type.
+  // Guard DRR patterns against mixed-type ops: a DenseElementsAttr paired
+  // with a PF value means the constant is an EF value with mismatched
+  // element type. DRR patterns would produce a PF result instead of the
+  // required EF result type. Bail.
+  if (auto denseAttr = dyn_cast<DenseElementsAttr>(attr)) {
+    Type attrElem = denseAttr.getType().getElementType();
+    if (isa<ExtensionFieldType>(attrElem) &&
+        !isa<ExtensionFieldType>(elementType))
+      return false;
+  }
   if (isa<DenseElementsAttr>(attr) && !isa<ShapedType>(val.getType()) &&
       !isa<ExtensionFieldType>(elementType))
     return false;
@@ -1950,34 +2027,42 @@ bool compareWithOffset(Attribute attr, Value val, uint32_t offset,
   TypedAttr typedAttr;
   if (auto intAttr = dyn_cast<IntegerAttr>(attr)) {
     typedAttr = intAttr;
-  } else if (auto splatAttr = dyn_cast<SplatElementsAttr>(attr)) {
-    // For EF types, a splat [v,v,...,v] can never be a valid scalar embedding
-    // [v,0,...,0] (unless degreeOverPrime == 1, but then it's PF).
-    if (isa<ExtensionFieldType>(elementType))
-      return false;
+  } else if (auto splatAttr = dyn_cast<SplatElementsAttr>(attr);
+             splatAttr && !isa<ExtensionFieldType>(elementType) &&
+             splatAttr.getElementType().isIntOrIndex()) {
+    // Storage-int splat (legacy DenseIntElementsAttr representation).
+    // For EF and field-typed dense, fall through to the DenseElementsAttr
+    // branch below which walks raw bytes for per-coeff comparison.
     typedAttr = splatAttr.getSplatValue<IntegerAttr>();
-  } else if (auto denseAttr = dyn_cast<DenseIntElementsAttr>(attr)) {
-    if (auto fti = dyn_cast<FieldTypeInterface>(elementType)) {
-      // Field types: verify all tensor elements are identical by checking
-      // each coefficient repeats the pattern of the first element.
+  } else if (auto denseAttr = dyn_cast<DenseElementsAttr>(attr)) {
+    if (auto fti = dyn_cast<FieldTypeInterface>(elementType);
+        fti && isa<PrimeFieldType, ExtensionFieldType>(elementType)) {
+      // PF/EF only: verify all tensor elements are identical by checking
+      // each coefficient repeats the pattern of the first element. Walks
+      // raw bytes so both legacy storage-int and new field-typed dense
+      // attrs work. BinaryField doesn't participate in mixed PF/EF DRR
+      // patterns.
+      auto pfType = field::getBasePrimeField(elementType);
       unsigned degreeOverPrime = fti.getDegreeOverPrime();
-      auto allValues = denseAttr.getValues<APInt>();
+      auto numElems = denseAttr.getType().getNumElements();
+      auto allValues = coeffsFromRawBytes(denseAttr, pfType.getTypeSizeInBits(),
+                                          numElems * degreeOverPrime);
+      if (allValues.empty())
+        return false;
       unsigned total = allValues.size();
       if (total % degreeOverPrime != 0)
         return false;
-
       for (unsigned i = degreeOverPrime; i < total; ++i) {
         if (allValues[i] != allValues[i % degreeOverPrime])
           return false;
       }
-
       if (degreeOverPrime == 1) {
-        typedAttr = IntegerAttr::get(denseAttr.getElementType(), allValues[0]);
+        typedAttr = IntegerAttr::get(pfType.getStorageType(), allValues[0]);
       } else {
         SmallVector<APInt> firstCoeffs(allValues.begin(),
                                        allValues.begin() + degreeOverPrime);
-        auto singleType = RankedTensorType::get(fti.getAttrShape(),
-                                                denseAttr.getElementType());
+        auto singleType =
+            RankedTensorType::get(fti.getAttrShape(), pfType.getStorageType());
         typedAttr = DenseIntElementsAttr::get(singleType, firstCoeffs);
       }
     } else {

--- a/prime_ir/Dialect/Field/IR/FieldOps.cpp
+++ b/prime_ir/Dialect/Field/IR/FieldOps.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 #include "prime_ir/Dialect/Field/IR/FieldOps.h"
 
 #include "llvm/ADT/TypeSwitch.h"
+#include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "prime_ir/Dialect/Field/IR/FieldDialect.h"
@@ -291,6 +292,36 @@ ParseResult parseFieldConstant(OpAsmParser &parser, OperationState &result) {
   }
   return parser.emitError(parser.getCurrentLocation(),
                           "unsupported element type for dense constant");
+}
+
+ParseResult parseOptionalFieldConstant(OpAsmParser &parser,
+                                       OperationState &result) {
+  // Mirrors the MLIR `parseOptional*` contract: try to parse, restore
+  // parser + `result` state on failure so the caller can try an
+  // alternative cleanly.
+  const char *startPtr = parser.getCurrentLocation().getPointer();
+  llvm::SmallVector<mlir::NamedAttribute> attrsSnapshot(
+      result.attributes.getAttrs());
+  size_t typesBefore = result.types.size();
+
+  // Capture parseFieldConstant's diagnostics; drop them on failure so the
+  // caller's pre-existing error stays surfaced. On success, parseFieldConstant
+  // emits no diagnostics, so the buffer is empty and dropping is a no-op.
+  llvm::SmallVector<mlir::Diagnostic, 2> captured;
+  mlir::ScopedDiagnosticHandler scope(
+      parser.getContext(), [&](mlir::Diagnostic &diag) {
+        captured.emplace_back(std::move(diag));
+        return mlir::success();
+      });
+
+  if (succeeded(parseFieldConstant(parser, result))) return success();
+
+  // Restore: rewind the token stream and roll back any attributes / result
+  // types parseFieldConstant added before failing.
+  parser.resetToken(startPtr);
+  result.attributes.assign(attrsSnapshot);
+  result.types.resize(typesBefore);
+  return failure();
 }
 
 OpFoldResult ConstantOp::fold(FoldAdaptor adaptor) {

--- a/prime_ir/Dialect/Field/IR/FieldOps.h
+++ b/prime_ir/Dialect/Field/IR/FieldOps.h
@@ -52,6 +52,22 @@ FailureOr<Attribute> validateAndCreateFieldAttribute(OpAsmParser &parser,
 
 ParseResult parseFieldConstant(OpAsmParser &parser, OperationState &result);
 
+// Optional variant: try to parse a field constant; on failure restore the
+// parser's token stream and `result` to the state at entry, so the caller
+// can attempt a different parser cleanly. Diagnostics emitted by the
+// underlying parseFieldConstant are captured and dropped on failure (the
+// caller's pre-existing error stays surfaced; on success no diagnostics
+// were emitted anyway).
+//
+// Mirrors the `parseOptional*` contract (succeed-and-consume, or
+// fail-without-consuming). Multi-token speculative parsing is required
+// because the first token (`dense`) is the same for field-typed and
+// non-field-typed dense literals — first-token dispatch can't
+// disambiguate. Rewind is via OpAsmParser::resetToken (provided by
+// asm_parser_rewind.patch).
+ParseResult parseOptionalFieldConstant(OpAsmParser &parser,
+                                       OperationState &result);
+
 } // namespace mlir::prime_ir::field
 
 #endif // PRIME_IR_DIALECT_FIELD_IR_FIELDOPS_H_

--- a/prime_ir/Dialect/Field/IR/FieldOps.td
+++ b/prime_ir/Dialect/Field/IR/FieldOps.td
@@ -94,7 +94,7 @@ def Field_ConstantOp : Field_Op_Base<"constant", [ConstantLike]> {
     OpBuilder<(ins "ExtensionFieldType":$ty, "uint64_t":$c0), [{
       auto primeField = ty.getBasePrimeField();
       unsigned degreeOverPrime = ty.getDegreeOverPrime();
-      unsigned bitWidth = primeField.getStorageBitWidth();
+      unsigned bitWidth = primeField.getTypeSizeInBits();
       SmallVector<APInt> coeffs(degreeOverPrime, APInt(bitWidth, 0));
       coeffs[0] = static_cast<APInt>(PrimeFieldOperation::fromUnchecked(APInt(bitWidth, c0), primeField));
       auto tensorType = RankedTensorType::get(ty.getAttrShape(), primeField.getStorageType());
@@ -103,7 +103,7 @@ def Field_ConstantOp : Field_Op_Base<"constant", [ConstantLike]> {
     OpBuilder<(ins "ExtensionFieldType":$ty, "llvm::ArrayRef<uint64_t>":$coeffs), [{
       assert(coeffs.size() == ty.getDegreeOverPrime() && "coefficient count must match total degree over prime");
       auto primeField = ty.getBasePrimeField();
-      unsigned bitWidth = primeField.getStorageBitWidth();
+      unsigned bitWidth = primeField.getTypeSizeInBits();
       SmallVector<APInt> coeffInts;
       for (auto c : coeffs)
         coeffInts.push_back(static_cast<APInt>(PrimeFieldOperation::fromUnchecked(APInt(bitWidth, c), primeField)));

--- a/prime_ir/Dialect/Field/IR/FieldTypes.cpp
+++ b/prime_ir/Dialect/Field/IR/FieldTypes.cpp
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "prime_ir/Dialect/Field/IR/FieldTypes.h"
 
+#include <cstring>
+
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "prime_ir/Dialect/Field/IR/FieldOperation.h"
@@ -22,6 +24,7 @@ limitations under the License.
 #include "prime_ir/Dialect/Field/IR/TowerFieldConfig.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithAttributes.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithOps.h"
+#include "prime_ir/IR/DenseElementBytes.h"
 #include "prime_ir/Utils/AssemblyFormatUtils.h"
 
 namespace mlir::prime_ir::field {
@@ -39,7 +42,7 @@ bool isMontgomery(Type type) {
 unsigned getIntOrPrimeFieldBitWidth(Type type) {
   assert((llvm::isa<PrimeFieldType, IntegerType>(type)));
   if (auto pfType = dyn_cast<PrimeFieldType>(type)) {
-    return pfType.getStorageBitWidth();
+    return pfType.getTypeSizeInBits();
   }
   return cast<IntegerType>(type).getWidth();
 }
@@ -145,7 +148,7 @@ void PrimeFieldType::print(AsmPrinter &printer) const {
 
 llvm::TypeSize PrimeFieldType::getTypeSizeInBits(
     DataLayout const &, llvm::ArrayRef<DataLayoutEntryInterface>) const {
-  return llvm::TypeSize::getFixed(getStorageBitWidth());
+  return llvm::TypeSize::getFixed(getTypeSizeInBits());
 }
 
 uint64_t PrimeFieldType::getABIAlignment(
@@ -221,7 +224,7 @@ void BinaryFieldType::print(AsmPrinter &printer) const {
 
 llvm::TypeSize BinaryFieldType::getTypeSizeInBits(
     DataLayout const &, llvm::ArrayRef<DataLayoutEntryInterface>) const {
-  return llvm::TypeSize::getFixed(getBitWidth());
+  return llvm::TypeSize::getFixed(getTypeSizeInBits());
 }
 
 uint64_t BinaryFieldType::getABIAlignment(
@@ -510,8 +513,7 @@ void ExtensionFieldType::print(AsmPrinter &printer) const {
 
 llvm::TypeSize ExtensionFieldType::getTypeSizeInBits(
     DataLayout const &, llvm::ArrayRef<DataLayoutEntryInterface>) const {
-  return llvm::TypeSize::getFixed(getDegreeOverPrime() *
-                                  getBasePrimeField().getStorageBitWidth());
+  return llvm::TypeSize::getFixed(getTypeSizeInBits());
 }
 
 uint64_t ExtensionFieldType::getABIAlignment(
@@ -533,7 +535,7 @@ TypedAttr ExtensionFieldType::createConstantAttr(int64_t c) const {
   PrimeFieldType pfType = getBasePrimeField();
   PrimeFieldOperation pfOp(c, pfType); // Handles Montgomery conversion
   unsigned degreeOverPrime = getDegreeOverPrime();
-  unsigned bitWidth = pfType.getStorageBitWidth();
+  unsigned bitWidth = pfType.getTypeSizeInBits();
 
   SmallVector<APInt> coeffs(degreeOverPrime, APInt::getZero(bitWidth));
   coeffs[0] = static_cast<APInt>(pfOp);
@@ -547,6 +549,61 @@ ExtensionFieldType::createConstantAttrFromValues(ArrayRef<APInt> coeffs) const {
 
 ShapedType ExtensionFieldType::overrideShapedType(ShapedType type) const {
   return type;
+}
+
+size_t ExtensionFieldType::getDenseElementBitSize() const {
+  return getTypeSizeInBits();
+}
+
+// An EF element serializes as its `degreeOverPrime` prime-field coefficients,
+// each a storage-int's worth of little-endian bytes. The (de)serialization is
+// symmetric with the `tensor<degree x iStorage>` cover the AsmPrinter walks.
+Attribute
+ExtensionFieldType::convertToAttribute(::llvm::ArrayRef<char> rawData) const {
+  PrimeFieldType pfType = getBasePrimeField();
+  unsigned primeBits = pfType.getTypeSizeInBits();
+  // Sub-byte prime storage isn't supported — would need bit-packing per coeff.
+  if (primeBits % 8 != 0)
+    return Attribute{};
+  unsigned primeBytes = primeBits / 8;
+  unsigned degree = getDegreeOverPrime();
+  if (rawData.size() != degree * primeBytes)
+    return Attribute{};
+
+  auto tensorTy = RankedTensorType::get({static_cast<int64_t>(degree)},
+                                        pfType.getStorageType());
+  return DenseElementsAttr::getFromRawBuffer(tensorTy, rawData);
+}
+
+::llvm::LogicalResult ExtensionFieldType::convertFromAttribute(
+    Attribute attr, ::llvm::SmallVectorImpl<char> &result) const {
+  PrimeFieldType pfType = getBasePrimeField();
+  unsigned primeBits = pfType.getTypeSizeInBits();
+  if (primeBits % 8 != 0)
+    return failure();
+  unsigned primeBytes = primeBits / 8;
+  unsigned degree = getDegreeOverPrime();
+
+  auto denseAttr = dyn_cast<DenseElementsAttr>(attr);
+  if (!denseAttr)
+    return failure();
+  if (denseAttr.getNumElements() != static_cast<int64_t>(degree))
+    return failure();
+
+  ArrayRef<char> raw = denseAttr.getRawData();
+  size_t want = static_cast<size_t>(degree) * primeBytes;
+  if (denseAttr.isSplat()) {
+    if (raw.size() != primeBytes)
+      return failure();
+    result.reserve(result.size() + want);
+    for (unsigned i = 0; i < degree; ++i)
+      result.append(raw.begin(), raw.end());
+  } else {
+    if (raw.size() != want)
+      return failure();
+    result.append(raw.begin(), raw.end());
+  }
+  return success();
 }
 
 unsigned ExtensionFieldType::getDegreeOverPrime() const {

--- a/prime_ir/Dialect/Field/IR/FieldTypes.td
+++ b/prime_ir/Dialect/Field/IR/FieldTypes.td
@@ -95,9 +95,10 @@ def Field_PrimeFieldType : Field_Type<"PrimeField", "pf", [
       // Prime field: use modulus type as-is
       return cast<IntegerType>(getModulus().getType());
     }
-    unsigned getStorageBitWidth() const {
-      return getStorageType().getWidth();
-    }
+    /// Returns the bit width of an element in this type.
+    unsigned getTypeSizeInBits() const { return getStorageType().getWidth(); }
+    [[deprecated("use getTypeSizeInBits() instead")]]
+    unsigned getStorageBitWidth() const { return getTypeSizeInBits(); }
   }];
   let hasCustomAssemblyFormat = 1;
 }
@@ -148,8 +149,12 @@ def Field_BinaryFieldType : Field_Type<"BinaryField", "bf", [
       return IntegerType::get(getContext(), getBitWidth());
     }
 
+    /// Returns the bit width of an element in this type.
+    unsigned getTypeSizeInBits() const { return getBitWidth(); }
+
     /// Returns the storage bit width.
-    unsigned getStorageBitWidth() const { return getBitWidth(); }
+    [[deprecated("use getTypeSizeInBits() instead")]]
+    unsigned getStorageBitWidth() const { return getTypeSizeInBits(); }
 
     /// Maximum supported tower level (GF(2^128)).
     static constexpr unsigned kMaxTowerLevel = 7;
@@ -167,7 +172,8 @@ def Field_ExtensionFieldType : Field_Type<"ExtensionField", "ef", [
   VectorElementTypeInterface,
   DeclareTypeInterfaceMethods<FieldTypeInterface>,
   DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
-  DeclareTypeInterfaceMethods<ConstantLikeInterface>
+  DeclareTypeInterfaceMethods<ConstantLikeInterface>,
+  DeclareTypeInterfaceMethods<DenseElementTypeInterface>
   ]> {
   let summary = "Extension field element type";
   let description = [{
@@ -203,10 +209,14 @@ def Field_ExtensionFieldType : Field_Type<"ExtensionField", "ef", [
     // Returns the tower depth (1 for direct extension over prime).
     unsigned getTowerDepth() const;
 
-    // Returns the total storage bit width (degreeOverPrime * prime field width).
-    unsigned getStorageBitWidth() const {
-      return getDegreeOverPrime() * getBasePrimeField().getStorageBitWidth();
+    // Returns the total bit width (degreeOverPrime * prime field width).
+    unsigned getTypeSizeInBits() const {
+      return getDegreeOverPrime() * getBasePrimeField().getTypeSizeInBits();
     }
+
+    // Returns the total storage bit width (degreeOverPrime * prime field width).
+    [[deprecated("use getTypeSizeInBits() instead")]]
+    unsigned getStorageBitWidth() const { return getTypeSizeInBits(); }
 
     Type cloneWith(Type baseField, Attribute element) const;
 

--- a/prime_ir/Dialect/Field/IR/PrimeFieldOperation.h
+++ b/prime_ir/Dialect/Field/IR/PrimeFieldOperation.h
@@ -58,7 +58,7 @@ public:
       : op(value, convertPrimeFieldType(type)), type(type) {}
 
   static PrimeFieldOperation fromUnchecked(int64_t value, PrimeFieldType type) {
-    return fromUnchecked(APInt(type.getStorageBitWidth(), value), type);
+    return fromUnchecked(APInt(type.getTypeSizeInBits(), value), type);
   }
   static PrimeFieldOperation fromUnchecked(const APInt &value,
                                            PrimeFieldType type) {

--- a/prime_ir/Dialect/Field/Transforms/FoldFieldLinalgContraction.cpp
+++ b/prime_ir/Dialect/Field/Transforms/FoldFieldLinalgContraction.cpp
@@ -41,23 +41,36 @@ unsigned getFieldDegree(Type elementType) {
 // Extract a scalar field element's attribute from a dense tensor attribute.
 // For tensor<MxN x PrimeField>: denseAttr has M*N elements
 // For tensor<MxN x ExtensionField<degree>>: denseAttr has M*N*degree elements
-TypedAttr extractFieldElementAttr(DenseIntElementsAttr denseAttr,
-                                  Type elementType, int64_t linearIndex) {
+TypedAttr extractFieldElementAttr(DenseElementsAttr denseAttr, Type elementType,
+                                  int64_t linearIndex) {
   unsigned degree = getFieldDegree(elementType);
-  auto values = denseAttr.getValues<APInt>();
+  PrimeFieldType pfType =
+      isa<PrimeFieldType>(elementType)
+          ? cast<PrimeFieldType>(elementType)
+          : cast<ExtensionFieldType>(elementType).getBasePrimeField();
+  unsigned primeBits = pfType.getTypeSizeInBits();
+  unsigned primeBytes = (primeBits + 7) / 8;
+  ArrayRef<char> raw = denseAttr.getRawData();
+  bool splat = denseAttr.isSplat();
+  unsigned available = raw.size() / primeBytes;
+  auto readCoeff = [&](unsigned idx) {
+    unsigned src = splat ? (idx % available) : idx;
+    unsigned numWords = (primeBits + 63) / 64;
+    SmallVector<uint64_t, 4> words(numWords, 0);
+    std::memcpy(words.data(), raw.data() + src * primeBytes, primeBytes);
+    return APInt(primeBits, words);
+  };
 
-  if (auto pfType = dyn_cast<PrimeFieldType>(elementType)) {
-    return IntegerAttr::get(pfType.getStorageType(), values[linearIndex]);
+  if (isa<PrimeFieldType>(elementType)) {
+    return IntegerAttr::get(pfType.getStorageType(), readCoeff(linearIndex));
   }
-
   auto efType = cast<ExtensionFieldType>(elementType);
   SmallVector<APInt> coeffs;
-  for (unsigned d = 0; d < degree; ++d) {
-    coeffs.push_back(values[linearIndex * degree + d]);
-  }
-  auto tensorType =
-      RankedTensorType::get({static_cast<int64_t>(degree)},
-                            efType.getBasePrimeField().getStorageType());
+  for (unsigned d = 0; d < degree; ++d)
+    coeffs.push_back(readCoeff(linearIndex * degree + d));
+  auto tensorType = RankedTensorType::get({static_cast<int64_t>(degree)},
+                                          pfType.getStorageType());
+  (void)efType;
   return DenseIntElementsAttr::get(tensorType, coeffs);
 }
 
@@ -91,7 +104,7 @@ struct FoldMatvecWithConstantMatrix : OpRewritePattern<linalg::MatvecOp> {
       return failure();
 
     // Get the dense attribute from the constant
-    auto denseAttr = dyn_cast<DenseIntElementsAttr>(matrixConst.getValue());
+    auto denseAttr = dyn_cast<DenseElementsAttr>(matrixConst.getValue());
     if (!denseAttr)
       return failure();
 
@@ -204,12 +217,9 @@ struct FoldDotWithConstantVector : OpRewritePattern<linalg::DotOp> {
       return failure();
     }
 
-    // Get the dense attribute from the constant
-    auto denseAttr = dyn_cast<DenseIntElementsAttr>(constOp.getValue());
+    auto denseAttr = dyn_cast<DenseElementsAttr>(constOp.getValue());
     if (!denseAttr)
       return failure();
-
-    // Get vector shape
     auto vecType = cast<RankedTensorType>(constOp.getType());
     if (vecType.getRank() != 1)
       return failure();

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -87,7 +87,7 @@ public:
 
 private:
   static IntegerType convertModArithType(ModArithType type) {
-    return IntegerType::get(type.getContext(), type.getStorageBitWidth());
+    return IntegerType::get(type.getContext(), type.getTypeSizeInBits());
   }
 };
 
@@ -129,7 +129,7 @@ protected:
     auto modType = dyn_cast<ModArithType>(getElementTypeOrSelf(v.getType()));
     if (!modType)
       return APInt(64, 0);
-    unsigned w = modType.getStorageBitWidth();
+    unsigned w = modType.getTypeSizeInBits();
     APInt p = modType.getModulus().getValue().zext(2 * w);
     return p - 1;
   }
@@ -139,7 +139,7 @@ protected:
     auto modType = dyn_cast<ModArithType>(getElementTypeOrSelf(v.getType()));
     if (!modType)
       return 1;
-    unsigned w = modType.getStorageBitWidth();
+    unsigned w = modType.getTypeSizeInBits();
     APInt p = modType.getModulus().getValue().zext(2 * w);
     return kpFromUmax(lookupUmax(v), p);
   }
@@ -150,7 +150,7 @@ protected:
 // Returns storage bit width for a type, handling ModArithType.
 unsigned getModArithStorageBitwidth(Type type) {
   if (auto modType = dyn_cast<ModArithType>(getElementTypeOrSelf(type)))
-    return modType.getStorageBitWidth();
+    return modType.getTypeSizeInBits();
   return ConstantIntRanges::getStorageBitwidth(type);
 }
 
@@ -308,7 +308,7 @@ void buildBoundMap(func::FuncOp funcOp, BoundMap &boundMap) {
       if (!modType)
         continue;
 
-      unsigned w = modType.getStorageBitWidth();
+      unsigned w = modType.getTypeSizeInBits();
       unsigned dw = 2 * w;
       APInt p = modType.getModulus().getValue().zext(dw);
       APInt defaultUmax = p - 1;
@@ -361,7 +361,7 @@ void buildBoundMap(func::FuncOp funcOp, BoundMap &boundMap) {
     auto modType = dyn_cast<ModArithType>(getElementTypeOrSelf(val.getType()));
     if (!modType)
       continue;
-    unsigned w = modType.getStorageBitWidth();
+    unsigned w = modType.getTypeSizeInBits();
     unsigned dw = 2 * w;
     APInt p = modType.getModulus().getValue().zext(dw);
     if (kpFromUmax(umax, p) <= 1)
@@ -689,7 +689,7 @@ struct ConvertAdd : public BoundMapPattern<AddOp> {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
     ModArithType modArithType = getResultModArithType(op);
     APInt modulus = modArithType.getModulus().getValue();
-    unsigned storageWidth = modArithType.getStorageBitWidth();
+    unsigned storageWidth = modArithType.getTypeSizeInBits();
     unsigned modWidth = modulus.getActiveBits();
     uint64_t resBound = lookupKp(op.getResult());
 
@@ -768,7 +768,7 @@ struct ConvertDouble : public BoundMapPattern<DoubleOp> {
 
     ModArithType modArithType = getResultModArithType(op);
     APInt modulus = modArithType.getModulus().getValue();
-    unsigned storageWidth = modArithType.getStorageBitWidth();
+    unsigned storageWidth = modArithType.getTypeSizeInBits();
     unsigned modWidth = modulus.getActiveBits();
     uint64_t resBound = lookupKp(op.getResult());
 
@@ -836,7 +836,7 @@ struct ConvertSub : public BoundMapPattern<SubOp> {
     MontReducer montReducer(b, modType);
     Value lhs = adaptor.getLhs();
     Value rhs = adaptor.getRhs();
-    unsigned w = modType.getStorageBitWidth();
+    unsigned w = modType.getTypeSizeInBits();
     unsigned dw = 2 * w;
     APInt wMax = APInt::getMaxValue(w).zext(dw);
     APInt p = modType.getModulus().getValue().zext(dw);
@@ -1105,7 +1105,7 @@ struct ConvertMontMul : public BoundMapPattern<MontMulOp> {
     APInt lhsUmax = lookupUmax(op.getLhs());
     APInt rhsUmax = lookupUmax(op.getRhs());
     MontReducer reducer(b, modType);
-    unsigned w = modType.getStorageBitWidth();
+    unsigned w = modType.getTypeSizeInBits();
     unsigned qw = 4 * w;
     APInt p = modType.getModulus().getValue().zext(qw);
     APInt redcLimit = p.shl(w);
@@ -1352,7 +1352,7 @@ struct ConvertSquare : public OpConversionPattern<SquareOp> {
     Value lowExt = arith::ExtUIOp::create(b, intExtType, result.lo);
     Value highExt = arith::ExtUIOp::create(b, intExtType, result.hi);
     Value shift = arith::ConstantIntOp::create(b, intExtType,
-                                               modType.getStorageBitWidth());
+                                               modType.getTypeSizeInBits());
     highExt = arith::ShLIOp::create(b, highExt, shift);
     Value squared = arith::OrIOp::create(b, lowExt, highExt);
 
@@ -1385,7 +1385,7 @@ struct ConvertMontSquare : public BoundMapPattern<MontSquareOp> {
     Value input = adaptor.getInput();
     APInt inputUmax = lookupUmax(op.getInput());
     MontReducer reducer(b, modType);
-    unsigned w = modType.getStorageBitWidth();
+    unsigned w = modType.getTypeSizeInBits();
     unsigned qw = 4 * w;
     APInt p = modType.getModulus().getValue().zext(qw);
     APInt redcLimit = p.shl(w);

--- a/prime_ir/Dialect/ModArith/IR/BUILD.bazel
+++ b/prime_ir/Dialect/ModArith/IR/BUILD.bazel
@@ -62,6 +62,7 @@ prime_ir_cc_library(
         ":dialect_inc_gen",
         ":ops_inc_gen",
         ":types_inc_gen",
+        "//prime_ir/IR:DenseElementBytes",
         "//prime_ir/Utils:APIntUtils",
         "//prime_ir/Utils:AssemblyFormatUtils",
         "//prime_ir/Utils:BitcastOpUtils",

--- a/prime_ir/Dialect/ModArith/IR/ModArithOperation.h
+++ b/prime_ir/Dialect/ModArith/IR/ModArithOperation.h
@@ -53,7 +53,7 @@ public:
     }
   }
   ModArithOperation(uint64_t value, ModArithType type)
-      : ModArithOperation(APInt(type.getStorageBitWidth(), value), type) {}
+      : ModArithOperation(APInt(type.getTypeSizeInBits(), value), type) {}
 
   static ModArithOperation fromUnchecked(const APInt &value,
                                          ModArithType type) {

--- a/prime_ir/Dialect/ModArith/IR/ModArithOps.cpp
+++ b/prime_ir/Dialect/ModArith/IR/ModArithOps.cpp
@@ -276,7 +276,7 @@ LogicalResult MontReduceOp::verify() {
       cast<IntegerType>(getElementTypeOrSelf(getLow().getType()));
   ModArithType modArithType = getResultModArithType(*this);
   unsigned intWidth = integerType.getWidth();
-  unsigned modWidth = modArithType.getStorageBitWidth();
+  unsigned modWidth = modArithType.getTypeSizeInBits();
   if (intWidth != modWidth)
     return emitOpError() << "Expected operand width to be " << modWidth
                          << ", but got " << intWidth << " instead.";
@@ -491,7 +491,7 @@ void setCanonicalRange(Value result, SetIntRangeFn setResultRange) {
 // etc.). Requires 2p - 1 to fit in w bits.
 void setLazyRedcRange(Value result, SetIntRangeFn setResultRange) {
   auto modType = cast<ModArithType>(getElementTypeOrSelf(result.getType()));
-  unsigned w = modType.getStorageBitWidth();
+  unsigned w = modType.getTypeSizeInBits();
   APInt p = modType.getModulus().getValue().zext(w);
   APInt twoPMinusOne = p.zext(w + 1) * APInt(w + 1, 2) - 1;
   assert(twoPMinusOne.getActiveBits() <= w &&
@@ -504,7 +504,7 @@ void setLazyRedcRange(Value result, SetIntRangeFn setResultRange) {
 
 ConstantIntRanges getCanonicalRange(Type type) {
   auto modType = cast<ModArithType>(getElementTypeOrSelf(type));
-  unsigned w = modType.getStorageBitWidth();
+  unsigned w = modType.getTypeSizeInBits();
   APInt p = modType.getModulus().getValue().zext(w);
   return ConstantIntRanges::fromUnsigned(APInt::getZero(w), p - 1);
 }
@@ -512,7 +512,7 @@ ConstantIntRanges getCanonicalRange(Type type) {
 void ConstantOp::inferResultRanges(ArrayRef<ConstantIntRanges> /*argRanges*/,
                                    SetIntRangeFn setResultRange) {
   auto modType = cast<ModArithType>(getElementTypeOrSelf(getType()));
-  unsigned w = modType.getStorageBitWidth();
+  unsigned w = modType.getTypeSizeInBits();
   auto attr = dyn_cast<IntegerAttr>(getValue());
   if (attr) {
     APInt val = attr.getValue().zext(w);
@@ -572,7 +572,7 @@ void NegateOp::inferResultRanges(ArrayRef<ConstantIntRanges> /*argRanges*/,
 void DoubleOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
                                  SetIntRangeFn setResultRange) {
   auto modType = cast<ModArithType>(getElementTypeOrSelf(getType()));
-  unsigned w = modType.getStorageBitWidth();
+  unsigned w = modType.getTypeSizeInBits();
   // double(x) = 2x, so umax = 2 * input.umax. May exceed w bits for lazy
   // inputs (e.g., BabyBear with 32-bit storage and input in [0, 2p)).
   // Clamping to maxValue(w) is conservative; the lowering's pre-reduce guard
@@ -606,7 +606,7 @@ void MontInverseOp::inferResultRanges(ArrayRef<ConstantIntRanges> /*argRanges*/,
 void AddOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
                               SetIntRangeFn setResultRange) {
   auto modType = cast<ModArithType>(getElementTypeOrSelf(getType()));
-  unsigned w = modType.getStorageBitWidth();
+  unsigned w = modType.getTypeSizeInBits();
   // Sum of two unsigned ranges, clamped to w bits.
   APInt sumMax =
       argRanges[0].umax().zext(w + 1) + argRanges[1].umax().zext(w + 1);
@@ -618,7 +618,7 @@ void AddOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
 void SubOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
                               SetIntRangeFn setResultRange) {
   auto modType = cast<ModArithType>(getElementTypeOrSelf(getType()));
-  unsigned w = modType.getStorageBitWidth();
+  unsigned w = modType.getTypeSizeInBits();
   APInt p = modType.getModulus().getValue().zext(w);
   // lhs + correction - rhs where correction = rhsBound * p,
   // rhsBound = ceil((rhs.umax + 1) / p). Must match ConvertSub lowering.

--- a/prime_ir/Dialect/ModArith/IR/ModArithTypes.cpp
+++ b/prime_ir/Dialect/ModArith/IR/ModArithTypes.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 #include "prime_ir/Dialect/ModArith/IR/ModArithTypes.h"
 
 #include "prime_ir/Dialect/ModArith/IR/ModArithOperation.h"
+#include "prime_ir/IR/DenseElementBytes.h"
 #include "prime_ir/Utils/AssemblyFormatUtils.h"
 
 namespace mlir::prime_ir::mod_arith {
@@ -31,7 +32,7 @@ void ModArithType::print(AsmPrinter &printer) const {
 llvm::TypeSize ModArithType::getTypeSizeInBits(
     mlir::DataLayout const &,
     llvm::ArrayRef<mlir::DataLayoutEntryInterface>) const {
-  return llvm::TypeSize::getFixed(getStorageBitWidth());
+  return llvm::TypeSize::getFixed(getTypeSizeInBits());
 }
 
 uint64_t

--- a/prime_ir/Dialect/ModArith/IR/ModArithTypes.h
+++ b/prime_ir/Dialect/ModArith/IR/ModArithTypes.h
@@ -32,7 +32,7 @@ namespace mlir::prime_ir::mod_arith {
 inline unsigned getIntOrModArithBitWidth(Type type) {
   assert((llvm::isa<ModArithType, IntegerType>(type)));
   if (auto modArithType = dyn_cast<ModArithType>(type)) {
-    return modArithType.getStorageBitWidth();
+    return modArithType.getTypeSizeInBits();
   }
   return cast<IntegerType>(type).getWidth();
 }

--- a/prime_ir/Dialect/ModArith/IR/ModArithTypes.td
+++ b/prime_ir/Dialect/ModArith/IR/ModArithTypes.td
@@ -95,13 +95,14 @@ def ModArith_ModArithType : ModArith_Type<"ModArith", "int", [
       // Prime field: use modulus type as-is
       return cast<IntegerType>(getModulus().getType());
     }
-    unsigned getStorageBitWidth() const {
-      return getStorageType().getWidth();
-    }
+    /// Returns the bit width of an element in this type.
+    unsigned getTypeSizeInBits() const { return getStorageType().getWidth(); }
+    [[deprecated("use getTypeSizeInBits() instead")]]
+    unsigned getStorageBitWidth() const { return getTypeSizeInBits(); }
     // Returns floor((2^storageWidth - 1) / modulus).
     uint64_t getMaxBound() const {
       APInt mod = getModulus().getValue();
-      unsigned w = getStorageBitWidth();
+      unsigned w = getTypeSizeInBits();
       APInt maxVal = APInt::getMaxValue(w);
       APInt modW = mod.zext(w);
       return maxVal.udiv(modW).getZExtValue();

--- a/prime_ir/IR/Attributes.cpp
+++ b/prime_ir/IR/Attributes.cpp
@@ -15,10 +15,23 @@ limitations under the License.
 
 #include "prime_ir/IR/Attributes.h"
 
+#include "prime_ir/Dialect/EllipticCurve/IR/EllipticCurveTypes.h"
 #include "prime_ir/Dialect/Field/IR/FieldTypes.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithTypes.h"
 
 namespace mlir::prime_ir {
+
+namespace {
+unsigned fieldElementBits(Type t) {
+  if (auto pf = dyn_cast<field::PrimeFieldType>(t))
+    return pf.getTypeSizeInBits();
+  if (auto ef = dyn_cast<field::ExtensionFieldType>(t))
+    return ef.getTypeSizeInBits();
+  if (auto bf = dyn_cast<field::BinaryFieldType>(t))
+    return bf.getTypeSizeInBits();
+  llvm_unreachable("unsupported base field type");
+}
+} // namespace
 
 ShapedType maybeConvertPrimeIRToBuiltinType(ShapedType type) {
   auto elementType = type.getElementType();
@@ -36,6 +49,15 @@ ShapedType maybeConvertPrimeIRToBuiltinType(ShapedType type) {
     SmallVector<int64_t> attrShape(type.getShape());
     attrShape.append(towerDims.begin(), towerDims.end());
     return type.clone(attrShape, pfType.getStorageType());
+  } else if (auto ptType =
+                 dyn_cast<elliptic_curve::PointTypeInterface>(elementType)) {
+    // A point appends a coordinate dim; each coord is one base-field-wide int
+    // (e.g. tensor<4x!affine<pf>> stores as tensor<4x2xi32>).
+    SmallVector<int64_t> shape(type.getShape());
+    shape.push_back(ptType.getNumCoords());
+    return type.clone(
+        shape, IntegerType::get(type.getContext(),
+                                fieldElementBits(ptType.getBaseFieldType())));
   }
   return type;
 }

--- a/prime_ir/IR/Attributes.cpp
+++ b/prime_ir/IR/Attributes.cpp
@@ -40,4 +40,18 @@ ShapedType maybeConvertPrimeIRToBuiltinType(ShapedType type) {
   return type;
 }
 
+DenseElementsAttr maybeConvertPrimeIRToBuiltinAttr(DenseElementsAttr attr) {
+  auto builtinType = maybeConvertPrimeIRToBuiltinType(attr.getType());
+  if (builtinType == attr.getType())
+    return attr;
+  // A splat holds one logical element's bytes (EF: degree primes; EC point:
+  // numCoords coords); the storage-int form has no splat encoding for a
+  // multi-int row, so tile across all N elements.
+  if (attr.isSplat())
+    return denseIntFromRawBytes(
+        builtinType,
+        replicateRawBytes(attr.getRawData(), attr.getType().getNumElements()));
+  return denseIntFromRawBytes(builtinType, attr.getRawData());
+}
+
 } // namespace mlir::prime_ir

--- a/prime_ir/IR/Attributes.h
+++ b/prime_ir/IR/Attributes.h
@@ -24,9 +24,9 @@ namespace mlir::prime_ir {
 
 ShapedType maybeConvertPrimeIRToBuiltinType(ShapedType type);
 
-// Attr-level dual of maybeConvertPrimeIRToBuiltinType: retype an EF-typed dense
-// value as its storage-int tower. Returns attr unchanged when the type already
-// maps to itself (PF/BF/ModArith and builtin ints).
+// Attr-level dual of maybeConvertPrimeIRToBuiltinType: retype a native-typed
+// dense value (EF or EC point) as its storage-int form. Returns attr unchanged
+// when the type already maps to itself (PF/BF/ModArith and builtin ints).
 DenseElementsAttr maybeConvertPrimeIRToBuiltinAttr(DenseElementsAttr attr);
 
 } // namespace mlir::prime_ir

--- a/prime_ir/IR/Attributes.h
+++ b/prime_ir/IR/Attributes.h
@@ -16,11 +16,18 @@ limitations under the License.
 #ifndef PRIME_IR_IR_ATTRIBUTES_H_
 #define PRIME_IR_IR_ATTRIBUTES_H_
 
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "prime_ir/IR/DenseElementBytes.h"
 
 namespace mlir::prime_ir {
 
 ShapedType maybeConvertPrimeIRToBuiltinType(ShapedType type);
+
+// Attr-level dual of maybeConvertPrimeIRToBuiltinType: retype an EF-typed dense
+// value as its storage-int tower. Returns attr unchanged when the type already
+// maps to itself (PF/BF/ModArith and builtin ints).
+DenseElementsAttr maybeConvertPrimeIRToBuiltinAttr(DenseElementsAttr attr);
 
 } // namespace mlir::prime_ir
 

--- a/prime_ir/IR/BUILD.bazel
+++ b/prime_ir/IR/BUILD.bazel
@@ -20,12 +20,23 @@ package(
 )
 
 prime_ir_cc_library(
+    name = "DenseElementBytes",
+    hdrs = ["DenseElementBytes.h"],
+    deps = [
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+prime_ir_cc_library(
     name = "Attributes",
     srcs = ["Attributes.cpp"],
     hdrs = ["Attributes.h"],
     deps = [
+        ":DenseElementBytes",
         "//prime_ir/Dialect/Field/IR:FieldHdrs",
         "//prime_ir/Dialect/ModArith/IR:ModArithHdrs",
+        "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
     ],
 )

--- a/prime_ir/IR/BUILD.bazel
+++ b/prime_ir/IR/BUILD.bazel
@@ -34,6 +34,7 @@ prime_ir_cc_library(
     hdrs = ["Attributes.h"],
     deps = [
         ":DenseElementBytes",
+        "//prime_ir/Dialect/EllipticCurve/IR:EllipticCurveHdrs",
         "//prime_ir/Dialect/Field/IR:FieldHdrs",
         "//prime_ir/Dialect/ModArith/IR:ModArithHdrs",
         "@llvm-project//llvm:Support",

--- a/prime_ir/IR/DenseElementBytes.h
+++ b/prime_ir/IR/DenseElementBytes.h
@@ -1,0 +1,148 @@
+/* Copyright 2025 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Pure APInt <-> byte primitives backing the DenseElementTypeInterface
+// (de)serialization for prime_ir field / mod_arith / elliptic-curve types.
+// Header-only and dependency-free beyond LLVM ADT + MLIR builtin types so the
+// base ModArith dialect can share them without depending on the field layer.
+// All helpers assume a little-endian host, matching MLIR's
+// DenseElementsAttr::getRawData layout.
+
+#ifndef PRIME_IR_IR_DENSEELEMENTBYTES_H_
+#define PRIME_IR_IR_DENSEELEMENTBYTES_H_
+
+#include <cstring>
+
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Endian.h"
+#include "llvm/Support/LogicalResult.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+namespace mlir::prime_ir {
+
+// Low `numBytes` of `v.getRawData()` as a char view. LE-host only.
+inline llvm::ArrayRef<char> apintLowBytes(const llvm::APInt &v,
+                                          unsigned numBytes) {
+  static_assert(llvm::endianness::native == llvm::endianness::little,
+                "prime_ir's APInt byte view assumes LE host");
+  return {reinterpret_cast<const char *>(v.getRawData()), numBytes};
+}
+
+// Pack APInts as a LE byte buffer (`bytesPerInt` each).
+inline llvm::SmallVector<char> packAPIntsLE(llvm::ArrayRef<llvm::APInt> coeffs,
+                                            unsigned bytesPerInt) {
+  llvm::SmallVector<char> bytes;
+  bytes.reserve(coeffs.size() * bytesPerInt);
+  for (const llvm::APInt &v : coeffs) {
+    auto chunk = apintLowBytes(v, bytesPerInt);
+    bytes.append(chunk.begin(), chunk.end());
+  }
+  return bytes;
+}
+
+// Decode `raw` as `total` `primeBits`-wide APInts (LE, `primeBytes` each).
+// `available` is the number of source coeffs; values past index `available`
+// wrap modulo it, so callers can pass an already-replicated buffer or use
+// the splat-aware DenseElementsAttr overload below.
+inline llvm::SmallVector<llvm::APInt, 0>
+coeffsFromRawBytes(llvm::ArrayRef<char> raw, size_t available, size_t total,
+                   unsigned primeBits) {
+  unsigned primeBytes = (primeBits + 7) / 8;
+  llvm::SmallVector<llvm::APInt, 0> coeffs;
+  coeffs.reserve(total);
+  if (primeBits <= 64) {
+    // Single-word fast path — skips per-coeff SmallVector<uint64_t>. Hot path
+    // for Babybear / Goldilocks / Mersenne31.
+    for (size_t i = 0; i < total; ++i) {
+      uint64_t word = 0;
+      std::memcpy(&word, raw.data() + (i % available) * primeBytes, primeBytes);
+      coeffs.emplace_back(primeBits, word);
+    }
+    return coeffs;
+  }
+  unsigned numWords = (primeBits + 63) / 64;
+  for (size_t i = 0; i < total; ++i) {
+    llvm::SmallVector<uint64_t, 4> words(numWords, 0);
+    std::memcpy(words.data(), raw.data() + (i % available) * primeBytes,
+                primeBytes);
+    coeffs.emplace_back(primeBits, words);
+  }
+  return coeffs;
+}
+
+// Splat-aware DenseElementsAttr overload. `expectedTotal < 0` means
+// "use whatever fits".
+inline llvm::SmallVector<llvm::APInt, 0>
+coeffsFromRawBytes(DenseElementsAttr dense, unsigned primeBits,
+                   int64_t expectedTotal = -1) {
+  unsigned primeBytes = (primeBits + 7) / 8;
+  llvm::ArrayRef<char> raw = dense.getRawData();
+  size_t available = raw.size() / primeBytes;
+  size_t total =
+      expectedTotal > 0 ? static_cast<size_t>(expectedTotal) : available;
+  return coeffsFromRawBytes(raw, available, total, primeBits);
+}
+
+// Replicate a byte buffer `fanout` times end-to-end.
+inline llvm::SmallVector<char> replicateRawBytes(llvm::ArrayRef<char> raw,
+                                                 size_t fanout) {
+  llvm::SmallVector<char> out;
+  out.reserve(fanout * raw.size());
+  for (size_t i = 0; i < fanout; ++i)
+    out.append(raw.begin(), raw.end());
+  return out;
+}
+
+// Reinterpret raw little-endian bytes as a DenseIntElementsAttr of intType.
+inline DenseIntElementsAttr denseIntFromRawBytes(ShapedType intType,
+                                                 llvm::ArrayRef<char> bytes) {
+  return cast<DenseIntElementsAttr>(
+      DenseElementsAttr::getFromRawBuffer(intType, bytes));
+}
+
+// Single-storage-int element types (prime field / binary field / mod_arith)
+// all (de)serialize one element as one storage-int's worth of LE bytes.
+inline Attribute scalarIntConvertToAttribute(IntegerType storageType,
+                                             llvm::ArrayRef<char> rawData) {
+  unsigned bitWidth = storageType.getWidth();
+  if (rawData.size() != (bitWidth + 7) / 8)
+    return Attribute{};
+  auto coeffs =
+      coeffsFromRawBytes(rawData, /*available=*/1, /*total=*/1, bitWidth);
+  return IntegerAttr::get(storageType, coeffs[0]);
+}
+
+inline llvm::LogicalResult
+scalarIntConvertFromAttribute(unsigned bitWidth, Attribute attr,
+                              llvm::SmallVectorImpl<char> &result) {
+  auto intAttr = dyn_cast<IntegerAttr>(attr);
+  if (!intAttr)
+    return llvm::failure();
+  // apintLowBytes reads `(bitWidth + 7) / 8` bytes straight off the APInt's
+  // word storage, so a narrower attr would expose memory past its backing
+  // store. Require an exact width match rather than silently widening.
+  llvm::APInt value = intAttr.getValue();
+  if (value.getBitWidth() != bitWidth)
+    return llvm::failure();
+  auto bytes = apintLowBytes(value, (bitWidth + 7) / 8);
+  result.append(bytes.begin(), bytes.end());
+  return llvm::success();
+}
+
+} // namespace mlir::prime_ir
+
+#endif // PRIME_IR_IR_DENSEELEMENTBYTES_H_

--- a/prime_ir/Utils/BitcastOpUtils.h
+++ b/prime_ir/Utils/BitcastOpUtils.h
@@ -90,9 +90,14 @@ LogicalResult canonicalizeBitcast(BitcastOpT op, PatternRewriter &rewriter) {
 // - getInput() method returning the input value
 // - getOutput() method returning the output value
 // - FoldAdaptor type for accessing constant attributes
+// `inputOverride`, when non-null, replaces `adaptor.getInput()` as the
+// constant operand. Callers whose constant operand needs normalizing first
+// (e.g. a field-typed DenseElementsAttr demoted to its storage-int view)
+// pass the normalized attribute here.
 template <typename BitcastOpT>
 OpFoldResult foldBitcast(BitcastOpT op,
-                         typename BitcastOpT::FoldAdaptor adaptor) {
+                         typename BitcastOpT::FoldAdaptor adaptor,
+                         Attribute inputOverride = nullptr) {
   // Fold bitcast with same input and output types.
   if (op.getInput().getType() == op.getOutput().getType()) {
     return op.getInput();
@@ -108,7 +113,7 @@ OpFoldResult foldBitcast(BitcastOpT op,
   // Fold bitcast of a constant operand. BitcastOp::verify already enforces
   // matching storage widths, so the raw bits are reinterpretable without
   // conversion.
-  Attribute input = adaptor.getInput();
+  Attribute input = inputOverride ? inputOverride : adaptor.getInput();
   Type outputType = op.getOutput().getType();
   if (auto intAttr = dyn_cast_if_present<IntegerAttr>(input)) {
     if (!isa<ShapedType>(outputType)) {

--- a/prime_ir/Utils/ConstantFolder.h
+++ b/prime_ir/Utils/ConstantFolder.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define PRIME_IR_UTILS_CONSTANTFOLDER_H_
 
 #include "llvm/ADT/SmallVectorExtras.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Support/LLVM.h"
 
@@ -40,25 +41,33 @@ public:
     virtual OpFoldResult
     getTensorAttr(ShapedType type, ArrayRef<NativeOutputType> values) const = 0;
 
+    // Extract per-prime-coeff values from a tensor constant. Field types
+    // (DenseElementsAttr<tensor<...x!PF>>) walk raw bytes; storage-int
+    // (DenseIntElementsAttr) iterates via getValues<APInt>. Delegates with
+    // non-trivial element types (e.g. EF using SmallVector<APInt>) override.
+    virtual SmallVector<NativeInputType, 0>
+    extractValues(TensorAttr attr) const {
+      if constexpr (std::is_same_v<NativeInputType, APInt>) {
+        if (auto intAttr = llvm::dyn_cast<DenseIntElementsAttr>(attr))
+          return llvm::to_vector<0>(intAttr.template getValues<APInt>());
+        return {};
+      } else {
+        return {};
+      }
+    }
+
     virtual OpFoldResult foldScalar(ScalarAttr lhs) const {
       return getScalarAttr(operate(getNativeInput(lhs)));
     }
     virtual OpFoldResult foldTensor(TensorAttr lhs) const {
       if constexpr (std::is_same_v<ScalarAttr, TensorAttr>) {
-        // Default behavior for complex types like Extension Fields returns
-        // empty. Subclasses should override foldTensor to handle these cases.
         return {};
       } else {
-        SmallVector<NativeOutputType> values;
-        if (lhs.isSplat()) {
-          values = {operate(lhs.template getSplatValue<NativeInputType>())};
-        } else {
-          values = llvm::map_to_vector(
-              lhs.template getValues<NativeInputType>(),
-              [this](const NativeInputType &value) -> NativeOutputType {
-                return operate(value);
-              });
-        }
+        SmallVector<NativeInputType, 0> inputs = extractValues(lhs);
+        if (inputs.empty())
+          return {};
+        auto values = llvm::map_to_vector(
+            inputs, [this](const NativeInputType &v) { return operate(v); });
         return getTensorAttr(lhs.getType(), values);
       }
     }
@@ -95,29 +104,39 @@ public:
     virtual OpFoldResult
     getTensorAttr(ShapedType type, ArrayRef<NativeOutputType> values) const = 0;
 
+    // Extract per-prime-coeff values from a tensor constant. See
+    // UnaryConstantFolder::Delegate::extractValues for the rationale.
+    virtual SmallVector<NativeInputType, 0>
+    extractValues(TensorAttr attr) const {
+      if constexpr (std::is_same_v<NativeInputType, APInt>) {
+        if (auto intAttr = llvm::dyn_cast<DenseIntElementsAttr>(attr))
+          return llvm::to_vector<0>(intAttr.template getValues<APInt>());
+        return {};
+      } else {
+        return {};
+      }
+    }
+
     virtual OpFoldResult foldScalar(ScalarAttr lhs, ScalarAttr rhs) const {
       return getScalarAttr(operate(getNativeInput(lhs), getNativeInput(rhs)));
     }
     virtual OpFoldResult foldScalar(ScalarAttr rhs) const { return {}; }
     virtual OpFoldResult foldTensor(TensorAttr lhs, TensorAttr rhs) const {
       if constexpr (std::is_same_v<ScalarAttr, TensorAttr>) {
-        // Default behavior for complex types like Extension Fields returns
-        // empty. Subclasses should override foldTensor to handle these cases.
         return {};
       } else {
-        SmallVector<NativeOutputType> values;
-        if (lhs.isSplat() && rhs.isSplat()) {
-          values = {operate(lhs.template getSplatValue<NativeInputType>(),
-                            rhs.template getSplatValue<NativeInputType>())};
-        } else {
-          values = llvm::map_to_vector(
-              llvm::zip(lhs.template getValues<NativeInputType>(),
-                        rhs.template getValues<NativeInputType>()),
-              [this](const auto &values) -> NativeOutputType {
-                const auto &[lhs, rhs] = values;
-                return operate(lhs, rhs);
-              });
-        }
+        SmallVector<NativeInputType, 0> lhsValues = extractValues(lhs);
+        SmallVector<NativeInputType, 0> rhsValues = extractValues(rhs);
+        if (lhsValues.empty() || rhsValues.empty())
+          return {};
+        if (lhsValues.size() != rhsValues.size())
+          return {};
+        auto values =
+            llvm::map_to_vector(llvm::zip(lhsValues, rhsValues),
+                                [this](const auto &pair) -> NativeOutputType {
+                                  const auto &[l, r] = pair;
+                                  return operate(l, r);
+                                });
         return getTensorAttr(lhs.getType(), values);
       }
     }
@@ -169,23 +188,15 @@ public:
 
   OpFoldResult foldTensor(TensorAttr rhs) const override {
     if constexpr (std::is_same_v<ScalarAttr, TensorAttr>) {
-      // Default behavior for complex types like Extension Fields returns
-      // empty. Subclasses should override foldTensor to handle these cases.
       return {};
     } else {
-      if (rhs.isSplat()) {
-        if (isZero(rhs.template getSplatValue<NativeInputType>())) {
-          // x ± 0 -> x
-          return getLhs();
-        }
-      } else {
-        auto rhsValues = rhs.template getValues<NativeInputType>();
-        if (llvm::all_of(rhsValues, [this](const NativeInputType &value) {
-              return isZero(value);
-            })) {
-          // x ± 0 -> x
-          return getLhs();
-        }
+      SmallVector<NativeInputType, 0> values = this->extractValues(rhs);
+      if (values.empty())
+        return {};
+      if (llvm::all_of(
+              values, [this](const NativeInputType &v) { return isZero(v); })) {
+        // x ± 0 -> x
+        return getLhs();
       }
       return {};
     }
@@ -222,33 +233,20 @@ public:
 
   OpFoldResult foldTensor(TensorAttr rhs) const override {
     if constexpr (std::is_same_v<ScalarAttr, TensorAttr>) {
-      // Default behavior for complex types like Extension Fields returns
-      // empty. Subclasses should override foldTensor to handle these cases.
       return {};
     } else {
-      if (rhs.isSplat()) {
-        auto rhsValue = rhs.template getSplatValue<NativeInputType>();
-        if (isZero(rhsValue)) {
-          // x * 0 -> 0
-          return rhs;
-        } else if (isOne(rhsValue)) {
-          // x * 1 -> x
-          return getLhs();
-        }
-      } else {
-        auto rhsValues = rhs.template getValues<NativeInputType>();
-        if (llvm::all_of(rhsValues, [this](const NativeInputType &value) {
-              return isZero(value);
-            })) {
-          // x * 0 -> 0
-          return rhs;
-        } else if (llvm::all_of(rhsValues,
-                                [this](const NativeInputType &value) {
-                                  return isOne(value);
-                                })) {
-          // x * 1 -> x
-          return getLhs();
-        }
+      SmallVector<NativeInputType, 0> values = this->extractValues(rhs);
+      if (values.empty())
+        return {};
+      if (llvm::all_of(
+              values, [this](const NativeInputType &v) { return isZero(v); })) {
+        // x * 0 -> 0
+        return rhs;
+      } else if (llvm::all_of(values, [this](const NativeInputType &v) {
+                   return isOne(v);
+                 })) {
+        // x * 1 -> x
+        return getLhs();
       }
       return {};
     }

--- a/tests/Dialect/Field/BUILD.bazel
+++ b/tests/Dialect/Field/BUILD.bazel
@@ -52,6 +52,18 @@ prime_ir_cc_test(
 )
 
 prime_ir_cc_test(
+    name = "FieldDenseElementInterfaceTest",
+    srcs = ["FieldDenseElementInterfaceTest.cpp"],
+    deps = [
+        "//prime_ir/Dialect/Field/IR:Field",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+prime_ir_cc_test(
     name = "ExtensionFieldOperationTest",
     srcs = ["ExtensionFieldOperationTest.cpp"],
     deps = [

--- a/tests/Dialect/Field/BUILD.bazel
+++ b/tests/Dialect/Field/BUILD.bazel
@@ -27,6 +27,7 @@ prime_ir_cc_test(
     name = "BinaryFieldOperationTest",
     srcs = ["BinaryFieldOperationTest.cpp"],
     deps = [
+        "//prime_ir/Dialect/EllipticCurve/IR:EllipticCurve",
         "//prime_ir/Dialect/Field/IR:Field",
         "//prime_ir/Utils:ZkDtypes",
         "@com_google_googletest//:gtest",
@@ -39,6 +40,7 @@ prime_ir_cc_test(
     name = "PrimeFieldOperationTest",
     srcs = ["PrimeFieldOperationTest.cpp"],
     deps = [
+        "//prime_ir/Dialect/EllipticCurve/IR:EllipticCurve",
         "//prime_ir/Dialect/Field/IR:Field",
         "//prime_ir/Utils:ZkDtypes",
         "@com_google_googletest//:gtest",
@@ -55,6 +57,7 @@ prime_ir_cc_test(
     name = "FieldDenseElementInterfaceTest",
     srcs = ["FieldDenseElementInterfaceTest.cpp"],
     deps = [
+        "//prime_ir/Dialect/EllipticCurve/IR:EllipticCurve",
         "//prime_ir/Dialect/Field/IR:Field",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
@@ -67,6 +70,7 @@ prime_ir_cc_test(
     name = "ExtensionFieldOperationTest",
     srcs = ["ExtensionFieldOperationTest.cpp"],
     deps = [
+        "//prime_ir/Dialect/EllipticCurve/IR:EllipticCurve",
         "//prime_ir/Dialect/Field/IR:Field",
         "//prime_ir/Utils:ZkDtypes",
         "@com_google_googletest//:gtest",
@@ -84,6 +88,7 @@ prime_ir_cc_test(
     name = "BitcastOpTest",
     srcs = ["BitcastOpTest.cpp"],
     deps = [
+        "//prime_ir/Dialect/EllipticCurve/IR:EllipticCurve",
         "//prime_ir/Dialect/Field/IR:Field",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",

--- a/tests/Dialect/Field/FieldDenseElementInterfaceTest.cpp
+++ b/tests/Dialect/Field/FieldDenseElementInterfaceTest.cpp
@@ -1,0 +1,125 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstring>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "prime_ir/Dialect/Field/IR/FieldDialect.h"
+#include "prime_ir/Dialect/Field/IR/FieldTypes.h"
+
+namespace mlir::prime_ir::field {
+namespace {
+
+class FieldDenseElementInterfaceTest : public testing::Test {
+protected:
+  static void SetUpTestSuite() { context.loadDialect<FieldDialect>(); }
+
+  // PF<31:i32>: a 4-byte storage int.
+  PrimeFieldType pf() {
+    auto modAttr = IntegerAttr::get(IntegerType::get(&context, 32), 31);
+    return PrimeFieldType::get(&context, modAttr, /*isMontgomery=*/false);
+  }
+  // EF<2x!PF, 6>: degreeOverPrime=2, storage = 8 bytes.
+  ExtensionFieldType ef() {
+    auto nonResidue = IntegerAttr::get(IntegerType::get(&context, 32), 6);
+    return ExtensionFieldType::get(&context, /*degree=*/2, pf(), nonResidue);
+  }
+
+  static MLIRContext context;
+};
+
+MLIRContext FieldDenseElementInterfaceTest::context;
+
+//===----------------------------------------------------------------------===//
+// getDenseElementBitSize
+//===----------------------------------------------------------------------===//
+
+TEST_F(FieldDenseElementInterfaceTest, BitSizeIsStorageWidth) {
+  // EF total storage = degreeOverPrime * prime storage.
+  EXPECT_EQ(cast<DenseElementType>(ef()).getDenseElementBitSize(),
+            ef().getDegreeOverPrime() * 32u);
+}
+
+//===----------------------------------------------------------------------===//
+// Extension field: per-coefficient storage round-trip.
+//===----------------------------------------------------------------------===//
+
+TEST_F(FieldDenseElementInterfaceTest, ExtensionFieldConvertToCoeffs) {
+  auto ty = cast<DenseElementType>(ef());
+  // Coeffs [3, 5] of a degree-2 EF, each in i32 little-endian storage.
+  std::vector<char> bytes = {3, 0, 0, 0, 5, 0, 0, 0};
+  Attribute attr = ty.convertToAttribute(bytes);
+  auto dense = dyn_cast<DenseIntElementsAttr>(attr);
+  ASSERT_TRUE(dense) << "expected DenseIntElementsAttr cover";
+  ASSERT_EQ(dense.getNumElements(), 2);
+  auto values = llvm::to_vector(dense.getValues<APInt>());
+  EXPECT_EQ(values[0].getZExtValue(), 3u);
+  EXPECT_EQ(values[1].getZExtValue(), 5u);
+}
+
+TEST_F(FieldDenseElementInterfaceTest, ExtensionFieldRoundTrip) {
+  auto ty = cast<DenseElementType>(ef());
+  std::vector<char> original = {7, 0, 0, 0, 11, 0, 0, 0};
+  Attribute attr = ty.convertToAttribute(original);
+  ASSERT_TRUE(attr);
+
+  llvm::SmallVector<char> back;
+  ASSERT_TRUE(succeeded(ty.convertFromAttribute(attr, back)));
+  ASSERT_EQ(back.size(), original.size());
+  EXPECT_EQ(std::memcmp(back.data(), original.data(), original.size()), 0);
+}
+
+TEST_F(FieldDenseElementInterfaceTest, ExtensionFieldRejectsWrongSize) {
+  auto ty = cast<DenseElementType>(ef());
+  std::vector<char> tooShort(7, 0); // 7 bytes for an 8-byte element
+  EXPECT_FALSE(ty.convertToAttribute(tooShort));
+}
+
+//===----------------------------------------------------------------------===//
+// DenseElementsAttr can carry field-typed tensors end-to-end.
+//===----------------------------------------------------------------------===//
+
+TEST_F(FieldDenseElementInterfaceTest, DenseElementsAttrOverEfTensor) {
+  auto tensorTy = RankedTensorType::get({2}, ef());
+  // Two EF elements: [3, 5] and [7, 11].
+  std::vector<char> bytes = {3, 0, 0, 0, 5, 0, 0, 0, 7, 0, 0, 0, 11, 0, 0, 0};
+  auto dense = DenseElementsAttr::getFromRawBuffer(tensorTy, bytes);
+  ASSERT_TRUE(dense);
+  EXPECT_EQ(dense.getNumElements(), 2);
+  EXPECT_EQ(dense.getRawData().size(), bytes.size());
+}
+
+TEST_F(FieldDenseElementInterfaceTest, ExtensionFieldConvertFromSplat) {
+  auto ty = cast<DenseElementType>(ef());
+  // A splat coeff attr (tensor<2xi32> all = 9): convertFromAttribute must
+  // expand the single stored coeff across the full degree.
+  auto coeffTy = RankedTensorType::get({2}, pf().getStorageType());
+  auto splat = DenseIntElementsAttr::get(coeffTy, APInt(32, 9));
+  ASSERT_TRUE(splat.isSplat());
+
+  llvm::SmallVector<char> back;
+  ASSERT_TRUE(succeeded(ty.convertFromAttribute(splat, back)));
+  ASSERT_EQ(back.size(), 8u); // degreeOverPrime * primeBytes
+  EXPECT_EQ(static_cast<unsigned char>(back[0]), 9u);
+  EXPECT_EQ(static_cast<unsigned char>(back[4]), 9u);
+}
+
+} // namespace
+} // namespace mlir::prime_ir::field

--- a/tests/Utils/BUILD.bazel
+++ b/tests/Utils/BUILD.bazel
@@ -4,6 +4,7 @@ prime_ir_cc_test(
     name = "BitSerialAlgorithmTest",
     srcs = ["BitSerialAlgorithmTest.cpp"],
     deps = [
+        "//prime_ir/Dialect/EllipticCurve/IR:EllipticCurve",
         "//prime_ir/Dialect/Field/IR:Field",
         "//prime_ir/Dialect/ModArith/IR:ModArith",
         "//prime_ir/Utils:BitSerialAlgorithm",

--- a/third_party/llvm-project/asm_parser_rewind.patch
+++ b/third_party/llvm-project/asm_parser_rewind.patch
@@ -1,0 +1,31 @@
+diff --git a/mlir/include/mlir/IR/OpImplementation.h b/mlir/include/mlir/IR/OpImplementation.h
+index 8710b970e8d7..ae05bf9af988 100644
+--- a/mlir/include/mlir/IR/OpImplementation.h
++++ b/mlir/include/mlir/IR/OpImplementation.h
+@@ -580,6 +580,13 @@ public:
+   /// Return the location of the original name token.
+   virtual SMLoc getNameLoc() const = 0;
+ 
++  //===--------------------------------------------------------------------===//
++  // Token Position
++  //===--------------------------------------------------------------------===//
++
++  /// Reset the token position to the given position.
++  virtual void resetToken(const char *tokPos) = 0;
++
+   //===--------------------------------------------------------------------===//
+   // Utilities
+   //===--------------------------------------------------------------------===//
+diff --git a/mlir/lib/AsmParser/AsmParserImpl.h b/mlir/lib/AsmParser/AsmParserImpl.h
+index eec2702cba34..fe2640d160bf 100644
+--- a/mlir/lib/AsmParser/AsmParserImpl.h
++++ b/mlir/lib/AsmParser/AsmParserImpl.h
+@@ -602,6 +602,8 @@ public:
+       (void)parser.codeCompleteExpectedTokens(tokens);
+   }
+ 
++  void resetToken(const char *tokPos) override { parser.resetToken(tokPos); }
++
+ protected:
+   /// The source location of the dialect symbol.
+   SMLoc nameLoc;

--- a/third_party/llvm-project/lazy_linking.patch
+++ b/third_party/llvm-project/lazy_linking.patch
@@ -10,10 +10,11 @@ index c64660420c9c..5f2b4b904311 100644
      ],
  )
  
-@@ -9404,6 +9405,8 @@ cc_binary(
+@@ -9404,6 +9405,9 @@ cc_binary(
          "//llvm:Linker",
          "//llvm:Support",
          "//llvm:X86AsmParser",
++        "@prime_ir//prime_ir/Dialect/EllipticCurve/IR:EllipticCurve",
 +        "@prime_ir//prime_ir/Dialect/Field/IR:Field",
 +        "@prime_ir//prime_ir/Dialect/ModArith/IR:ModArith",
      ],

--- a/third_party/llvm-project/tensor_type_support.patch
+++ b/third_party/llvm-project/tensor_type_support.patch
@@ -113,37 +113,39 @@ index d33b8d32a1d8..a8386aefa02b 100644
    return {};
  }
  
-@@ -1609,9 +1672,12 @@ LogicalResult GatherOp::verify() {
+@@ -1609,9 +1672,13 @@ LogicalResult GatherOp::verify() {
  }
  
  OpFoldResult GatherOp::fold(FoldAdaptor adaptor) {
 +  auto resultType = cast<TensorType>(
 +      prime_ir::maybeConvertPrimeIRToBuiltinType(
 +          cast<ShapedType>(getResult().getType())));
++  auto src = dyn_cast_if_present<DenseElementsAttr>(adaptor.getSource());
++  if (src) src = prime_ir::maybeConvertPrimeIRToBuiltinAttr(src);
    if (OpFoldResult reshapedSource = reshapeConstantSource(
 -          llvm::dyn_cast_if_present<DenseElementsAttr>(adaptor.getSource()),
 -          getResult().getType()))
-+          dyn_cast_if_present<DenseElementsAttr>(adaptor.getSource()),
-+          resultType))
++          src, resultType))
      return reshapedSource;
    return {};
  }
-@@ -1850,9 +1916,12 @@ LogicalResult ReshapeOp::verify() {
+@@ -1850,9 +1917,13 @@ LogicalResult ReshapeOp::verify() {
  }
  
  OpFoldResult ReshapeOp::fold(FoldAdaptor adaptor) {
 +  auto resultType = cast<TensorType>(
 +      prime_ir::maybeConvertPrimeIRToBuiltinType(
 +          cast<ShapedType>(getResult().getType())));
++  auto src = dyn_cast_if_present<DenseElementsAttr>(adaptor.getSource());
++  if (src) src = prime_ir::maybeConvertPrimeIRToBuiltinAttr(src);
    if (OpFoldResult reshapedSource = reshapeConstantSource(
 -          llvm::dyn_cast_if_present<DenseElementsAttr>(adaptor.getSource()),
 -          getResult().getType()))
-+          dyn_cast_if_present<DenseElementsAttr>(adaptor.getSource()),
-+          resultType))
++          src, resultType))
      return reshapedSource;
  
    // If the producer of operand 'source' is another 'tensor.reshape' op, use the
-@@ -2311,11 +2380,29 @@ void CollapseShapeOp::getCanonicalizationPatterns(RewritePatternSet &results,
+@@ -2311,11 +2382,31 @@ void CollapseShapeOp::getCanonicalizationPatterns(RewritePatternSet &results,
  }
  
  OpFoldResult ExpandShapeOp::fold(FoldAdaptor adaptor) {
@@ -151,6 +153,7 @@ index d33b8d32a1d8..a8386aefa02b 100644
 +  // DenseElementsAttr has extra coefficient dimensions.
 +  if (auto elements =
 +          dyn_cast_or_null<DenseElementsAttr>(adaptor.getOperands().front())) {
++    elements = prime_ir::maybeConvertPrimeIRToBuiltinAttr(elements);
 +    auto resultType = prime_ir::maybeConvertPrimeIRToBuiltinType(
 +        cast<ShapedType>(getResult().getType()));
 +    if (resultType != cast<ShapedType>(getResult().getType()))
@@ -165,6 +168,7 @@ index d33b8d32a1d8..a8386aefa02b 100644
 +  // DenseElementsAttr has extra coefficient dimensions.
 +  if (auto elements =
 +          dyn_cast_or_null<DenseElementsAttr>(adaptor.getOperands().front())) {
++    elements = prime_ir::maybeConvertPrimeIRToBuiltinAttr(elements);
 +    auto resultType = prime_ir::maybeConvertPrimeIRToBuiltinType(
 +        cast<ShapedType>(getResult().getType()));
 +    if (resultType != cast<ShapedType>(getResult().getType()))
@@ -173,22 +177,24 @@ index d33b8d32a1d8..a8386aefa02b 100644
    return foldReshapeOp<CollapseShapeOp, ExpandShapeOp>(*this,
                                                         adaptor.getOperands());
  }
-@@ -2806,9 +2893,12 @@ static Value foldExtractAfterInsertSlice(ExtractSliceOp extractOp) {
+@@ -2806,9 +2897,14 @@ static Value foldExtractAfterInsertSlice(ExtractSliceOp extractOp) {
  }
  
  OpFoldResult ExtractSliceOp::fold(FoldAdaptor adaptor) {
 +  auto resultType = cast<TensorType>(
 +      prime_ir::maybeConvertPrimeIRToBuiltinType(
 +          cast<ShapedType>(getResult().getType())));
++  auto src = dyn_cast_if_present<DenseElementsAttr>(adaptor.getSource());
++  if (src) src = prime_ir::maybeConvertPrimeIRToBuiltinAttr(src);
++  auto splatSrc = dyn_cast_if_present<SplatElementsAttr>(src);
    if (OpFoldResult reshapedSource = reshapeConstantSource(
 -          llvm::dyn_cast_if_present<SplatElementsAttr>(adaptor.getSource()),
 -          getResult().getType()))
-+          dyn_cast_if_present<SplatElementsAttr>(adaptor.getSource()),
-+          resultType))
++          splatSrc, resultType))
      return reshapedSource;
    if (getSourceType() == getType() &&
        succeeded(foldIdentityOffsetSizeAndStrideOpInterface(*this, getType())))
-@@ -4096,7 +4186,8 @@ SplatOp::reifyResultShapes(OpBuilder &builder,
+@@ -4096,7 +4192,8 @@ SplatOp::reifyResultShapes(OpBuilder &builder,
  
  OpFoldResult SplatOp::fold(FoldAdaptor adaptor) {
    auto constOperand = adaptor.getInput();
@@ -198,7 +204,7 @@ index d33b8d32a1d8..a8386aefa02b 100644
      return {};
  
    // Do not fold if the splat is not statically shaped
-@@ -4105,7 +4196,19 @@ OpFoldResult SplatOp::fold(FoldAdaptor adaptor) {
+@@ -4105,7 +4202,19 @@ OpFoldResult SplatOp::fold(FoldAdaptor adaptor) {
  
    // SplatElementsAttr::get treats single value for second arg as being a
    // splat.

--- a/third_party/llvm-project/workspace.bzl
+++ b/third_party/llvm-project/workspace.bzl
@@ -41,4 +41,10 @@ LLVM_PATCHES = [
     "@prime_ir//third_party/llvm-project:lazy_linking.patch",
     "@prime_ir//third_party/llvm-project:elementwise_op_fusion_constant_support.patch",
     "@prime_ir//third_party/llvm-project:constant_like_interface.patch",
+    # Adds OpAsmParser::resetToken — used by parseOptionalFieldConstant for
+    # the speculative-parse-then-rewind pattern that disambiguates
+    # field-typed dense literals from f32/i32 ones (the first token is the
+    # same `dense` keyword in both cases, so MLIR's first-token-dispatch
+    # convention can't be applied).
+    "@prime_ir//third_party/llvm-project:asm_parser_rewind.patch",
 ]

--- a/tools/setup_llvm_clone.sh
+++ b/tools/setup_llvm_clone.sh
@@ -58,6 +58,7 @@ patches=(
     "$patch_dir/lazy_linking.patch"
     "$patch_dir/elementwise_op_fusion_constant_support.patch"
     "$patch_dir/constant_like_interface.patch"
+    "$patch_dir/asm_parser_rewind.patch"
 )
 shopt -u nullglob
 


### PR DESCRIPTION
## What

Adds `DenseElementTypeInterface` to the **multi-element** prime-ir types — `ExtensionField` and the EC point types (`Affine` / `Jacobian` / `XYZZ`) — and routes their constants through native field/point-typed `DenseElementsAttr` storage instead of an exploded storage-int tensor.

`PrimeField` / `BinaryField` / `ModArith` are single-limb, so they stay raw storage-int (no interface) — a deliberate split, not an omission.

## Why native-typed storage

A multi-element type stored as plain `DenseIntElementsAttr` forces an **extra trailing dimension** — `tensor<Nx!affine>` → `tensor<N×numCoords×iN>`, `tensor<Nx!ef>` → `tensor<N×degree×iN>`. The value attribute's shape then no longer matches the op's result shape. `DenseElementTypeInterface` lets the attr hold **one element per slot** at the logical shape `tensor<Nx!T>`, with the element type supplying its `(numCoords | degree) × baseFieldBits` byte width — so value-shape == result-shape, and any generic `DenseElementsAttr<tensor<Nx!T>>` is well-defined instead of hitting `llvm_unreachable`.

## Pieces

- **`getTypeSizeInBits()`** becomes the canonical bit-width accessor on all prime-ir element types; `getStorageBitWidth()` is now a `[[deprecated]]` forwarder.
- **`DenseElementBytes.h`** — shared little-endian APInt↔byte codecs backing the interface impls.
- **prime_ir↔builtin attr bridge** (`maybeConvertPrimeIRToBuiltinType` / `…Attr` in `prime_ir/IR/Attributes`): retypes a native EF/EC dense value to its storage-int view at the boundaries that need raw ints — the MLIR tensor reshape/gather/expand folds (`tensor_type_support.patch`), bitcast folds, and `FieldToModArith`.
- **EC bridge wiring**: `maybeConvertPrimeIRToBuiltinType` gains an `elliptic_curve::PointTypeInterface` branch. Because `prime_ir/IR:Attributes` is the floor that the patched MLIR links (the reshape patch calls it from `mlir-runner` et al.), the EC dialect is added to `lazy_linking.patch`'s `mlir-runner` deps — exactly how `Field` / `ModArith` already are — so the EC interface symbols resolve in those binaries.
- **`parseOptionalFieldConstant`** — silent-decline fallback parser (rewinds the parser + `OperationState`) so another dialect's op can try it without shadowing its own diagnostic.

## Commit structure

8 commits, **each independently buildable**. Commits 1–7 are EC-free (they build on the floor's existing Field/ModArith lazy-linking); the EC-bridge wiring — `Attributes` EC branch + `lazy_linking` EC dep + leaf-test deps — lands as a single atomic `feat:` commit, since the reference and its symbol providers must ship together to stay buildable.

Bottom of the stack; base `main` (on the squashed LLVM bump #316).
Stack: main → **dense** → goldilocks → function-outliner.
