### PR TITLE
build: bump zk_dtypes to d880d1c465ba

### DIFF
--- a/third_party/zk_dtypes/workspace.bzl
+++ b/third_party/zk_dtypes/workspace.bzl
@@ -17,8 +17,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def repo():
-    ZK_DTYPES_COMMIT = "03073da60554672eda488d5634e43a5e6d68b980"
-    ZK_DTYPES_SHA256 = "eb1c448214009f13552c001296581695ee44b3550f2b2a23a27fd262b6a5f771"
+    ZK_DTYPES_COMMIT = "d880d1c465baa4efb5706b5ba38b70cc6f2501e1"
+    ZK_DTYPES_SHA256 = "c044948de97063bc5504f6b4c537a4a924f203147ef1c64e9d781c8ad0db2ad9"
     http_archive(
         name = "zk_dtypes",
         sha256 = ZK_DTYPES_SHA256,


### PR DESCRIPTION
Automated pin bump of `zk_dtypes` to [`d880d1c465ba`](https://github.com/fractalyze/zk_dtypes/commit/d880d1c465baa4efb5706b5ba38b70cc6f2501e1).