### PR TITLE
ci: skip pywrap Windows def helpers in diff-only bazel tests

### DIFF
--- a/build_tools/github_actions/ci_build_bazel.sh
+++ b/build_tools/github_actions/ci_build_bazel.sh
@@ -105,8 +105,13 @@ bazel-test-diff() {
   echo "$formatted_impacted_targets"
   echo ""
 
-  # Remove external and duplicate targets.
-  sort "$IMPACTED_TARGETS_PATH" | uniq | grep -v '//external' > "$FILTERED_TARGETS_PATH" || true
+  # Remove external and duplicate targets. Also drop pywrap_library's
+  # Windows DLL-export helpers (`*_def`): their WinDefFileParse action is a
+  # Windows-only stub (no_op.bat) on Linux, so building them explicitly
+  # fails. The full-suite path never reaches them — `bazel test //...`
+  # builds only tests and their deps.
+  sort "$IMPACTED_TARGETS_PATH" | uniq | grep -v '//external' \
+    | grep -vE '_def$' > "$FILTERED_TARGETS_PATH" || true
 
   # Build and Test impacted targets. A single `test` invocation also builds
   # the impacted non-test targets — a separate `build` would compile a second


### PR DESCRIPTION
## Description

First real exercise of the diff-only bazel path (#335) on a source-touching PR (#334) failed before running any test:

```
ERROR: ... WinDefFileParse prime_ir/_prime_ir_common_def.gen.def failed: (Exit 2): no_op.bat failed
external/bazel_tools/tools/def_parser/no_op.bat: 3: Syntax error: "(" unexpected
Executed 0 out of 103 tests: 103 were skipped.
```

bazel-diff's impacted set includes non-test targets, and `bazel test --target_pattern_file` builds those too. `pywrap_library`'s Windows DLL-export helpers (`_prime_ir_common_def`, `_prime_ir_{0,1,2}_win_def`) carry a WinDefFileParse action whose parser on Linux is bazel's `no_op.bat` Windows stub — building them explicitly always fails on the Linux runners. The full-suite path never reaches them: `bazel test //...` builds only tests and their deps.

Filter `_def$`-suffixed targets out of the impacted set, next to the existing `//external` filter. `bazel query 'filter("_def$", //...)'` confirms the pattern matches exactly the four pywrap helpers.

Unblocks #334.