### PR TITLE
feat(mod_arith): add Goldilocks Solinas reduction in ConvertMul/ConvertSquare

### DIFF
--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/BUILD.bazel
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/BUILD.bazel
@@ -33,6 +33,7 @@ prime_ir_cc_library(
         "//prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Inverter:BYInverter",
         "//prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer:BarrettReducer",
         "//prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer:MontReducer",
+        "//prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer:SolinasReducer",
         "//prime_ir/Dialect/ModArith/IR:ModArith",
         "//prime_ir/Dialect/TensorExt/IR:TensorExt",
         "//prime_ir/Utils:ConversionUtils",
@@ -58,6 +59,7 @@ prime_ir_cc_library(
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:UBDialect",
         "@llvm-project//mlir:VectorDialect",
+        "@zk_dtypes//zk_dtypes:goldilocks",
     ],
 )
 

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -48,6 +48,7 @@ limitations under the License.
 #include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Inverter/BYInverter.h"
 #include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BarrettReducer.h"
 #include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.h"
+#include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithDialect.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithOperation.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithOps.h"
@@ -55,6 +56,7 @@ limitations under the License.
 #include "prime_ir/Dialect/TensorExt/IR/TensorExtOps.h"
 #include "prime_ir/Utils/ConversionUtils.h"
 #include "prime_ir/Utils/ShapedTypeConverter.h"
+#include "zk_dtypes/include/field/goldilocks/goldilocks.h"
 
 namespace mlir::prime_ir::mod_arith {
 
@@ -1018,8 +1020,15 @@ struct ConvertMul : public OpConversionPattern<MulOp> {
       return success();
     }
 
-    // Barrett path for wide non-Mersenne primes. The Mersenne branch below
-    // (p = 2^k - 1) keeps precedence — its shift+add is faster than Barrett.
+    // Goldilocks (p = 2^64 - 2^32 + 1) matches the wide non-Mersenne shape
+    // but has a faster Solinas fast-path below, so it takes precedence over
+    // Barrett — same as the Mersenne branch.
+    bool isGoldilocks =
+        modulus.getBitWidth() == 64 &&
+        modulus == APInt(64, zk_dtypes::Goldilocks::Config::kModulus);
+
+    // Barrett path for wide non-Mersenne primes. The Mersenne and Goldilocks
+    // branches below keep precedence — their shift+add is faster than Barrett.
     // Below 64 bits, hardware urem is a single instruction and wins anyway.
     // The `!modulus.isPowerOf2()` guard is defensive: the type parser rejects
     // power-of-two moduli today, but if the dialect ever supports binary
@@ -1027,10 +1036,23 @@ struct ConvertMul : public OpConversionPattern<MulOp> {
     // `modulus.getBitWidth()` — which would break the reducer's
     // `2k == extBitWidth` precondition.
     if (modulus.getBitWidth() >= 64 && !(modulus + 1).isPowerOf2() &&
-        !modulus.isPowerOf2()) {
+        !modulus.isPowerOf2() && !isGoldilocks) {
       auto result =
           BarrettMulOp::create(b, op.getType(), op.getLhs(), op.getRhs());
       rewriter.replaceOp(op, result);
+      return success();
+    }
+
+    // Goldilocks (p = 2^64 - 2^32 + 1) reduces the 128-bit product via the
+    // 64-bit Solinas fast path, sidestepping the `arith.remui i128` fallback
+    // below (which lowers to libgcc's `__umodti3`, unavailable on the CPU JIT
+    // runtime). Take the product halves straight from mului_extended — the
+    // reduction stays in 64-bit arithmetic, no i128.
+    if (isGoldilocks) {
+      auto prod =
+          arith::MulUIExtendedOp::create(b, adaptor.getLhs(), adaptor.getRhs());
+      rewriter.replaceOp(
+          op, SolinasReducer(b, modType).reduce(prod.getLow(), prod.getHigh()));
       return success();
     }
 
@@ -1347,8 +1369,23 @@ struct ConvertSquare : public OpConversionPattern<SquareOp> {
       return success();
     }
 
-    Type intExtType = modulusType(op, /*extended=*/true);
     MulExtendedResult result = squareExtended(b, op, adaptor.getInput());
+
+    // Goldilocks reduces the 128-bit square via the 64-bit Solinas fast path
+    // (mirrors ConvertMul), sidestepping the `arith.remui i128` fallback below.
+    // squareExtended already hands back the product halves, so reduce them
+    // directly — no i128 reassembly.
+    APInt modulus = modType.getModulus().getValue();
+    bool isGoldilocks =
+        modulus.getBitWidth() == 64 &&
+        modulus == APInt(64, zk_dtypes::Goldilocks::Config::kModulus);
+    if (isGoldilocks) {
+      rewriter.replaceOp(
+          op, SolinasReducer(b, modType).reduce(result.lo, result.hi));
+      return success();
+    }
+
+    Type intExtType = modulusType(op, /*extended=*/true);
     Value lowExt = arith::ExtUIOp::create(b, intExtType, result.lo);
     Value highExt = arith::ExtUIOp::create(b, intExtType, result.hi);
     Value shift = arith::ConstantIntOp::create(b, intExtType,

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BUILD.bazel
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BUILD.bazel
@@ -46,3 +46,16 @@ prime_ir_cc_library(
         "@llvm-project//mlir:TensorDialect",
     ],
 )
+
+prime_ir_cc_library(
+    name = "SolinasReducer",
+    srcs = ["SolinasReducer.cpp"],
+    hdrs = ["SolinasReducer.h"],
+    deps = [
+        "//prime_ir/Dialect/ModArith/IR:ModArith",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@zk_dtypes//zk_dtypes:goldilocks",
+    ],
+)

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.cpp
@@ -1,0 +1,75 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.h"
+
+#include "llvm/ADT/APInt.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "prime_ir/Dialect/ModArith/IR/ModArithTypes.h" // IWYU pragma: keep
+#include "zk_dtypes/include/field/goldilocks/goldilocks.h"
+
+namespace mlir::prime_ir::mod_arith {
+
+SolinasReducer::SolinasReducer(ImplicitLocOpBuilder &b,
+                               ModArithType modArithType)
+    : b(b), modAttr(modArithType.getModulus()) {
+  bitWidth = modAttr.getValue().getBitWidth();
+  assert(bitWidth == 64 &&
+         modAttr.getValue() ==
+             APInt(64, zk_dtypes::Goldilocks::Config::kModulus) &&
+         "SolinasReducer only supports the Goldilocks prime "
+         "p = 2^64 - 2^32 + 1");
+}
+
+Value SolinasReducer::reduce(Value lo, Value hi) {
+  Type t = lo.getType();
+  auto konst = [&](uint64_t v) {
+    return arith::ConstantOp::create(b, t, b.getIntegerAttr(t, v));
+  };
+  // ε = 2^32 - 1 = 2^64 mod p. With hi = hi_hi·2^32 + hi_lo and the
+  // congruences 2^64 ≡ ε, 2^96 ≡ -1 (mod p):
+  //   x = hi·2^64 + lo ≡ lo - hi_hi + hi_lo·ε   (mod p).
+  Value half = konst(bitWidth / 2); // 32
+  Value epsilon = konst((1ULL << 32) - 1);
+  Value hiHi = arith::ShRUIOp::create(b, hi, half);   // hi >> 32   < 2^32
+  Value hiLo = arith::AndIOp::create(b, hi, epsilon); // hi & ε     < 2^32
+
+  // t0 = lo - hi_hi. The subtraction borrows iff lo < hi_hi; a borrow means
+  // the true value wrapped by 2^64 ≡ ε, so correct by subtracting ε.
+  Value borrow = arith::CmpIOp::create(b, arith::CmpIPredicate::ult, lo, hiHi);
+  Value t0Raw = arith::SubIOp::create(b, lo, hiHi);
+  Value t0Corr = arith::SubIOp::create(b, t0Raw, epsilon);
+  Value t0 = arith::SelectOp::create(b, borrow, t0Corr, t0Raw);
+
+  // t1 = hi_lo · ε < 2^64 (both factors < 2^32), so the narrow multiply is
+  // exact — no high half needed.
+  Value t1 = arith::MulIOp::create(b, hiLo, epsilon);
+
+  // t2 = t0 + t1; an add carry again means a 2^64 ≡ ε wrap, corrected by +ε.
+  auto add = arith::AddUIExtendedOp::create(b, t0, t1);
+  Value t2Corr = arith::AddIOp::create(b, add.getSum(), epsilon);
+  Value t2 =
+      arith::SelectOp::create(b, add.getOverflow(), t2Corr, add.getSum());
+
+  // t2 < 2^64 < 2p, but may be ≥ p; one conditional subtract canonicalizes.
+  Value p = konst(modAttr.getValue().getZExtValue());
+  Value ge = arith::CmpIOp::create(b, arith::CmpIPredicate::uge, t2, p);
+  Value sub = arith::SubIOp::create(b, t2, p);
+  return arith::SelectOp::create(b, ge, sub, t2);
+}
+
+} // namespace mlir::prime_ir::mod_arith

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.h
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.h
@@ -1,0 +1,61 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef PRIME_IR_DIALECT_MODARITH_CONVERSIONS_MODARITHTOARITH_REDUCER_SOLINASREDUCER_H_
+#define PRIME_IR_DIALECT_MODARITH_CONVERSIONS_MODARITHTOARITH_REDUCER_SOLINASREDUCER_H_
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Value.h"
+#include "prime_ir/Dialect/ModArith/IR/ModArithTypes.h" // IWYU pragma: keep
+
+namespace mlir::prime_ir::mod_arith {
+
+// Helper class to perform Solinas reduction for the Goldilocks prime
+// `p = 2^64 - 2^32 + 1`. This is the field's reason for being: reduction is a
+// handful of 64-bit shifts/adds rather than a division.
+//
+// Works on the 64-bit halves of the 128-bit product directly (as produced by
+// `arith.mului_extended`), staying entirely in 64-bit arithmetic — no `i128`
+// and no `arith.remui i128` (which would lower to libgcc's `__umodti3`, absent
+// from the CPU JIT runtime).
+//
+// Using `ε = 2^32 - 1` (so `2^64 ≡ ε` and `2^96 ≡ -1 (mod p)`), for
+// `x = hi·2^64 + lo` with `hi = hi_hi·2^32 + hi_lo`:
+//   x ≡ lo - hi_hi + hi_lo·ε  (mod p)
+// Each ± wraps by `2^64 ≡ ε`, corrected by a conditional ∓ε off the
+// borrow/carry bit; a final conditional subtract of `p` canonicalizes into
+// `[0, p)`. (Plonky2/sppark reduce128.)
+class SolinasReducer {
+public:
+  // Constructs a SolinasReducer with the given builder and ModArithType.
+  // Precondition: the type's modulus is the Goldilocks prime.
+  explicit SolinasReducer(ImplicitLocOpBuilder &b, ModArithType modArithType);
+
+  // Reduces the 128-bit product `hi·2^64 + lo` (each half a canonical-width
+  // `k`-bit integer, e.g. from `arith.mului_extended`) to the canonical
+  // `k`-bit residue in `[0, p)`. Precondition: `hi·2^64 + lo < p²`.
+  Value reduce(Value lo, Value hi);
+
+private:
+  ImplicitLocOpBuilder &b;
+  IntegerAttr modAttr;
+  unsigned bitWidth;
+};
+
+} // namespace mlir::prime_ir::mod_arith
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#endif // PRIME_IR_DIALECT_MODARITH_CONVERSIONS_MODARITHTOARITH_REDUCER_SOLINASREDUCER_H_

--- a/tests/Dialect/ModArith/mod_arith_to_arith.mlir
+++ b/tests/Dialect/ModArith/mod_arith_to_arith.mlir
@@ -304,3 +304,65 @@ func.func @test_lower_sub_goldilocks(%lhs : !Gp, %rhs : !Gp) -> !Gp {
   %res = mod_arith.sub %lhs, %rhs : !Gp
   return %res : !Gp
 }
+
+// -----
+
+// Goldilocks p = 2^64 - 2^32 + 1 takes a 64-bit Solinas reduction path so the
+// CPU JIT runtime doesn't need libgcc's `__umodti3` (the generic
+// `arith.remui i128, i128` fallback is unsupported on that runtime). The whole
+// reduction stays in i64: the product comes from mului_extended and the
+// borrow/carry corrections come from addui_extended — no i128.
+!Goldilocks = !mod_arith.int<18446744069414584321 : i64>
+// The full reducer chain is asserted via SSA capture: product halves from
+// mului_extended, the lo - hi_hi borrow correction, the hi_lo·ε term, the
+// addui_extended carry correction, and the final canonicalizing subtract.
+// CHECK-LABEL: @test_lower_mul_goldilocks
+func.func @test_lower_mul_goldilocks(%lhs : !Goldilocks, %rhs : !Goldilocks)
+    -> !Goldilocks {
+  // CHECK-NOT: mod_arith.mul
+  // CHECK-NOT: arith.remui
+  // CHECK-NOT: i128
+  // CHECK:      %[[LO:.*]], %[[HI:.*]] = arith.mului_extended %{{.*}}, %{{.*}} : i64
+  // CHECK:      %[[HIHI:.*]] = arith.shrui %[[HI]], %{{.*}} : i64
+  // CHECK:      %[[HILO:.*]] = arith.andi %[[HI]], %{{.*}} : i64
+  // CHECK:      %[[BORROW:.*]] = arith.cmpi ult, %[[LO]], %[[HIHI]] : i64
+  // CHECK:      %[[T0RAW:.*]] = arith.subi %[[LO]], %[[HIHI]] : i64
+  // CHECK:      %[[T0COR:.*]] = arith.subi %[[T0RAW]], %{{.*}} : i64
+  // CHECK:      %[[T0:.*]] = arith.select %[[BORROW]], %[[T0COR]], %[[T0RAW]] : i64
+  // CHECK:      %[[T1:.*]] = arith.muli %[[HILO]], %{{.*}} : i64
+  // CHECK:      %[[SUM:.*]], %[[CARRY:.*]] = arith.addui_extended %[[T0]], %[[T1]] : i64, i1
+  // CHECK:      %[[T2COR:.*]] = arith.addi %[[SUM]], %{{.*}} : i64
+  // CHECK:      %[[T2:.*]] = arith.select %[[CARRY]], %[[T2COR]], %[[SUM]] : i64
+  // CHECK:      %[[GE:.*]] = arith.cmpi uge, %[[T2]], %{{.*}} : i64
+  // CHECK:      %[[PSUB:.*]] = arith.subi %[[T2]], %{{.*}} : i64
+  // CHECK:      %[[RES:.*]] = arith.select %[[GE]], %[[PSUB]], %[[T2]] : i64
+  // CHECK:      return %[[RES]] : i64
+  %res = mod_arith.mul %lhs, %rhs : !Goldilocks
+  return %res : !Goldilocks
+}
+
+// Squaring feeds the same reducer (via squareExtended's product halves), so it
+// must lower to the identical i64 chain.
+// CHECK-LABEL: @test_lower_square_goldilocks
+func.func @test_lower_square_goldilocks(%lhs : !Goldilocks) -> !Goldilocks {
+  // CHECK-NOT: mod_arith.square
+  // CHECK-NOT: arith.remui
+  // CHECK-NOT: i128
+  // CHECK:      %[[LO:.*]], %[[HI:.*]] = arith.mului_extended %{{.*}}, %{{.*}} : i64
+  // CHECK:      %[[HIHI:.*]] = arith.shrui %[[HI]], %{{.*}} : i64
+  // CHECK:      %[[HILO:.*]] = arith.andi %[[HI]], %{{.*}} : i64
+  // CHECK:      %[[BORROW:.*]] = arith.cmpi ult, %[[LO]], %[[HIHI]] : i64
+  // CHECK:      %[[T0RAW:.*]] = arith.subi %[[LO]], %[[HIHI]] : i64
+  // CHECK:      %[[T0COR:.*]] = arith.subi %[[T0RAW]], %{{.*}} : i64
+  // CHECK:      %[[T0:.*]] = arith.select %[[BORROW]], %[[T0COR]], %[[T0RAW]] : i64
+  // CHECK:      %[[T1:.*]] = arith.muli %[[HILO]], %{{.*}} : i64
+  // CHECK:      %[[SUM:.*]], %[[CARRY:.*]] = arith.addui_extended %[[T0]], %[[T1]] : i64, i1
+  // CHECK:      %[[T2COR:.*]] = arith.addi %[[SUM]], %{{.*}} : i64
+  // CHECK:      %[[T2:.*]] = arith.select %[[CARRY]], %[[T2COR]], %[[SUM]] : i64
+  // CHECK:      %[[GE:.*]] = arith.cmpi uge, %[[T2]], %{{.*}} : i64
+  // CHECK:      %[[PSUB:.*]] = arith.subi %[[T2]], %{{.*}} : i64
+  // CHECK:      %[[RES:.*]] = arith.select %[[GE]], %[[PSUB]], %[[T2]] : i64
+  // CHECK:      return %[[RES]] : i64
+  %res = mod_arith.square %lhs : !Goldilocks
+  return %res : !Goldilocks
+}


### PR DESCRIPTION
Adds the Goldilocks (2^64 − 2^32 + 1) Solinas fast-path reduction in `ConvertMul` / `ConvertSquare`. Solinas is excluded from the Barrett path so Goldilocks keeps its fast reduction — orthogonal to the wide-modulus Barrett overflow fix already on `main` (#322); the rebase onto the squashed main was merge-tree clean.

Stacked on dense; base `feat/dense-element-foundation`.

Stack: main → dense → **goldilocks** → function-outliner.
