### PR TITLE
ci: fractal-lint v0.7.0 scope derivation + diff-only bazel tests on PRs

### DIFF
--- a/.fractal-commit-lint.toml
+++ b/.fractal-commit-lint.toml
@@ -1,21 +1,18 @@
 # Commit-scope policy for prime_ir (fractal-commit-lint).
 #
-# A scope is valid iff it equals the canonical scope derived from the changed
-# files (root stripped, each path segment camel_to_snake'd, capped at
-# max_scope_depth), or it is a curated [scopes] alias. See fractal-lint's
-# docs/scope-resolution.md.
-#
-# The [scopes] block blesses prime_ir's established short dialect names
-# (field, mod_arith, ...) as aliases: a blessed scope is checked by scope-path
-# only (its files must live under the listed prefixes) and is exempt from the
-# deepest-directory derivation — so feat(mod_arith) stays valid for a commit
-# under prime_ir/Dialect/ModArith/Conversions without demanding
-# mod_arith/conversions. CI runs this same tool over each commit via the
-# commit-lint action in hybrid mode (.github/workflows/commit-lint.yml), so
-# local pre-commit and CI agree.
+# Scopes are derived from the changed files: the `prime_ir` root is stripped, a
+# leading `tests` segment folds a test file onto its source scope (test_dirs),
+# each segment is camel_to_snake'd (with EllipticCurve shortened to ec), and
+# the result is capped at max_scope_depth (default 2). So
+# prime_ir/Dialect/ModArith/... and tests/Dialect/ModArith/... both derive
+# `dialect/mod_arith`, any deeper subdir (IR, Conversions) still caps to the
+# same scope, and a commit spanning two dialects takes no scope. CI runs this
+# same tool over each commit via the commit-lint action in hybrid mode
+# (.github/workflows/commit-lint.yml), so local pre-commit and CI agree.
 
 roots = ["prime_ir"]
 require_scope = false
+test_dirs = ["tests"]
 
 exempt_paths = [
   "WORKSPACE.bazel",
@@ -26,11 +23,5 @@ exempt_paths = [
   ".github",
 ]
 
-[scopes]
-arith_ext = ["prime_ir/Dialect/ArithExt"]
-elliptic_curve = ["prime_ir/Dialect/EllipticCurve"]
-field = ["prime_ir/Dialect/Field"]
-mod_arith = ["prime_ir/Dialect/ModArith"]
-poly = ["prime_ir/Dialect/Poly"]
-tensor_ext = ["prime_ir/Dialect/TensorExt"]
-tools = ["tools"]
+[dictionary]
+EllipticCurve = "ec"   # dialect/ec, not dialect/elliptic_curve

--- a/.fractal-commit-lint.toml
+++ b/.fractal-commit-lint.toml
@@ -21,6 +21,7 @@ exempt_paths = [
   "BUILD.bazel",
   "third_party",     # vendored deps (llvm, zk_dtypes pins)
   ".github",
+  "build_tools",     # CI scripts, cross-cutting
 ]
 
 [dictionary]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,26 @@ jobs:
   build-and-test:
     runs-on: [self-hosted, cpu]
     steps:
+      # Full history so bazel-diff can check out and hash the PR base revision.
       - name: Checkout PrimeIR
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Run `bazel test`
+      # PRs build and test only the targets bazel-diff reports as impacted by
+      # the base..head change; pushes to main run the full suite.
+      - name: Run `bazel test` (diff only)
+        if: github.event_name == 'pull_request'
         run: |
-          bazel --bazelrc=.bazelrc.ci test \
-            --config ci \
-            //...
+          BAZEL_DIFF=$(mktemp -t bazel-diff.XXXXXX.jar)
+          curl -Lo "$BAZEL_DIFF" https://github.com/Tinder/bazel-diff/releases/download/17.0.2/bazel-diff_deploy.jar
+          ./build_tools/github_actions/ci_build_bazel.sh "$BAZEL_DIFF" \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}"
+
+      - name: Run `bazel test` (all)
+        if: github.event_name != 'pull_request'
+        run: ./build_tools/github_actions/ci_build_bazel.sh
 
   pre-commit-style:
     if: github.actor != 'fractalyze-dev'

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -24,4 +24,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           scope_mode: hybrid
-          fractal_lint_version: v0.6.0
+          fractal_lint_version: v0.7.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
   # commit-lint action in hybrid mode. (fractal-lint / fractal-build-lint are
   # intentionally not enabled — cpplint/clang-format/buildifier cover C++/BUILD.)
   - repo: https://github.com/fractalyze/fractal-lint
-    rev: v0.6.0
+    rev: v0.7.0
     hooks:
       - id: fractal-commit-lint
 

--- a/build_tools/github_actions/ci_build_bazel.sh
+++ b/build_tools/github_actions/ci_build_bazel.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Copyright 2026 The PrimeIR Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ $# -ne 0 && $# -ne 3 ]] ; then
+  echo "Usage: $0 [<bazel-diff.jar> <start_commit> <end_commit>]"
+  echo "   Builds and tests all bazel targets."
+  echo "   If start_commit and end_commit are specified, uses bazel-diff to"
+  echo "   determine the set of targets to build based on code changes."
+  echo
+  echo "Example: Build all affected targets between current branch and main"
+  echo "  $ curl -Lo /tmp/bazel-diff.jar https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy.jar"
+  echo "  $ ci_build_bazel.sh /tmp/bazel-diff.jar main \$(git rev-parse --abbrev-ref HEAD)"
+  exit 1
+fi
+
+# CI options live in .bazelrc.ci as :ci-namespaced configs.
+bazel-ci() {
+  bazel --bazelrc=.bazelrc.ci "$@" --config ci
+}
+
+bazel-test-all() {
+  bazel-ci test //...
+}
+
+bazel-test-diff() {
+  set -e
+  WORKSPACE_PATH=$(git rev-parse --show-toplevel)
+  BAZEL_DIFF_JAR="$1"
+  PREVIOUS_REV="$2" # Starting Revision SHA
+  FINAL_REV="$3" # Final Revision SHA
+  BAZEL_PATH="$(which bazel)"
+
+  # Per-invocation scratch dir: fixed /tmp names collide when several runner
+  # slots on one host execute this script concurrently.
+  SCRATCH_DIR="$(mktemp -d -t bazel-diff.XXXXXX)"
+  trap 'rm -rf "$SCRATCH_DIR"' EXIT
+  STARTING_HASHES_JSON="$SCRATCH_DIR/starting_hashes.json"
+  FINAL_HASHES_JSON="$SCRATCH_DIR/final_hashes.json"
+  IMPACTED_TARGETS_PATH="$SCRATCH_DIR/impacted_targets.txt"
+  FILTERED_TARGETS_PATH="$SCRATCH_DIR/filtered_targets.txt"
+
+  bazel-diff() {
+    java -jar "$BAZEL_DIFF_JAR" "$@"
+  }
+
+  # Build-configuration files live outside the target graph: editing them
+  # changes what every target means but no target hash. Seed them into every
+  # hash so such a change falls back to a full run.
+  SEED_FILEPATHS="$SCRATCH_DIR/seed_filepaths.txt"
+  seed-filepaths() {
+    : > "$SEED_FILEPATHS"
+    for f in .bazelrc .bazelrc.ci .bazelversion WORKSPACE.bazel MODULE.bazel; do
+      [[ -f "$WORKSPACE_PATH/$f" ]] && echo "$WORKSPACE_PATH/$f" >> "$SEED_FILEPATHS"
+    done
+  }
+
+  git -C "$WORKSPACE_PATH" checkout "$PREVIOUS_REV" --quiet
+
+  echo "Generating Hashes for Revision '$PREVIOUS_REV'"
+  seed-filepaths
+  bazel-diff generate-hashes -w "$WORKSPACE_PATH" -b "$BAZEL_PATH" -s "$SEED_FILEPATHS" $STARTING_HASHES_JSON
+
+  UNCOMMITTED_CHANGES="$(git status -s)"
+  if [[ -n "$UNCOMMITTED_CHANGES" ]]; then
+    echo "[WARNING] Uncommitted changes found, likely build byproducts:"
+    echo "$UNCOMMITTED_CHANGES"
+  fi
+
+  git reset --hard "$PREVIOUS_REV"
+  git -C "$WORKSPACE_PATH" checkout "$FINAL_REV" --quiet
+
+  echo "Generating Hashes for Revision '$FINAL_REV'"
+  seed-filepaths
+  bazel-diff generate-hashes -w "$WORKSPACE_PATH" -b "$BAZEL_PATH" -s "$SEED_FILEPATHS" $FINAL_HASHES_JSON
+
+  echo "Determining Impacted Targets"
+  bazel-diff get-impacted-targets -sh $STARTING_HASHES_JSON -fh $FINAL_HASHES_JSON -o $IMPACTED_TARGETS_PATH -w "$WORKSPACE_PATH"
+  echo ""
+
+  impacted_targets=()
+  IFS=$'\n' read -d '' -r -a impacted_targets < $IMPACTED_TARGETS_PATH || true
+  formatted_impacted_targets=$(IFS=$'\n'; echo "${impacted_targets[*]}")
+  if [[ -z "$formatted_impacted_targets" ]]; then
+    echo "No impacted targets from change."
+    exit 0
+  fi
+
+  NUM_IMPACTED=$(echo "$formatted_impacted_targets" | wc -l)
+  echo "[$NUM_IMPACTED] Impacted Targets between $PREVIOUS_REV and $FINAL_REV:"
+  echo "$formatted_impacted_targets"
+  echo ""
+
+  # Remove external and duplicate targets.
+  sort "$IMPACTED_TARGETS_PATH" | uniq | grep -v '//external' > "$FILTERED_TARGETS_PATH" || true
+
+  # Build and Test impacted targets. A single `test` invocation also builds
+  # the impacted non-test targets — a separate `build` would compile a second
+  # configuration, since test:ci carries build settings (--//:has_avx512).
+  # Exit code 4 means everything built but the impacted set contains no tests.
+  if [[ -s "$FILTERED_TARGETS_PATH" ]]; then
+    echo "Building and Testing Impacted (Non-External) Targets..."
+    bazel-ci test --target_pattern_file="$FILTERED_TARGETS_PATH" || {
+      ec=$?
+      if [[ $ec -eq 4 ]]; then
+        echo "No test targets among the impacted set; build succeeded."
+      else
+        exit $ec
+      fi
+    }
+  else
+    echo "No non-external impacted targets to build and test."
+  fi
+}
+
+# Run bazel build and test
+if [[ $# -eq 0 ]] ; then
+  bazel-test-all
+else
+  bazel-test-diff "$@"
+fi


### PR DESCRIPTION
## Description

Two CI changes:

**Commit-scope derivation (fractal-lint v0.7.0).** The blessed `[scopes]` aliases list only `prime_ir/Dialect/*` prefixes, so any scoped commit touching the parallel `tests/Dialect/*` mirror — the normal shape for a dialect change, per the repo's history (#332, #329, #328) — fails the scope-path check. v0.7.0 derives scopes per file with `test_dirs` folding the `tests/` mirror onto its source scope, so the curated aliases go away: source and test files alike derive `dialect/<name>` (`dialect/field`, `dialect/mod_arith`, `dialect/ec`, …), with `EllipticCurve` dictionary-shortened to `ec` to keep headers inside the 80-char budget. stablehlo_fork already uses this setup. Lands separately from #334 because commit-lint runs on `pull_request_target`: the workflow definition (and its `fractal_lint_version` pin) comes from the base branch, so the bump must be on main before any PR with `dialect/*`-scoped commits can pass.

**Diff-only bazel tests on PRs.** Every PR ran the full `//...` suite regardless of what changed. PRs now hash base and head with bazel-diff and run only impacted targets; pushes to main keep the full run. Adapted from stablehlo_fork with three deviations: a single `bazel test` invocation instead of build-then-test (test:ci carries build settings — `--//:has_avx512` — that would compile a second configuration; bazel exit 4 tolerated for impacted sets with no tests); mktemp scratch paths instead of fixed /tmp names, which collide between runner slots sharing a host; and build-config files (.bazelrc, .bazelrc.ci, .bazelversion, WORKSPACE.bazel, MODULE.bazel) passed as bazel-diff seeds, so an edit to them — invisible to the target graph — falls back to a full run instead of running zero targets.

Verified locally: hashed main vs #334's head (456 impacted targets), mixed library+test pattern file runs, no-test pattern file exits 4 and is tolerated, and a .bazelrc edit marks all 1241 targets impacted via the seed path.

## Related Issues/PRs

Unblocks #334.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline
