### PR TITLE
ci: filter bazel-diff impacted targets to wildcard semantics

### DIFF
--- a/build_tools/github_actions/ci_build_bazel.sh
+++ b/build_tools/github_actions/ci_build_bazel.sh
@@ -108,6 +108,22 @@ bazel-test-diff() {
   # Remove external and duplicate targets.
   sort "$IMPACTED_TARGETS_PATH" | uniq | grep -v '//external' > "$FILTERED_TARGETS_PATH" || true
 
+  # Mirror wildcard (//...) semantics: keep only rule targets and drop
+  # `manual`-tagged ones. bazel-diff also lists output-file labels and manual
+  # rules; naming those in --target_pattern_file would force-build targets a
+  # plain `bazel test //...` run never touches (e.g. the Windows-only
+  # _prime_ir_common_def stub, which fails outright on Linux).
+  if [[ -s "$FILTERED_TARGETS_PATH" ]]; then
+    QUERY_FILE="$SCRATCH_DIR/wildcard_semantics_query.txt"
+    {
+      printf 'let t = set('
+      tr '\n' ' ' < "$FILTERED_TARGETS_PATH"
+      printf ') in kind(rule, $t) except attr("tags", "(^\\[|, )manual(, |\\]$)", $t)'
+    } > "$QUERY_FILE"
+    bazel query --query_file="$QUERY_FILE" > "$FILTERED_TARGETS_PATH.rules"
+    mv "$FILTERED_TARGETS_PATH.rules" "$FILTERED_TARGETS_PATH"
+  fi
+
   # Build and Test impacted targets. A single `test` invocation also builds
   # the impacted non-test targets — a separate `build` would compile a second
   # configuration, since test:ci carries build settings (--//:has_avx512).


### PR DESCRIPTION
## Description

bazel-diff lists every impacted label — output files and `manual`-tagged rules included — and `--target_pattern_file` names them explicitly, overriding the `manual` tag that wildcard expansion honors. The first PR through the diff-only path (#334) failed building `//prime_ir:_prime_ir_common_def`, a Windows-only def-parser stub (`no_op.bat`) that `bazel test //...` never touches on Linux.

Pipe the filtered impacted set through `kind(rule, $t) except attr(tags, manual, $t)` so the explicit list builds exactly the wildcard's universe. Validated against #334's real 456-target impacted list: 456 → 335 targets, the def stub and all generated-file labels dropped, all 108 test targets kept.

## Related Issues/PRs

Fixes the diff-only path from #335; unblocks #334.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline