### PR TITLE
fix: shaped-constant materialization and single-element tensor AOT path

### DIFF
--- a/build_tools/github_actions/ci_build_bazel.sh
+++ b/build_tools/github_actions/ci_build_bazel.sh
@@ -108,6 +108,22 @@ bazel-test-diff() {
   # Remove external and duplicate targets.
   sort "$IMPACTED_TARGETS_PATH" | uniq | grep -v '//external' > "$FILTERED_TARGETS_PATH" || true
 
+  # Mirror wildcard (//...) semantics: keep only rule targets and drop
+  # `manual`-tagged ones. bazel-diff also lists output-file labels and manual
+  # rules; naming those in --target_pattern_file would force-build targets a
+  # plain `bazel test //...` run never touches (e.g. the Windows-only
+  # _prime_ir_common_def stub, which fails outright on Linux).
+  if [[ -s "$FILTERED_TARGETS_PATH" ]]; then
+    QUERY_FILE="$SCRATCH_DIR/wildcard_semantics_query.txt"
+    {
+      printf 'let t = set('
+      tr '\n' ' ' < "$FILTERED_TARGETS_PATH"
+      printf ') in kind(rule, $t) except attr("tags", "(^\\[|, )manual(, |\\]$)", $t)'
+    } > "$QUERY_FILE"
+    bazel query --query_file="$QUERY_FILE" > "$FILTERED_TARGETS_PATH.rules"
+    mv "$FILTERED_TARGETS_PATH.rules" "$FILTERED_TARGETS_PATH"
+  fi
+
   # Build and Test impacted targets. A single `test` invocation also builds
   # the impacted non-test targets — a separate `build` would compile a second
   # configuration, since test:ci carries build settings (--//:has_avx512).

--- a/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
+++ b/prime_ir/Dialect/EllipticCurve/Conversions/EllipticCurveToField/EllipticCurveToField.cpp
@@ -304,6 +304,10 @@ struct ConvertConvertPointType
   explicit ConvertConvertPointType(MLIRContext *context,
                                    AOTConfig aotConfig = {})
       : OpConversionPattern<ConvertPointTypeOp>(context), aotConfig(aotConfig) {
+    // The wrapped-scalar normalization below re-emits a scalar
+    // convert_point_type that this same pattern must legalize; the scalar op
+    // cannot match the normalization branch again, so recursion is bounded.
+    setHasBoundedRewriteRecursion();
   }
 
   LogicalResult
@@ -311,12 +315,31 @@ struct ConvertConvertPointType
                   ConversionPatternRewriter &rewriter) const override {
     Type inputType = op.getInput().getType();
     Type outputType = getElementTypeOrSelf(op.getType());
+    auto loc = op.getLoc();
+
+    // Normalize wrapped scalars: a statically single-element tensor (any
+    // rank, including rank-0) is a scalar in disguise — extract it, convert
+    // as a scalar, and wrap the result back. The scalar convert_point_type
+    // re-enters this pattern and takes the AOT or inline path per lowering
+    // mode. The batch path below saves nothing at N = 1 (Montgomery's trick
+    // costs 3(N-1) muls + 1 inverse).
+    if (auto tensorType = dyn_cast<RankedTensorType>(inputType);
+        tensorType && tensorType.hasStaticShape() &&
+        tensorType.getNumElements() == 1) {
+      Value zeroIdx = arith::ConstantIndexOp::create(rewriter, loc, 0);
+      SmallVector<Value> indices(tensorType.getRank(), zeroIdx);
+      Value scalar =
+          tensor::ExtractOp::create(rewriter, loc, adaptor.getInput(), indices);
+      Value converted =
+          ConvertPointTypeOp::create(rewriter, loc, outputType, scalar);
+      rewriter.replaceOpWithNewOp<tensor::FromElementsOp>(
+          op, cast<RankedTensorType>(op.getType()), converted);
+      return success();
+    }
 
     // Tensor batch path: Jacobian/XYZZ → Affine with batch field.inverse.
     // The batch inverse avoids per-element scalar inverse, enabling
     // Montgomery's trick (3(N-1) muls + 1 inverse instead of N inverses).
-    // Skip rank-0 tensors — they are scalars wrapped in tensor<T> and should
-    // use the scalar AOT/inline path below.
     if (auto tensorType = dyn_cast<RankedTensorType>(inputType);
         tensorType && tensorType.getRank() > 0) {
       auto inputPti = cast<PointTypeInterface>(tensorType.getElementType());
@@ -329,8 +352,8 @@ struct ConvertConvertPointType
     }
 
     // AOT runtime path for point type conversions.
-    // Use getElementTypeOrSelf for inputType since it is a rank-0 tensor
-    // when the batch path above is skipped (rank>0 tensors are handled there).
+    // Use getElementTypeOrSelf for inputType: multi-element tensors that the
+    // batch path doesn't cover (e.g. affine input) can still reach here.
     if (shouldUseAOTRuntime(op, outputType, aotConfig.mode,
                             aotConfig.inlineConstOps)) {
       auto inputPti = cast<PointTypeInterface>(getElementTypeOrSelf(inputType));

--- a/prime_ir/Dialect/Field/IR/FieldCanonicalization.td
+++ b/prime_ir/Dialect/Field/IR/FieldCanonicalization.td
@@ -46,7 +46,9 @@ def IsNegativeNine : Constraint<CPred<"isNegativeOf($0, $1, 9)">>;
 
 // Constant materialization
 def GetAsConstant : NativeCodeCall<"ConstantOp::create($_builder, odsLoc, $0.getType(), cast<TypedAttr>($1))">;
-def GetZeroAttr : NativeCodeCall<"cast<ConstantLikeInterface>(getElementTypeOrSelf($0.getType())).createConstantAttr(0)">;
+// The zero attribute must match the full result type: a scalar attr for
+// scalar results, a storage-int splat over the result shape for shaped ones.
+def GetZeroAttr : NativeCodeCall<"createZeroAttr($0.getType())">;
 
 //===----------------------------------------------------------------------===//
 // Include Canonicalization Pattern Files

--- a/prime_ir/Dialect/Field/IR/FieldOps.cpp
+++ b/prime_ir/Dialect/Field/IR/FieldOps.cpp
@@ -2112,6 +2112,33 @@ bool isEqualTo(Attribute attr, Value val, uint32_t offset) {
       [](const FieldOperation &a, const FieldOperation &b) { return a == b; });
 }
 
+// DRR constant helper: builds a zero attribute matching `type` — the element
+// type's scalar attr for scalar results, a storage-int splat over the result
+// shape (with the EF coefficient dims appended) for shaped ones.
+TypedAttr createZeroAttr(Type type) {
+  auto elementType = getElementTypeOrSelf(type);
+  TypedAttr zero =
+      cast<ConstantLikeInterface>(elementType).createConstantAttr(0);
+  auto shapedTy = dyn_cast<ShapedType>(type);
+  if (!shapedTy) {
+    return zero;
+  }
+  SmallVector<int64_t> attrShape(shapedTy.getShape());
+  IntegerType storageType;
+  if (auto efType = dyn_cast<ExtensionFieldType>(elementType)) {
+    auto towerShape = efType.getAttrShape();
+    attrShape.append(towerShape.begin(), towerShape.end());
+    storageType = efType.getBasePrimeField().getStorageType();
+  } else if (auto pfType = dyn_cast<PrimeFieldType>(elementType)) {
+    storageType = pfType.getStorageType();
+  } else {
+    storageType = cast<BinaryFieldType>(elementType).getStorageType();
+  }
+  return DenseIntElementsAttr::get(
+      RankedTensorType::get(attrShape, storageType),
+      APInt(storageType.getWidth(), 0));
+}
+
 } // namespace
 
 namespace {

--- a/prime_ir/Dialect/Field/IR/FieldOps.cpp
+++ b/prime_ir/Dialect/Field/IR/FieldOps.cpp
@@ -376,18 +376,6 @@ ConstantOp ConstantOp::materialize(OpBuilder &builder, Attribute value,
       auto scalarAttr = DenseIntElementsAttr::get(tensorType, coeffs);
       return ConstantOp::create(builder, loc, type, scalarAttr);
     }
-    if (auto shapedTy = dyn_cast<ShapedType>(type)) {
-      // PF/BF: a scalar carries implicit-splat semantics; store as a
-      // storage-int DenseIntElementsAttr splat matching the result shape.
-      auto storageType =
-          isa<PrimeFieldType>(elementType)
-              ? cast<PrimeFieldType>(elementType).getStorageType()
-              : cast<BinaryFieldType>(elementType).getStorageType();
-      auto splatAttr = DenseIntElementsAttr::get(
-          shapedTy.clone(storageType),
-          intAttr.getValue().zextOrTrunc(storageType.getWidth()));
-      return ConstantOp::create(builder, loc, type, splatAttr);
-    }
     return ConstantOp::create(builder, loc, type, intAttr);
   }
   // Fold results may arrive as storage-int-typed DenseElementsAttr. For an EF

