### PR TITLE
fix(field): decline folding a scalar-int bitcast into an extension field

### DIFF
--- a/prime_ir/Dialect/Field/IR/FieldOps.cpp
+++ b/prime_ir/Dialect/Field/IR/FieldOps.cpp
@@ -825,6 +825,15 @@ LogicalResult BitcastOp::verify() {
 }
 
 OpFoldResult BitcastOp::fold(FoldAdaptor adaptor) {
+  // A scalar integer operand folds through foldBitcast as a raw IntegerAttr,
+  // but for an ExtensionField result that integer packs all tower coefficients
+  // and materializeConstant can't stamp it into a field.constant (whose value
+  // attr is tower-shaped). Mirror foldBitcast's dense-operand EF exclusion and
+  // decline the fold; the bitcast lowers via field-to-llvm as a noop
+  // reinterpret.
+  if (dyn_cast_if_present<IntegerAttr>(adaptor.getInput()) &&
+      isa<ExtensionFieldType>(getOutput().getType()))
+    return {};
   return foldBitcast(*this, adaptor);
 }
 

--- a/tests/Dialect/Field/ext_field_canonicalize.mlir
+++ b/tests/Dialect/Field/ext_field_canonicalize.mlir
@@ -643,6 +643,21 @@ func.func @test_bitcast_chain_simplify(%arg0: tensor<2x!QF>) -> tensor<4x!PF> {
   return %1 : tensor<4x!PF>
 }
 
+// CHECK-LABEL: @test_bitcast_scalar_int_to_ef_no_fold
+// CHECK-SAME: () -> [[T:.*]] {
+func.func @test_bitcast_scalar_int_to_ef_no_fold() -> !QF {
+  // A scalar integer constant bitcast into an extension field must NOT be
+  // constant-folded: the packed integer spans every tower coefficient and
+  // can't be stamped into a field.constant. Leave the bitcast for
+  // field-to-llvm. Regression for an assert in ConstantOp::materialize.
+  // CHECK: %[[C:.*]] = arith.constant 1 : i64
+  // CHECK: %[[B:.*]] = field.bitcast %[[C]] : i64 -> [[T]]
+  // CHECK: return %[[B]] : [[T]]
+  %c = arith.constant 1 : i64
+  %0 = field.bitcast %c : i64 -> !QF
+  return %0 : !QF
+}
+
 //===----------------------------------------------------------------------===//
 // ToMont/FromMont cancellation
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## Description

`foldBitcast` passes a scalar constant operand through as a raw `IntegerAttr`
for any non-shaped output. For an `ExtensionField` result that integer is the
whole element bit-packed across all tower coefficients, which `materializeConstant`
can't stamp into a `field.constant` (its value attr is tower-shaped). Post-#283
`ConstantOp::materialize` asserts the attr is base-prime width and aborts.

The dense-operand branch of `foldBitcast` already excludes extension fields
(#318 — "NOT for ExtensionField, whose value attribute carries tower
dimensions"); the scalar-`IntegerAttr` branch never got the same guard. This
mirrors it in the field-dialect wrapper, since `BitcastOpUtils.h` is
intentionally dialect-agnostic and must not depend on `ExtensionFieldType`.

Surfaced downstream as a SIGABRT in zkx's GPU `OptimizeLoopsPass` when compiling
any koalabearx4 (extension-field) computation. Verified e2e by rebuilding the
cuda-pjrt plugin with this change: the previously-aborting zorch sumcheck EF
test now passes on GPU.

## Related Issues/PRs

Completes the ExtensionField bitcast-fold exclusion started in #318; the assert
it trips was added in #283. No tracking issue.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline