### PR TITLE
ci: enable fractal-build-lint for BUILD target sort + naming

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,15 @@ default_install_hook_types: [pre-commit, commit-msg]
 repos:
   # fractal-commit-lint — Conventional Commits + scope policy. Scope rules live
   # in .fractal-commit-lint.toml; CI runs the same tool over each commit via the
-  # commit-lint action in hybrid mode. (fractal-lint / fractal-build-lint are
-  # intentionally not enabled — cpplint/clang-format/buildifier cover C++/BUILD.)
+  # commit-lint action in hybrid mode.
+  # fractal-build-lint — BUILD.bazel target sorting + test naming, which
+  # buildifier does NOT enforce (buildifier only formats/lints Starlark).
+  # fractal-lint (C++ style) stays off — cpplint/clang-format cover C++.
   - repo: https://github.com/fractalyze/fractal-lint
     rev: v0.6.0
     hooks:
       - id: fractal-commit-lint
+      - id: fractal-build-lint
 
   # Built-in hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
buildifier formats/lints Starlark but does **not** enforce BUILD target ordering or test-target naming — `fractal-build-lint` (`check_target_sort` + `check_test_name`) does. The existing config comment claimed cpplint/clang-format/buildifier already covered this; that's accurate for C++ but wrong for the BUILD half.

All 57 existing BUILD files already conform (`pre-commit run fractal-build-lint --all-files` passes), so enabling is zero-churn — it just prevents future drift in target ordering / test naming.

`fractal-lint` (ZKX C++ style) stays off; cpplint + clang-format cover C++ style here.