--- a/prime_ir/Dialect/ModArith/IR/ModArithCanonicalization.td
+++ b/prime_ir/Dialect/ModArith/IR/ModArithCanonicalization.td
@@ -46,7 +46,9 @@ def IsNegativeNine : Constraint<CPred<"isNegativeOf($0, $1, 9)">>;
 
 // Constant materialization
 def GetAsConstant : NativeCodeCall<"ConstantOp::create($_builder, odsLoc, $0.getType(), cast<TypedAttr>($1))">;
-def GetZeroAttr : NativeCodeCall<"cast<ConstantLikeInterface>(getElementTypeOrSelf($0.getType())).createConstantAttr(0)">;
+// The zero attribute must match the full result type: a scalar attr for
+// scalar results, a storage-int splat over the result shape for shaped ones.
+def GetZeroAttr : NativeCodeCall<"createZeroAttr($0.getType())">;
 
 //===----------------------------------------------------------------------===//
 // Include Canonicalization Pattern Files

--- a/prime_ir/Dialect/ModArith/IR/ModArithOps.cpp
+++ b/prime_ir/Dialect/ModArith/IR/ModArithOps.cpp
@@ -756,6 +756,20 @@ bool isEqualTo(Attribute attr, Value val, uint32_t offset) {
                               const ModArithOperation &b) { return a == b; });
 }
 
+// DRR constant helper: builds a zero attribute matching `type` — the element
+// type's scalar attr for scalar results, a storage-int splat over the result
+// shape for shaped ones.
+TypedAttr createZeroAttr(Type type) {
+  auto modArithType = cast<ModArithType>(getElementTypeOrSelf(type));
+  auto zero = cast<IntegerAttr>(modArithType.createConstantAttr(0));
+  auto shapedTy = dyn_cast<ShapedType>(type);
+  if (!shapedTy) {
+    return zero;
+  }
+  return DenseIntElementsAttr::get(
+      shapedTy.clone(modArithType.getStorageType()), zero.getValue());
+}
+
 } // namespace
 
 namespace {

--- a/tests/Dialect/EllipticCurve/elliptic_curve_to_field.mlir
+++ b/tests/Dialect/EllipticCurve/elliptic_curve_to_field.mlir
@@ -216,3 +216,39 @@ func.func @test_batch_xyzz_to_affine(%arg0: tensor<4x!xyzzm>) -> tensor<4x!affin
   %result = elliptic_curve.convert_point_type %arg0 : tensor<4x!xyzzm> -> tensor<4x!affinem>
   return %result : tensor<4x!affinem>
 }
+
+// Single-element tensor convert_point_type takes the scalar path in inline
+// mode too: extract, scalar conversion, wrap back. The batch field.inverse
+// path saves nothing at N = 1, and the inline scalar codegen cannot consume
+// a tensor-typed point.
+// CHECK-LABEL: @test_1elem_jacobian_to_affine_inline
+func.func @test_1elem_jacobian_to_affine_inline(%arg0: tensor<1x!jacobianm>) -> tensor<1x!affinem> {
+  // CHECK-NOT: tensor.generate
+  // CHECK: tensor.extract
+  // CHECK: field.inverse
+  // CHECK-NOT: tensor.generate
+  // CHECK: tensor.from_elements
+  %result = elliptic_curve.convert_point_type %arg0 : tensor<1x!jacobianm> -> tensor<1x!affinem>
+  return %result : tensor<1x!affinem>
+}
+
+// Same for directions the batch path never covered (affine input).
+// CHECK-LABEL: @test_1elem_affine_to_jacobian_inline
+func.func @test_1elem_affine_to_jacobian_inline(%arg0: tensor<1x!affinem>) -> tensor<1x!jacobianm> {
+  // CHECK-NOT: elliptic_curve.convert_point_type
+  // CHECK: tensor.extract
+  // CHECK: elliptic_curve.from_coords
+  // CHECK: tensor.from_elements
+  %result = elliptic_curve.convert_point_type %arg0 : tensor<1x!affinem> -> tensor<1x!jacobianm>
+  return %result : tensor<1x!jacobianm>
+}
+
+// Multi-dim single-element tensors unwrap with one zero index per dimension.
+// CHECK-LABEL: @test_1x1_jacobian_to_affine_inline
+// CHECK: %[[C0:.*]] = arith.constant 0 : index
+func.func @test_1x1_jacobian_to_affine_inline(%arg0: tensor<1x1x!jacobianm>) -> tensor<1x1x!affinem> {
+  // CHECK: tensor.extract %{{.*}}[%[[C0]], %[[C0]]]
+  // CHECK: tensor.from_elements
+  %result = elliptic_curve.convert_point_type %arg0 : tensor<1x1x!jacobianm> -> tensor<1x1x!affinem>
+  return %result : tensor<1x1x!affinem>
+}

--- a/tests/Dialect/EllipticCurve/elliptic_curve_to_field_aot.mlir
+++ b/tests/Dialect/EllipticCurve/elliptic_curve_to_field_aot.mlir
@@ -37,3 +37,26 @@ func.func @test_r0_jacobian_to_affine_aot(%arg0: tensor<!jacobianm>) -> tensor<!
   %result = elliptic_curve.convert_point_type %arg0 : tensor<!jacobianm> -> tensor<!affinem>
   return %result : tensor<!affinem>
 }
+
+// Single-element tensors take the scalar AOT path too — the batch
+// jacobian → affine lowering (Montgomery's trick) saves nothing at N = 1,
+// and its batch field.inverse path can't unwrap to the runtime call.
+// CHECK-LABEL: @test_1elem_jacobian_to_affine_aot
+func.func @test_1elem_jacobian_to_affine_aot(%arg0: tensor<1x!jacobianm>) -> tensor<1x!affinem> {
+  // CHECK: tensor.extract
+  // CHECK: call @ec_jacobian_to_affine_bn254_g1_mont
+  // CHECK: tensor.from_elements
+  %result = elliptic_curve.convert_point_type %arg0 : tensor<1x!jacobianm> -> tensor<1x!affinem>
+  return %result : tensor<1x!affinem>
+}
+
+// Multi-dim single-element tensors unwrap with one index per dimension.
+// CHECK-LABEL: @test_1x1_affine_to_jacobian_aot
+// CHECK: %[[C0:.*]] = arith.constant 0 : index
+func.func @test_1x1_affine_to_jacobian_aot(%arg0: tensor<1x1x!affinem>) -> tensor<1x1x!jacobianm> {
+  // CHECK: tensor.extract %{{.*}}[%[[C0]], %[[C0]]]
+  // CHECK: call @ec_affine_to_jacobian_bn254_g1_mont
+  // CHECK: tensor.from_elements
+  %result = elliptic_curve.convert_point_type %arg0 : tensor<1x1x!affinem> -> tensor<1x1x!jacobianm>
+  return %result : tensor<1x1x!jacobianm>
+}

--- a/tests/Dialect/Field/field_canonicalize.mlir
+++ b/tests/Dialect/Field/field_canonicalize.mlir
@@ -533,6 +533,17 @@ func.func @test_sub_self_is_zero(%arg0: !PF17) -> !PF17 {
   return %0 : !PF17
 }
 
+// The zero constant must materialize as a splat matching the shaped result —
+// a scalar attr on a tensor-typed field.constant fails verification.
+// CHECK-LABEL: @test_sub_self_tensor_is_zero
+// CHECK-SAME: (%[[ARG0:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_sub_self_tensor_is_zero(%arg0: tensor<4x!PF17>) -> tensor<4x!PF17> {
+  %0 = field.sub %arg0, %arg0 : tensor<4x!PF17>
+  // CHECK: %[[C:.*]] = field.constant dense<0> : [[T]]
+  // CHECK: return %[[C]] : [[T]]
+  return %0 : tensor<4x!PF17>
+}
+
 // CHECK-LABEL: @test_sub_lhs_after_add
 // CHECK-SAME: (%[[ARG0:.*]]: [[T:.*]], %[[ARG1:.*]]: [[T]]) -> [[T]]
 func.func @test_sub_lhs_after_add(%arg0: !PF17, %arg1: !PF17) -> !PF17 {

--- a/tests/Dialect/ModArith/canonicalize.mlir
+++ b/tests/Dialect/ModArith/canonicalize.mlir
@@ -850,6 +850,17 @@ func.func @test_sub_self_is_zero(%arg0: !Zp) -> !Zp {
   return %0 : !Zp
 }
 
+// The zero constant must materialize as a splat matching the shaped result —
+// a scalar attr on a tensor-typed mod_arith.constant fails verification.
+// CHECK-LABEL: @test_sub_self_tensor_is_zero
+// CHECK-SAME: (%[[ARG0:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_sub_self_tensor_is_zero(%arg0: tensor<4x!Zp>) -> tensor<4x!Zp> {
+  %0 = mod_arith.sub %arg0, %arg0 : tensor<4x!Zp>
+  // CHECK: %[[C:.*]] = mod_arith.constant dense<0> : [[T]]
+  // CHECK: return %[[C]] : [[T]]
+  return %0 : tensor<4x!Zp>
+}
+
 // CHECK-LABEL: @test_sub_lhs_after_add
 // CHECK-SAME: (%[[ARG0:.*]]: [[T:.*]], %[[ARG1:.*]]: [[T]]) -> [[T]]
 func.func @test_sub_lhs_after_add(%arg0: !Zp, %arg1: !Zp) -> !Zp {


### PR DESCRIPTION
## Summary

Three changes surfaced by XLA CPU field/EC tests (shaped field arithmetic scalarized via `convert-elementwise-to-linalg`, point conversion on wrapped scalars):

- **fix: build shaped zero attrs in DRR canonicalization** — the shared `SubSelfIsZero`-style patterns built zero constants with `GetZeroAttr`, which produces the *element* type's scalar attr; gluing that onto a shaped result creates a constant whose attr doesn't match its type (passes the in-memory verifier, but the printed form fails to re-parse). `GetZeroAttr` now builds the attr from the full result type: storage-int splat over the result shape, EF coefficient dims appended.
- **refactor(dialect/field): drop scalar→splat lift from ConstantOp::materialize** — `ConstantOp::materialize` lifted a scalar `IntegerAttr` to a storage-int splat for shaped results, but only for PF/BF elements: the lift is undefinable for EF (a scalar EF attr is already a coefficient tensor) and EC (no scalar attr form), and mod_arith never lifted. A PF/BF-only convenience lets the same caller code silently break on EF/EC; `materialize` is the fold-constant hook whose attr must already match the result type, so a mismatched pair is a caller bug to surface. The sole dependent caller was `GetZeroAttr`, fixed above.
- **fix(dialect/ec): convert single-element tensor points via scalar path** — `convert_point_type` is deliberately not elementwise-mappable, so wrapped-scalar tensors reach the conversion whole, and both scalar backends only accept true scalars. On main: affine-input directions crash in `PointCodeGen` (`llvm_unreachable`) in inline/auto modes and emit an AOT call with a tensor-typed signature that doesn't match the scalar runtime ABI; multi-dim single-element tensors fail legalization outright. `ConvertConvertPointType` now normalizes statically single-element tensors (any rank, including rank-0) up front: extract the scalar, re-emit a scalar `convert_point_type` that re-enters the pattern (`setHasBoundedRewriteRecursion`) and takes the AOT or inline path per lowering mode, wrap the result back. This also routes N = 1 jacobian/xyzz→affine away from the batch path — Montgomery's trick saves nothing at N = 1, the scalar path keeps AOT as one fused runtime call, and the scalar lowering's identity (Z = 0) guard applies.

Known seams left as-is (pre-existing):
- N > 1 tensors in directions the batch path doesn't cover (e.g. `tensor<4x>` affine→jacobian) still crash inline / emit tensor-typed AOT calls.
- The batch jacobian/xyzz→affine path has no identity-point guard; one identity in a batch poisons every element through the Montgomery prefix products.

## Test plan

- New lit cases: `tests/Dialect/Field/field_canonicalize.mlir` + `tests/Dialect/ModArith/canonicalize.mlir` (shaped `sub(x, x)` → `dense<0>` splat), `tests/Dialect/EllipticCurve/elliptic_curve_to_field_aot.mlir` (`tensor<1x...>` and `tensor<1x1x...>` through the scalar AOT call), `tests/Dialect/EllipticCurve/elliptic_curve_to_field.mlir` (same shapes in default inline mode, both directions).
- Full suite `//tests/... //prime_ir/...`: 102/103; sole failure `pairing_check_4pairs_runner` timeout, pre-existing on clean main. Removing the materialize lift surfaced no other caller.
- Each commit builds and passes its tests independently.
