### PR TITLE
fix: set llvm.linkage = Internal on outlined helpers

### DIFF
--- a/prime_ir/Utils/BUILD.bazel
+++ b/prime_ir/Utils/BUILD.bazel
@@ -207,6 +207,7 @@ prime_ir_cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LLVMDialect",
     ],
 )
 

--- a/prime_ir/Utils/FunctionOutlinerBase.h
+++ b/prime_ir/Utils/FunctionOutlinerBase.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include "llvm/ADT/SmallVector.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/SymbolTable.h"
@@ -84,6 +85,14 @@ protected:
     auto func =
         func::FuncOp::create(builder, module_.getLoc(), funcName, funcType);
     func.setPrivate();
+    // setPrivate() only sets symbol visibility; FuncToLLVM does not derive
+    // LLVM linkage from that alone, so an explicit Internal linkage attribute
+    // is needed for the LLVM IR functions to be local (otherwise downstream
+    // CPU codegen's "module must have one externally visible definition"
+    // check fails for outlined pairing helpers).
+    func->setAttr(
+        "llvm.linkage",
+        LLVM::LinkageAttr::get(module_.getContext(), LLVM::Linkage::Internal));
 
     bodyGenerator(func);
     symbolTable_.insert(func);

--- a/tests/Dialect/EllipticCurve/pairing_outliner_linkage.mlir
+++ b/tests/Dialect/EllipticCurve/pairing_outliner_linkage.mlir
@@ -1,0 +1,46 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// Pairing-check lowering outlines Fp12 helpers (CyclotomicSquare, Fp12Mul,
+// MulBy034 — bn254's D-type twist uses the 034 sparse multiply) into private
+// func.func ops. The host LLVM pipeline
+// requires those to lower with Internal linkage; setPrivate() alone only
+// updates symbol visibility, so FunctionOutlinerBase must also attach
+// `llvm.linkage = #llvm.linkage<internal>` to each outlined function.
+
+// RUN: cat %S/../../bn254_defs.mlir %s \
+// RUN:   | prime-ir-opt -elliptic-curve-to-field \
+// RUN:   | FileCheck %s -enable-var-scope
+
+func.func @drive_pairing_check(
+    %g1_pts: tensor<2x!affinem>,
+    %g2_pts: tensor<2x!g2affinem>) -> i1 {
+  %r = elliptic_curve.pairing_check %g1_pts, %g2_pts
+      : tensor<2x!affinem>, tensor<2x!g2affinem> -> i1
+  return %r : i1
+}
+
+// Each outlined Fp12 helper carries Internal linkage.
+// CHECK-DAG: func.func private @__prime_ir_cyclotomic_square_
+// CHECK-DAG-SAME: attributes {llvm.linkage = #llvm.linkage<internal>}
+// CHECK-DAG: func.func private @__prime_ir_fp12_mul_
+// CHECK-DAG-SAME: attributes {llvm.linkage = #llvm.linkage<internal>}
+// CHECK-DAG: func.func private @__prime_ir_mul_by_034_
+// CHECK-DAG-SAME: attributes {llvm.linkage = #llvm.linkage<internal>}
+
+// No outlined helper should be missing the linkage attribute (and
+// therefore default to external).
+// CHECK-NOT: func.func private @__prime_ir_{{.*}}
+// CHECK-NOT:   #llvm.linkage<external>


### PR DESCRIPTION
Outlined pairing helpers were emitted with default (external) linkage; this sets `llvm.linkage = Internal` so they don't leak symbols or collide at link time across binaries that share the runtime.

Top of the stacked series; base `fix/goldilocks-solinas-reduction`.

Stack: main → dense → goldilocks → **function-outliner**.
