### PR TITLE
feat(mod_arith): target-conditioned 32-bit-limb CIOS Montgomery lowering

### DIFF
--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/BUILD.bazel
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/BUILD.bazel
@@ -32,6 +32,7 @@ prime_ir_cc_library(
         "//prime_ir/Dialect/Field/IR:Field",
         "//prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Inverter:BYInverter",
         "//prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer:BarrettReducer",
+        "//prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer:CiosMontEmitter",
         "//prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer:MontReducer",
         "//prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer:SolinasReducer",
         "//prime_ir/Dialect/ModArith/IR:ModArith",

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -547,7 +547,11 @@ struct ConvertNegate : public BoundMapPattern<NegateOp> {
 };
 
 struct ConvertMontReduce : public BoundMapPattern<MontReduceOp> {
-  using BoundMapPattern::BoundMapPattern;
+  ConvertMontReduce(const TypeConverter &tc, MLIRContext *context,
+                    const BoundMap *boundMap, bool useGpuCios,
+                    PatternBenefit benefit = 1)
+      : BoundMapPattern(tc, context, boundMap, benefit),
+        useGpuCios(useGpuCios) {}
 
   LogicalResult
   matchAndRewrite(MontReduceOp op, OpAdaptor adaptor,
@@ -559,13 +563,26 @@ struct ConvertMontReduce : public BoundMapPattern<MontReduceOp> {
     Value tLow = adaptor.getLow();
     Value tHigh = adaptor.getHigh();
 
-    // Perform Montgomery reduction using MontReducer helper class.
-    MontReducer reducer(b, getResultModArithType(op));
+    ModArithType modType = getResultModArithType(op);
     uint64_t resBound = lookupKp(op.getResult());
+
+    // GPU target: emit 32-bit-limb fused-CIOS REDC instead of the wide-int
+    // path. Same R as the wide path. Falls through when ineligible.
+    if (useGpuCios && CiosMontEmitter::isEligible(modType, tLow.getType())) {
+      Value result = CiosMontEmitter(b, modType)
+                         .emitRedc(tLow, tHigh, /*lazy=*/resBound >= 2);
+      rewriter.replaceOp(op, result);
+      return success();
+    }
+
+    // Perform Montgomery reduction using MontReducer helper class.
+    MontReducer reducer(b, modType);
     Value result = reducer.reduce(tLow, tHigh, /*lazy=*/resBound >= 2);
     rewriter.replaceOp(op, result);
     return success();
   }
+
+  bool useGpuCios;
 };
 
 struct ConvertToMont : public OpConversionPattern<ToMontOp> {
@@ -1421,7 +1438,11 @@ struct ConvertSquare : public OpConversionPattern<SquareOp> {
 };
 
 struct ConvertMontSquare : public BoundMapPattern<MontSquareOp> {
-  using BoundMapPattern::BoundMapPattern;
+  ConvertMontSquare(const TypeConverter &tc, MLIRContext *context,
+                    const BoundMap *boundMap, bool useGpuCios,
+                    PatternBenefit benefit = 1)
+      : BoundMapPattern(tc, context, boundMap, benefit),
+        useGpuCios(useGpuCios) {}
 
   LogicalResult
   matchAndRewrite(MontSquareOp op, OpAdaptor adaptor,
@@ -1450,14 +1471,26 @@ struct ConvertMontSquare : public BoundMapPattern<MontSquareOp> {
         input = reducer.getCanonicalFromExtended(input, inputKp);
     }
 
-    auto sqResult = squareExtended(b, op, input);
     uint64_t resBound = lookupKp(op.getResult());
 
+    // GPU target: emit 32-bit-limb fused-CIOS via emitMontMul(input, input).
+    // Same R as the wide path; the operand pre-reduction above applies
+    // unchanged. Falls through when ineligible.
+    if (useGpuCios && CiosMontEmitter::isEligible(modType, input.getType())) {
+      Value result = CiosMontEmitter(b, modType)
+                         .emitMontMul(input, input, /*lazy=*/resBound >= 2);
+      rewriter.replaceOp(op, result);
+      return success();
+    }
+
+    auto sqResult = squareExtended(b, op, input);
     Value result = reducer.reduce(sqResult.lo, sqResult.hi,
                                   /*lazy=*/resBound >= 2);
     rewriter.replaceOp(op, result);
     return success();
   }
+
+  bool useGpuCios;
 };
 
 // TODO(ashjeong): Account for Montgomery domain inputs. Currently only accounts
@@ -1578,14 +1611,13 @@ void ModArithToArith::runOnOperation() {
       ConvertDouble,
       ConvertInverse,
       ConvertMontInverse,
-      ConvertMontReduce,
-      ConvertMontSquare,
       ConvertNegate,
       ConvertSub
       // clang-format on
       >(typeConverter, context, bm);
-  // ConvertMontMul additionally takes the GPU/CIOS routing flag.
-  patterns.add<ConvertMontMul>(typeConverter, context, bm, useGpuCios);
+  // The Montgomery-family patterns additionally take the GPU/CIOS routing flag.
+  patterns.add<ConvertMontMul, ConvertMontReduce, ConvertMontSquare>(
+      typeConverter, context, bm, useGpuCios);
   // Patterns that don't use BoundMap.
   patterns.add<
       // clang-format off

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -548,10 +548,10 @@ struct ConvertNegate : public BoundMapPattern<NegateOp> {
 
 struct ConvertMontReduce : public BoundMapPattern<MontReduceOp> {
   ConvertMontReduce(const TypeConverter &tc, MLIRContext *context,
-                    const BoundMap *boundMap, bool useGpuCios,
+                    const BoundMap *boundMap, bool useExperimentalCios,
                     PatternBenefit benefit = 1)
       : BoundMapPattern(tc, context, boundMap, benefit),
-        useGpuCios(useGpuCios) {}
+        useExperimentalCios(useExperimentalCios) {}
 
   LogicalResult
   matchAndRewrite(MontReduceOp op, OpAdaptor adaptor,
@@ -566,9 +566,10 @@ struct ConvertMontReduce : public BoundMapPattern<MontReduceOp> {
     ModArithType modType = getResultModArithType(op);
     uint64_t resBound = lookupKp(op.getResult());
 
-    // GPU target: emit 32-bit-limb fused-CIOS REDC instead of the wide-int
-    // path. Same R as the wide path. Falls through when ineligible.
-    if (useGpuCios && CiosMontEmitter::isEligible(modType, tLow.getType())) {
+    // Experimental opt-in: emit 32-bit-limb fused-CIOS REDC instead of the
+    // wide-int path. Same R as the wide path. Falls through when ineligible.
+    if (useExperimentalCios &&
+        CiosMontEmitter::isEligible(modType, tLow.getType())) {
       Value result = CiosMontEmitter(b, modType)
                          .emitRedc(tLow, tHigh, /*lazy=*/resBound >= 2);
       rewriter.replaceOp(op, result);
@@ -582,7 +583,7 @@ struct ConvertMontReduce : public BoundMapPattern<MontReduceOp> {
     return success();
   }
 
-  bool useGpuCios;
+  bool useExperimentalCios;
 };
 
 struct ConvertToMont : public OpConversionPattern<ToMontOp> {
@@ -1122,10 +1123,10 @@ struct ConvertMul : public OpConversionPattern<MulOp> {
 
 struct ConvertMontMul : public BoundMapPattern<MontMulOp> {
   ConvertMontMul(const TypeConverter &tc, MLIRContext *context,
-                 const BoundMap *boundMap, bool useGpuCios,
+                 const BoundMap *boundMap, bool useExperimentalCios,
                  PatternBenefit benefit = 1)
       : BoundMapPattern(tc, context, boundMap, benefit),
-        useGpuCios(useGpuCios) {}
+        useExperimentalCios(useExperimentalCios) {}
 
   LogicalResult
   matchAndRewrite(MontMulOp op, OpAdaptor adaptor,
@@ -1177,10 +1178,11 @@ struct ConvertMontMul : public BoundMapPattern<MontMulOp> {
       }
     }
 
-    // GPU target: emit 32-bit-limb fused-CIOS instead of the wide-int path.
-    // Same R as the wide path, so the operand pre-reduction above (REDC
+    // Experimental opt-in: emit 32-bit-limb fused-CIOS instead of the wide-int
+    // path. Same R as the wide path, so the operand pre-reduction above (REDC
     // precondition) applies unchanged. Falls through when ineligible.
-    if (useGpuCios && CiosMontEmitter::isEligible(modType, lhs.getType())) {
+    if (useExperimentalCios &&
+        CiosMontEmitter::isEligible(modType, lhs.getType())) {
       Value result = CiosMontEmitter(b, modType)
                          .emitMontMul(lhs, rhs, /*lazy=*/resBound >= 2);
       rewriter.replaceOp(op, result);
@@ -1215,7 +1217,7 @@ struct ConvertMontMul : public BoundMapPattern<MontMulOp> {
     return success();
   }
 
-  bool useGpuCios;
+  bool useExperimentalCios;
 };
 
 struct ConvertBarrettMul : public OpConversionPattern<BarrettMulOp> {
@@ -1439,10 +1441,10 @@ struct ConvertSquare : public OpConversionPattern<SquareOp> {
 
 struct ConvertMontSquare : public BoundMapPattern<MontSquareOp> {
   ConvertMontSquare(const TypeConverter &tc, MLIRContext *context,
-                    const BoundMap *boundMap, bool useGpuCios,
+                    const BoundMap *boundMap, bool useExperimentalCios,
                     PatternBenefit benefit = 1)
       : BoundMapPattern(tc, context, boundMap, benefit),
-        useGpuCios(useGpuCios) {}
+        useExperimentalCios(useExperimentalCios) {}
 
   LogicalResult
   matchAndRewrite(MontSquareOp op, OpAdaptor adaptor,
@@ -1473,10 +1475,11 @@ struct ConvertMontSquare : public BoundMapPattern<MontSquareOp> {
 
     uint64_t resBound = lookupKp(op.getResult());
 
-    // GPU target: emit 32-bit-limb fused-CIOS via emitMontMul(input, input).
-    // Same R as the wide path; the operand pre-reduction above applies
+    // Experimental opt-in: emit 32-bit-limb fused-CIOS via emitMontMul(input,
+    // input). Same R as the wide path; the operand pre-reduction above applies
     // unchanged. Falls through when ineligible.
-    if (useGpuCios && CiosMontEmitter::isEligible(modType, input.getType())) {
+    if (useExperimentalCios &&
+        CiosMontEmitter::isEligible(modType, input.getType())) {
       Value result = CiosMontEmitter(b, modType)
                          .emitMontMul(input, input, /*lazy=*/resBound >= 2);
       rewriter.replaceOp(op, result);
@@ -1490,7 +1493,7 @@ struct ConvertMontSquare : public BoundMapPattern<MontSquareOp> {
     return success();
   }
 
-  bool useGpuCios;
+  bool useExperimentalCios;
 };
 
 // TODO(ashjeong): Account for Montgomery domain inputs. Currently only accounts
@@ -1595,7 +1598,12 @@ void ModArithToArith::runOnOperation() {
     }
   }
   const BoundMap *bm = lazyReduction ? &moduleBoundMap : nullptr;
-  const bool useGpuCios = this->target == "gpu";
+  // 32-bit-limb CIOS is opt-in (limb-bits=32) and off by default: it regresses
+  // montmul on a strong-64-bit-multiply target (prime-ir#337 PR3 measured
+  // ~0.81x vs the wide-int 64-bit-limb schoolbook on the RTX 5090). Intended
+  // for a 32-bit-native-multiply target (e.g. a 32-bit CPU). Any other width
+  // keeps the wide-int path.
+  const bool useExperimentalCios = this->limbBits == 32;
 
   ConversionTarget target(*context);
   target.addIllegalDialect<ModArithDialect>();
@@ -1615,9 +1623,10 @@ void ModArithToArith::runOnOperation() {
       ConvertSub
       // clang-format on
       >(typeConverter, context, bm);
-  // The Montgomery-family patterns additionally take the GPU/CIOS routing flag.
+  // The Montgomery-family patterns additionally take the CIOS routing flag
+  // (opt-in via limb-bits=32).
   patterns.add<ConvertMontMul, ConvertMontReduce, ConvertMontSquare>(
-      typeConverter, context, bm, useGpuCios);
+      typeConverter, context, bm, useExperimentalCios);
   // Patterns that don't use BoundMap.
   patterns.add<
       // clang-format off

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -47,6 +47,7 @@ limitations under the License.
 #include "prime_ir/Dialect/Field/IR/FieldOps.h"
 #include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Inverter/BYInverter.h"
 #include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BarrettReducer.h"
+#include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/CiosMontEmitter.h"
 #include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.h"
 #include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/SolinasReducer.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithDialect.h"
@@ -1103,7 +1104,11 @@ struct ConvertMul : public OpConversionPattern<MulOp> {
 };
 
 struct ConvertMontMul : public BoundMapPattern<MontMulOp> {
-  using BoundMapPattern::BoundMapPattern;
+  ConvertMontMul(const TypeConverter &tc, MLIRContext *context,
+                 const BoundMap *boundMap, bool useGpuCios,
+                 PatternBenefit benefit = 1)
+      : BoundMapPattern(tc, context, boundMap, benefit),
+        useGpuCios(useGpuCios) {}
 
   LogicalResult
   matchAndRewrite(MontMulOp op, OpAdaptor adaptor,
@@ -1155,6 +1160,16 @@ struct ConvertMontMul : public BoundMapPattern<MontMulOp> {
       }
     }
 
+    // GPU target: emit 32-bit-limb fused-CIOS instead of the wide-int path.
+    // Same R as the wide path, so the operand pre-reduction above (REDC
+    // precondition) applies unchanged. Falls through when ineligible.
+    if (useGpuCios && CiosMontEmitter::isEligible(modType, lhs.getType())) {
+      Value result = CiosMontEmitter(b, modType)
+                         .emitMontMul(lhs, rhs, /*lazy=*/resBound >= 2);
+      rewriter.replaceOp(op, result);
+      return success();
+    }
+
     // Signed multiply optimization: extract pre-reduction values from
     // minui(sub, sub+p) to use MulSIExtendedOp. Only safe for single-limb
     // types — reduceMultiLimb uses unsigned shifts that don't preserve
@@ -1182,6 +1197,8 @@ struct ConvertMontMul : public BoundMapPattern<MontMulOp> {
     rewriter.replaceOp(op, result);
     return success();
   }
+
+  bool useGpuCios;
 };
 
 struct ConvertBarrettMul : public OpConversionPattern<BarrettMulOp> {
@@ -1545,6 +1562,7 @@ void ModArithToArith::runOnOperation() {
     }
   }
   const BoundMap *bm = lazyReduction ? &moduleBoundMap : nullptr;
+  const bool useGpuCios = this->target == "gpu";
 
   ConversionTarget target(*context);
   target.addIllegalDialect<ModArithDialect>();
@@ -1560,13 +1578,14 @@ void ModArithToArith::runOnOperation() {
       ConvertDouble,
       ConvertInverse,
       ConvertMontInverse,
-      ConvertMontMul,
       ConvertMontReduce,
       ConvertMontSquare,
       ConvertNegate,
       ConvertSub
       // clang-format on
       >(typeConverter, context, bm);
+  // ConvertMontMul additionally takes the GPU/CIOS routing flag.
+  patterns.add<ConvertMontMul>(typeConverter, context, bm, useGpuCios);
   // Patterns that don't use BoundMap.
   patterns.add<
       // clang-format off

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.td
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.td
@@ -44,11 +44,18 @@ def ModArithToArith : Pass<"mod-arith-to-arith", "ModuleOp"> {
   let options = [
     Option<"lazyReduction", "lazy-reduction", "bool", "false",
       "Enable lazy reduction optimization via integer range analysis">,
-    Option<"target", "target", "std::string", /*default=*/"\"cpu\"",
-      "Lowering target: 'cpu' keeps the wide-int limb lowering (native "
-      "64-bit multiply); 'gpu' lowers multi-limb Montgomery multiplies "
-      "via 32-bit-limb CIOS (IMAD.WIDE). Sign-bit-set moduli always use "
-      "the cpu path.">,
+    Option<"limbBits", "limb-bits", "unsigned", /*default=*/"64",
+      "Montgomery-multiply limb width. 64 (default) keeps the wide-int "
+      "lowering, which LLVM legalizes to a native 64-bit-limb schoolbook "
+      "(mul.lo/hi + carry chains). 32 emits an explicit 32-bit-limb CIOS "
+      "(every limb product is a 32x32->64 widening multiply) for multi-limb "
+      "moduli. 32 is EXPERIMENTAL and off by default: it measured ~0.81x "
+      "(slower) than 64 on RTX 5090 (prime-ir#337 PR3) because the GPU has "
+      "a strong 64-bit multiply; it is intended for a target whose native "
+      "multiply is 32-bit (e.g. a 32-bit CPU), where the wide path emulates "
+      "64-bit products. No such target in the fleet today. Sign-bit-set and "
+      "single-limb moduli always keep the wide-int path. Values other than "
+      "32 keep the wide-int path.">,
   ];
 }
 

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.td
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.td
@@ -44,6 +44,11 @@ def ModArithToArith : Pass<"mod-arith-to-arith", "ModuleOp"> {
   let options = [
     Option<"lazyReduction", "lazy-reduction", "bool", "false",
       "Enable lazy reduction optimization via integer range analysis">,
+    Option<"target", "target", "std::string", /*default=*/"\"cpu\"",
+      "Lowering target: 'cpu' keeps the wide-int limb lowering (native "
+      "64-bit multiply); 'gpu' lowers multi-limb Montgomery multiplies "
+      "via 32-bit-limb CIOS (IMAD.WIDE). Sign-bit-set moduli always use "
+      "the cpu path.">,
   ];
 }
 

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BUILD.bazel
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/BUILD.bazel
@@ -34,6 +34,19 @@ prime_ir_cc_library(
 )
 
 prime_ir_cc_library(
+    name = "CiosMontEmitter",
+    srcs = ["CiosMontEmitter.cpp"],
+    hdrs = ["CiosMontEmitter.h"],
+    deps = [
+        ":MontReducer",
+        "//prime_ir/Dialect/ModArith/IR:ModArith",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+prime_ir_cc_library(
     name = "BarrettReducer",
     srcs = ["BarrettReducer.cpp"],
     hdrs = ["BarrettReducer.h"],

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/CiosMontEmitter.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/CiosMontEmitter.cpp
@@ -124,6 +124,21 @@ std::pair<Value, Value> CiosMontEmitter::addCarryStep(Value t32, Value c32) {
   return {lo, hi};
 }
 
+Value CiosMontEmitter::reduceRow(MutableArrayRef<Value> t,
+                                 ArrayRef<Value> nConst, Value np32,
+                                 unsigned n) {
+  // m = t[0] * n′₃₂ (low half); the resulting t[0] + m*n[0] has a zero low
+  // limb, which is the limb dropped by the ÷2³² shift.
+  Value m = arith::MulIOp::create(b, t[0], np32);
+  Value c;
+  // mulAddStep on (m, n[0], t[0], 0): lo is 0 by construction, discard it.
+  std::tie(std::ignore, c) = mulAddStep(m, nConst[0], t[0], i32Const(0));
+  for (unsigned j = 1; j < n; ++j)
+    std::tie(t[j - 1], c) = mulAddStep(m, nConst[j], t[j], c);
+  std::tie(t[n - 1], c) = addCarryStep(t[n], c);
+  return c;
+}
+
 Value CiosMontEmitter::emitMontMul(Value lhs, Value rhs, bool lazy) {
   auto wideTy = cast<IntegerType>(lhs.getType());
   unsigned w = wideTy.getWidth();
@@ -156,15 +171,62 @@ Value CiosMontEmitter::emitMontMul(Value lhs, Value rhs, bool lazy) {
     // hi add cannot overflow t[N+1]'s column, so a plain i32 add suffices.
     t[n + 1] = arith::AddIOp::create(b, t[n + 1], hi);
 
-    // Reduction row: m = t[0] * n′₃₂, then t += m * n and shift down one limb.
-    Value m = arith::MulIOp::create(b, t[0], np32);
-    // mulAddStep on (m, n[0], t[0], 0): lo is 0 by construction, discard it.
-    std::tie(std::ignore, c) = mulAddStep(m, nConst[0], t[0], i32Const(0));
-    for (unsigned j = 1; j < n; ++j)
-      std::tie(t[j - 1], c) = mulAddStep(m, nConst[j], t[j], c);
-    std::tie(t[n - 1], c) = addCarryStep(t[n], c);
+    // Reduction row: t += m * n, shift down one limb.
+    c = reduceRow(t, nConst, np32, n);
     t[n] = arith::AddIOp::create(b, t[n + 1], c);
     t[n + 1] = i32Const(0);
+  }
+
+  // Spare-bit modulus: result is in t[0..N) with t[N) == 0 (range < 2p < 2ʷ).
+  t.truncate(n);
+  Value result = recompose(t, wideTy);
+
+  if (lazy)
+    return result;
+  return MontReducer(b, modArithType)
+      .getCanonicalFromExtended(result, /*bound=*/2);
+}
+
+Value CiosMontEmitter::emitRedc(Value tLow, Value tHigh, bool lazy) {
+  auto wideTy = cast<IntegerType>(tLow.getType());
+  unsigned w = wideTy.getWidth();
+  unsigned n = (w + kLimbBits - 1) / kLimbBits;
+
+  // T = tLow + tHigh·2ʷ as 2N i32 limbs: low N from tLow, high N from tHigh.
+  SmallVector<Value> tl = decompose(tLow);
+  SmallVector<Value> th = decompose(tHigh);
+  tl.append(th.begin(), th.end());
+
+  // Compile-time constants: modulus limbs n[0..N) and n′₃₂ = low 32 bits of n′.
+  APInt mod = modAttr.getValue();
+  SmallVector<Value> nConst;
+  nConst.reserve(n);
+  for (unsigned j = 0; j < n; ++j)
+    nConst.push_back(
+        i32Const(mod.extractBits(kLimbBits, j * kLimbBits).getZExtValue()));
+  Value np32 = i32Const(
+      montAttr.getNPrime().getValue().extractBits(kLimbBits, 0).getZExtValue());
+
+  // Fixed window t[0..N+1] over the 2N-limb T, mirroring emitMontMul's
+  // reduction accumulator: t[N] holds the limb consumed this row (a full T
+  // limb plus a tiny carry), t[N+1] holds the residual carry (always ≤ 2).
+  // The low N+1 limbs are pre-loaded; the higher limbs feed in one per row.
+  SmallVector<Value> t(n + 2, i32Const(0));
+  for (unsigned j = 0; j <= n; ++j)
+    t[j] = tl[j];
+  unsigned feedIdx = n + 1;
+
+  for (unsigned i = 0; i < n; ++i) {
+    // Reduction row consumes t[N] and returns the carry exiting column N.
+    Value c = reduceRow(t, nConst, np32, n);
+    // Slide the window up by one: t[N] ← next T limb + carry c + residual
+    // t[N+1]; the carry-outs are ≤ 1 each, so t[N+1] stays ≤ 2.
+    Value feed = feedIdx < 2 * n ? tl[feedIdx] : i32Const(0);
+    ++feedIdx;
+    auto [lo, hi] = addCarryStep(feed, c);
+    auto [lo2, hi2] = addCarryStep(lo, t[n + 1]);
+    t[n] = lo2;
+    t[n + 1] = arith::AddIOp::create(b, hi, hi2);
   }
 
   // Spare-bit modulus: result is in t[0..N) with t[N) == 0 (range < 2p < 2ʷ).

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/CiosMontEmitter.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/CiosMontEmitter.cpp
@@ -1,0 +1,180 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/CiosMontEmitter.h"
+
+#include <tuple>
+
+#include "llvm/ADT/APInt.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/MontReducer.h"
+#include "prime_ir/Dialect/ModArith/IR/ModArithTypes.h" // IWYU pragma: keep
+
+namespace mlir::prime_ir::mod_arith {
+
+// Limb width for the CIOS schedule. Fixed at 32 bits so that each
+// multiply-accumulate is a (i32 x i32 -> i64) widening — the IMAD.WIDE shape.
+static constexpr unsigned kLimbBits = 32;
+
+CiosMontEmitter::CiosMontEmitter(ImplicitLocOpBuilder &b,
+                                 ModArithType modArithType)
+    : b(b), modArithType(modArithType), modAttr(modArithType.getModulus()),
+      montAttr(modArithType.getMontgomeryAttr()) {}
+
+// static
+bool CiosMontEmitter::isEligible(ModArithType modArithType,
+                                 Type convertedType) {
+  // Scalar integer storage only: the IMAD.WIDE rationale and the 32-bit limb
+  // schedule are register-resident scalar codegen.
+  auto intTy = dyn_cast<IntegerType>(convertedType);
+  if (!intTy)
+    return false;
+  if (modArithType.getMontgomeryAttr().getNumLimbs() <= 1)
+    return false;
+  // Width must be a whole number of 64-bit words: the CIOS row count
+  // 32*ceil(w/32) must equal the type's Montgomery radix exponent
+  // 64*numLimbs (w=96 would divide by 2^96, not R=2^128), and the
+  // 32-bit modulus-limb extraction must stay in bounds.
+  if (intTy.getWidth() % 64 != 0)
+    return false;
+  // Spare-bit moduli only: with the sign bit set, 2p > 2ʷ and the cheap
+  // skip-the-final-overflow-column invariant (t[N] == 0) no longer holds.
+  return !modArithType.getModulus().getValue().isSignBitSet();
+}
+
+Value CiosMontEmitter::i32Const(uint64_t v) {
+  return arith::ConstantOp::create(
+      b, b.getIntegerAttr(b.getIntegerType(kLimbBits), v));
+}
+
+SmallVector<Value> CiosMontEmitter::decompose(Value wide) {
+  auto wideTy = cast<IntegerType>(wide.getType());
+  unsigned w = wideTy.getWidth();
+  unsigned n = (w + kLimbBits - 1) / kLimbBits;
+  Type i32 = b.getIntegerType(kLimbBits);
+  SmallVector<Value> limbs;
+  limbs.reserve(n);
+  for (unsigned j = 0; j < n; ++j) {
+    Value chunk = wide;
+    if (j != 0) {
+      auto shift =
+          arith::ConstantOp::create(b, b.getIntegerAttr(wideTy, j * kLimbBits));
+      chunk = arith::ShRUIOp::create(b, wide, shift);
+    }
+    limbs.push_back(arith::TruncIOp::create(b, i32, chunk));
+  }
+  return limbs;
+}
+
+Value CiosMontEmitter::recompose(ArrayRef<Value> limbs, Type wideTy) {
+  auto wTy = cast<IntegerType>(wideTy);
+  Value acc;
+  for (unsigned j = 0; j < limbs.size(); ++j) {
+    Value ext = arith::ExtUIOp::create(b, wTy, limbs[j]);
+    if (j != 0) {
+      auto shift =
+          arith::ConstantOp::create(b, b.getIntegerAttr(wTy, j * kLimbBits));
+      ext = arith::ShLIOp::create(b, ext, shift);
+    }
+    acc = acc ? arith::OrIOp::create(b, acc, ext).getResult() : ext;
+  }
+  return acc;
+}
+
+std::pair<Value, Value> CiosMontEmitter::mulAddStep(Value a32, Value b32,
+                                                    Value t32, Value c32) {
+  Type i64 = b.getIntegerType(2 * kLimbBits);
+  Value aw = arith::ExtUIOp::create(b, i64, a32);
+  Value bw = arith::ExtUIOp::create(b, i64, b32);
+  Value p = arith::MulIOp::create(b, aw, bw);
+  Value tw = arith::ExtUIOp::create(b, i64, t32);
+  Value cw = arith::ExtUIOp::create(b, i64, c32);
+  // s = a*b + t + c <= (2³²-1)² + 2(2³²-1) < 2⁶⁴, so no overflow.
+  Value s = arith::AddIOp::create(b, arith::AddIOp::create(b, p, tw), cw);
+  Value lo = arith::TruncIOp::create(b, b.getIntegerType(kLimbBits), s);
+  auto shift = arith::ConstantOp::create(b, b.getIntegerAttr(i64, kLimbBits));
+  Value hi = arith::TruncIOp::create(b, b.getIntegerType(kLimbBits),
+                                     arith::ShRUIOp::create(b, s, shift));
+  return {lo, hi};
+}
+
+std::pair<Value, Value> CiosMontEmitter::addCarryStep(Value t32, Value c32) {
+  Type i64 = b.getIntegerType(2 * kLimbBits);
+  Value tw = arith::ExtUIOp::create(b, i64, t32);
+  Value cw = arith::ExtUIOp::create(b, i64, c32);
+  Value s = arith::AddIOp::create(b, tw, cw);
+  Value lo = arith::TruncIOp::create(b, b.getIntegerType(kLimbBits), s);
+  auto shift = arith::ConstantOp::create(b, b.getIntegerAttr(i64, kLimbBits));
+  Value hi = arith::TruncIOp::create(b, b.getIntegerType(kLimbBits),
+                                     arith::ShRUIOp::create(b, s, shift));
+  return {lo, hi};
+}
+
+Value CiosMontEmitter::emitMontMul(Value lhs, Value rhs, bool lazy) {
+  auto wideTy = cast<IntegerType>(lhs.getType());
+  unsigned w = wideTy.getWidth();
+  unsigned n = (w + kLimbBits - 1) / kLimbBits;
+
+  SmallVector<Value> a = decompose(lhs);
+  SmallVector<Value> bLimbs = decompose(rhs);
+
+  // Compile-time constants: modulus limbs n[0..N) and n′₃₂ = low 32 bits of
+  // n′ (x ≡ −n⁻¹ mod 2⁶⁴ ⇒ x ≡ −n⁻¹ mod 2³²).
+  APInt mod = modAttr.getValue();
+  SmallVector<Value> nConst;
+  nConst.reserve(n);
+  for (unsigned j = 0; j < n; ++j)
+    nConst.push_back(
+        i32Const(mod.extractBits(kLimbBits, j * kLimbBits).getZExtValue()));
+  Value np32 = i32Const(
+      montAttr.getNPrime().getValue().extractBits(kLimbBits, 0).getZExtValue());
+
+  // t[0..N+2): accumulator with two overflow columns t[N], t[N+1].
+  SmallVector<Value> t(n + 2, i32Const(0));
+
+  for (unsigned i = 0; i < n; ++i) {
+    // Multiply-accumulate row: t += a[i] * b.
+    Value c = i32Const(0);
+    for (unsigned j = 0; j < n; ++j)
+      std::tie(t[j], c) = mulAddStep(a[i], bLimbs[j], t[j], c);
+    auto [lo, hi] = addCarryStep(t[n], c);
+    t[n] = lo;
+    // hi add cannot overflow t[N+1]'s column, so a plain i32 add suffices.
+    t[n + 1] = arith::AddIOp::create(b, t[n + 1], hi);
+
+    // Reduction row: m = t[0] * n′₃₂, then t += m * n and shift down one limb.
+    Value m = arith::MulIOp::create(b, t[0], np32);
+    // mulAddStep on (m, n[0], t[0], 0): lo is 0 by construction, discard it.
+    std::tie(std::ignore, c) = mulAddStep(m, nConst[0], t[0], i32Const(0));
+    for (unsigned j = 1; j < n; ++j)
+      std::tie(t[j - 1], c) = mulAddStep(m, nConst[j], t[j], c);
+    std::tie(t[n - 1], c) = addCarryStep(t[n], c);
+    t[n] = arith::AddIOp::create(b, t[n + 1], c);
+    t[n + 1] = i32Const(0);
+  }
+
+  // Spare-bit modulus: result is in t[0..N) with t[N) == 0 (range < 2p < 2ʷ).
+  t.truncate(n);
+  Value result = recompose(t, wideTy);
+
+  if (lazy)
+    return result;
+  return MontReducer(b, modArithType)
+      .getCanonicalFromExtended(result, /*bound=*/2);
+}
+
+} // namespace mlir::prime_ir::mod_arith

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/CiosMontEmitter.cpp
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/CiosMontEmitter.cpp
@@ -26,9 +26,11 @@ limitations under the License.
 
 namespace mlir::prime_ir::mod_arith {
 
+namespace {
 // Limb width for the CIOS schedule. Fixed at 32 bits so that each
 // multiply-accumulate is a (i32 x i32 -> i64) widening — the IMAD.WIDE shape.
-static constexpr unsigned kLimbBits = 32;
+constexpr unsigned kLimbBits = 32;
+} // namespace
 
 CiosMontEmitter::CiosMontEmitter(ImplicitLocOpBuilder &b,
                                  ModArithType modArithType)
@@ -139,6 +141,18 @@ Value CiosMontEmitter::reduceRow(MutableArrayRef<Value> t,
   return c;
 }
 
+void CiosMontEmitter::buildModConsts(unsigned n, SmallVector<Value> &nConst,
+                                     Value &np32) {
+  // n′₃₂ = low 32 bits of n′ (x ≡ −n⁻¹ mod 2⁶⁴ ⇒ x ≡ −n⁻¹ mod 2³²).
+  APInt mod = modAttr.getValue();
+  nConst.reserve(n);
+  for (unsigned j = 0; j < n; ++j)
+    nConst.push_back(
+        i32Const(mod.extractBits(kLimbBits, j * kLimbBits).getZExtValue()));
+  np32 = i32Const(
+      montAttr.getNPrime().getValue().extractBits(kLimbBits, 0).getZExtValue());
+}
+
 Value CiosMontEmitter::emitMontMul(Value lhs, Value rhs, bool lazy) {
   auto wideTy = cast<IntegerType>(lhs.getType());
   unsigned w = wideTy.getWidth();
@@ -147,16 +161,9 @@ Value CiosMontEmitter::emitMontMul(Value lhs, Value rhs, bool lazy) {
   SmallVector<Value> a = decompose(lhs);
   SmallVector<Value> bLimbs = decompose(rhs);
 
-  // Compile-time constants: modulus limbs n[0..N) and n′₃₂ = low 32 bits of
-  // n′ (x ≡ −n⁻¹ mod 2⁶⁴ ⇒ x ≡ −n⁻¹ mod 2³²).
-  APInt mod = modAttr.getValue();
   SmallVector<Value> nConst;
-  nConst.reserve(n);
-  for (unsigned j = 0; j < n; ++j)
-    nConst.push_back(
-        i32Const(mod.extractBits(kLimbBits, j * kLimbBits).getZExtValue()));
-  Value np32 = i32Const(
-      montAttr.getNPrime().getValue().extractBits(kLimbBits, 0).getZExtValue());
+  Value np32;
+  buildModConsts(n, nConst, np32);
 
   // t[0..N+2): accumulator with two overflow columns t[N], t[N+1].
   SmallVector<Value> t(n + 2, i32Const(0));
@@ -197,15 +204,9 @@ Value CiosMontEmitter::emitRedc(Value tLow, Value tHigh, bool lazy) {
   SmallVector<Value> th = decompose(tHigh);
   tl.append(th.begin(), th.end());
 
-  // Compile-time constants: modulus limbs n[0..N) and n′₃₂ = low 32 bits of n′.
-  APInt mod = modAttr.getValue();
   SmallVector<Value> nConst;
-  nConst.reserve(n);
-  for (unsigned j = 0; j < n; ++j)
-    nConst.push_back(
-        i32Const(mod.extractBits(kLimbBits, j * kLimbBits).getZExtValue()));
-  Value np32 = i32Const(
-      montAttr.getNPrime().getValue().extractBits(kLimbBits, 0).getZExtValue());
+  Value np32;
+  buildModConsts(n, nConst, np32);
 
   // Fixed window t[0..N+1] over the 2N-limb T, mirroring emitMontMul's
   // reduction accumulator: t[N] holds the limb consumed this row (a full T

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/CiosMontEmitter.h
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/CiosMontEmitter.h
@@ -50,6 +50,11 @@ public:
   // a * b * R⁻¹ mod n. lazy=true returns [0, 2p), else [0, p).
   Value emitMontMul(Value a, Value b, bool lazy);
 
+  // REDC of T = tLow + tHigh·2ʷ (each w = storage bits) to T·R⁻¹ mod n, in
+  // 32-bit limbs. Shares the reduction row with emitMontMul. lazy=true returns
+  // [0, 2p), else [0, p).
+  Value emitRedc(Value tLow, Value tHigh, bool lazy);
+
 private:
   SmallVector<Value> decompose(Value wide);            // iW -> N x i32
   Value recompose(ArrayRef<Value> limbs, Type wideTy); // N x i32 -> iW
@@ -58,6 +63,14 @@ private:
                                      Value c32);
   // s = (i64)t + (i64)c. Returns {lo32(s), hi32(s)} for the overflow columns.
   std::pair<Value, Value> addCarryStep(Value t32, Value c32);
+
+  // One CIOS reduction row over the window t[0..N]: m = t[0]·n′₃₂ (low half),
+  // then t[0..N] += m·n[0..N) with the bottom limb zeroed and the window
+  // shifted down one limb, so the reduced limbs land in t[0..N-1]. Consumes
+  // t[N] via an i64-safe add. Returns the carry exiting column N for the caller
+  // to fold into its overflow columns. Shared by emitMontMul and emitRedc.
+  Value reduceRow(MutableArrayRef<Value> t, ArrayRef<Value> nConst, Value np32,
+                  unsigned n);
 
   Value i32Const(uint64_t v);
 

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/CiosMontEmitter.h
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/CiosMontEmitter.h
@@ -1,0 +1,73 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef PRIME_IR_DIALECT_MODARITH_CONVERSIONS_MODARITHTOARITH_REDUCER_CIOSMONTEMITTER_H_
+#define PRIME_IR_DIALECT_MODARITH_CONVERSIONS_MODARITHTOARITH_REDUCER_CIOSMONTEMITTER_H_
+
+#include <utility>
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Value.h"
+#include "prime_ir/Dialect/ModArith/IR/ModArithTypes.h" // IWYU pragma: keep
+
+namespace mlir {
+class IntegerAttr;
+} // namespace mlir
+
+namespace mlir::prime_ir::mod_arith {
+
+// Emits 32-bit-limb fused-CIOS Montgomery arithmetic for multi-limb moduli
+// with at least one spare storage bit. Uses the same R = 2^storageBits as
+// MontReducer's wide path, so results are interchangeable.
+//
+// Each limb multiply-accumulate is lowered to the LLVM IR shape
+// `add i64 (mul i64 (zext i32 a), (zext i32 b)), %acc`, which selects a single
+// IMAD.WIDE.U32 on NVIDIA targets (no native 64-bit IMAD, so the wide-path
+// `arith.mului_extended` would scalarize). See CIOS in Koç, Acar, Kaliski,
+// "Analyzing and Comparing Montgomery Multiplication Algorithms", IEEE Micro
+// 1996 (https://eprint.iacr.org/2017/1057 reproduces the algorithm).
+class CiosMontEmitter {
+public:
+  explicit CiosMontEmitter(ImplicitLocOpBuilder &b, ModArithType modArithType);
+
+  // True when the CIOS path applies: multi-limb, scalar integer storage,
+  // modulus sign bit clear. The `target == "gpu"` gate is the caller's.
+  static bool isEligible(ModArithType modArithType, Type convertedType);
+
+  // a * b * R⁻¹ mod n. lazy=true returns [0, 2p), else [0, p).
+  Value emitMontMul(Value a, Value b, bool lazy);
+
+private:
+  SmallVector<Value> decompose(Value wide);            // iW -> N x i32
+  Value recompose(ArrayRef<Value> limbs, Type wideTy); // N x i32 -> iW
+  // s = (i64)a*b + t + c. Returns {lo32(s), hi32(s)}. THE IMAD.WIDE shape.
+  std::pair<Value, Value> mulAddStep(Value a32, Value b32, Value t32,
+                                     Value c32);
+  // s = (i64)t + (i64)c. Returns {lo32(s), hi32(s)} for the overflow columns.
+  std::pair<Value, Value> addCarryStep(Value t32, Value c32);
+
+  Value i32Const(uint64_t v);
+
+  ImplicitLocOpBuilder &b;
+  ModArithType modArithType;
+  IntegerAttr modAttr;
+  MontgomeryAttr montAttr;
+};
+
+} // namespace mlir::prime_ir::mod_arith
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#endif // PRIME_IR_DIALECT_MODARITH_CONVERSIONS_MODARITHTOARITH_REDUCER_CIOSMONTEMITTER_H_

--- a/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/CiosMontEmitter.h
+++ b/prime_ir/Dialect/ModArith/Conversions/ModArithToArith/Reducer/CiosMontEmitter.h
@@ -72,6 +72,10 @@ private:
   Value reduceRow(MutableArrayRef<Value> t, ArrayRef<Value> nConst, Value np32,
                   unsigned n);
 
+  // Compile-time reduction constants: modulus limbs n[0..N) and n′₃₂ = low 32
+  // bits of n′. Shared setup for emitMontMul and emitRedc.
+  void buildModConsts(unsigned n, SmallVector<Value> &nConst, Value &np32);
+
   Value i32Const(uint64_t v);
 
   ImplicitLocOpBuilder &b;

--- a/prime_ir/Dialect/ModArith/IR/ModArithAttributes.cpp
+++ b/prime_ir/Dialect/ModArith/IR/ModArithAttributes.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "prime_ir/Dialect/ModArith/IR/ModArithAttributes.h"
 
+#include <algorithm>
 #include <utility>
 
 #include "llvm/ADT/STLExtras.h"
@@ -71,9 +72,11 @@ MontgomeryAttrStorage::construct(AttributeStorageAllocator &allocator,
   // `b` = 2^`w`
   APInt b = APInt::getOneBitSet(w + 1, w);
 
-  // `bReduced` = `b` (mod `modulus`)
-  APInt modExt = modulus.zextOrTrunc(b.getBitWidth());
-  APInt bReduced = b.urem(modExt);
+  // `bReduced` = `b` (mod `modulus`). Truncating the modulus first
+  // (b.getBitWidth() == w+1 < modulus width for multi-word moduli) gave a
+  // wrong bReduced for bit-64==0 fields like BLS12-377 (issue #344).
+  unsigned cw = std::max(b.getBitWidth(), modulus.getBitWidth());
+  APInt bReduced = b.zext(cw).urem(modulus.zext(cw));
   bReduced = bReduced.zextOrTrunc(modulus.getBitWidth());
   ModArithType modType = ModArithType::get(modAttr.getContext(), modAttr);
   ModArithOperation bReducedOp(bReduced, modType);

--- a/tests/Dialect/Field/ext_field_bls377_gpu_cios.mlir
+++ b/tests/Dialect/Field/ext_field_bls377_gpu_cios.mlir
@@ -15,12 +15,12 @@
 
 // Verify that field.mul over a degree-2 extension of the BLS12-377 base field
 // (in Montgomery form) decomposes into base-field mont_muls that ride the
-// 32-bit-limb CIOS path under target=gpu.
+// 32-bit-limb CIOS path under limb-bits=32.
 //
 // BLS12-377 Fp2 = Fp[u] / (u^2 + 5).  The irreducible polynomial coefficient
 // stored in the ef type is beta = -5 mod p = p - 5.
 
-// RUN: prime-ir-opt -field-to-mod-arith '-mod-arith-to-arith=target=gpu' %s | FileCheck %s
+// RUN: prime-ir-opt -field-to-mod-arith -mod-arith-to-arith=limb-bits=32 %s | FileCheck %s
 
 !BLS377m = !field.pf<258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 : i384, true>
 // beta = p - 5

--- a/tests/Dialect/Field/ext_field_bls377_gpu_cios.mlir
+++ b/tests/Dialect/Field/ext_field_bls377_gpu_cios.mlir
@@ -1,0 +1,38 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// Verify that field.mul over a degree-2 extension of the BLS12-377 base field
+// (in Montgomery form) decomposes into base-field mont_muls that ride the
+// 32-bit-limb CIOS path under target=gpu.
+//
+// BLS12-377 Fp2 = Fp[u] / (u^2 + 5).  The irreducible polynomial coefficient
+// stored in the ef type is beta = -5 mod p = p - 5.
+
+// RUN: prime-ir-opt -field-to-mod-arith '-mod-arith-to-arith=target=gpu' %s | FileCheck %s
+
+!BLS377m = !field.pf<258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 : i384, true>
+// beta = p - 5
+!BLS377Fp2m = !field.ef<2x!BLS377m, 258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458172 : i384>
+
+// CHECK-LABEL: @fp2_bls377_mul_gpu_cios
+// field.mul decomposes into base mont_muls via Karatsuba; each must take the
+// CIOS path (i64 limb products) and must not fall back to the wide-int path.
+// CHECK: arith.muli {{.*}} : i64
+// CHECK-NOT: arith.mului_extended {{.*}} : i384
+// CHECK: return
+func.func @fp2_bls377_mul_gpu_cios(%a : !BLS377Fp2m, %b : !BLS377Fp2m) -> !BLS377Fp2m {
+  %r = field.mul %a, %b : !BLS377Fp2m
+  return %r : !BLS377Fp2m
+}

--- a/tests/Dialect/ModArith/mod_arith_gpu_cios_runner.mlir
+++ b/tests/Dialect/ModArith/mod_arith_gpu_cios_runner.mlir
@@ -1,0 +1,208 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// Executable correctness cross-check for the BLS12-377 base field (384-bit,
+// width%64==0, bit-64==0 — the class whose Montgomery bInv constant was wrong,
+// issue #344). mont_mul operands are loaded from a memref so the op does NOT
+// constant-fold via zk_dtypes before lowering; the CIOS/wide-int arith is
+// actually emitted and executed. The same CHECK pins both the default
+// (wide-int REDC) and the target=gpu (32-bit-limb CIOS) lowerings, so a green
+// run simultaneously proves the bInv fix (default path correct), proves the
+// CIOS lowering, and cross-checks the two against each other.
+//
+// Expected values computed in Python (R = 2^384):
+//
+//   p = 258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177
+//   Rinv = pow(R, -1, p)
+//   to_mont(x)   = x * R % p
+//   from_mont(x) = x * Rinv % p
+//   mont_mul(x,y) = x * y * Rinv % p
+//   a = 999999999999999999999999999;  b = 888888888888888888888888888
+//   Am = to_mont(a);  Bm = to_mont(b)
+//   # mont_mul(Am, Bm) == a*b*R % p; from_mont(mont_mul(Am,Bm)) == a*b % p
+//   def limbs(x): return [((x>>(32*i))&0xffffffff)-(2**32 if ((x>>(32*i))&0xffffffff)>=2**31 else 0) for i in range(12)]
+//   Am limbs: [-993027604, -388498365, -1470266380, 258085974, 1271394216, -1006981957, -1774979521, 1779210631, 1700853052, 920988029, -85444264, 1398356]
+//   Bm limbs: [-405472615, 857098982, -262987786, -1159288151, 1476924906, 1071475599, -621537805, 198586088, -1626159698, 1188184566, -31640358, 4375805]
+//   a  limbs: [-402653185, -1613725636, 54210108, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+//   b  limbs: [2028179000, 951670155, 48186763, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+//   mont_mul(Am,Bm) limbs: [-2085231504, -944653634, 788851044, 435972004, -2052965250, 763951016, 195537406, 351631468, -670383268, 1389461931, -1947203231, 21569816]
+//   a*b % p     limbs: [1193046472, -1631176585, -403608459, 1030493760, 1969132180, 608202, 0, 0, 0, 0, 0, 0]
+
+// RUN: prime-ir-opt %s -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_bls377_mont_mul -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_MONT_MUL < %t
+
+// RUN: prime-ir-opt %s -mod-arith-to-arith=target=gpu -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_bls377_mont_mul -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_MONT_MUL < %t
+
+// RUN: prime-ir-opt %s -mod-arith-to-arith -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_bls377_roundtrip -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_ROUNDTRIP < %t
+
+// RUN: prime-ir-opt %s -mod-arith-to-arith=target=gpu -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN:   | mlir-runner -e test_bls377_roundtrip -entry-point-result=void \
+// RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
+// RUN: FileCheck %s -check-prefix=CHECK_ROUNDTRIP < %t
+
+func.func private @printMemrefI32(memref<*xi32>) attributes { llvm.emit_c_interface }
+
+// BLS12-377 base field (spare bit set: p < 2^383, so 2p < 2^384).
+!BLS377m = !mod_arith.int<258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 : i384, true>
+!BLS377 = !mod_arith.int<258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 : i384>
+
+// Store 12 i32 limbs and read them back as an opaque i384. Routing the value
+// through memref load/store keeps it non-constant at fold time, so mont_mul
+// (and to_mont/from_mont) lower to real arith instead of folding.
+func.func private @load_i384(%limbs : memref<12xi32>) -> i384 {
+  %c0 = arith.constant 0 : index
+  %vec = vector.load %limbs[%c0] : memref<12xi32>, vector<12xi32>
+  %wide = vector.bitcast %vec : vector<12xi32> to vector<1xi384>
+  %v = vector.extract %wide[0] : i384 from vector<1xi384>
+  return %v : i384
+}
+
+func.func private @print_i384(%v : i384) {
+  %c0 = arith.constant 0 : index
+  %vec = vector.from_elements %v : vector<1xi384>
+  %i32vec = vector.bitcast %vec : vector<1xi384> to vector<12xi32>
+  %mem = memref.alloc() : memref<12xi32>
+  vector.store %i32vec, %mem[%c0] : memref<12xi32>, vector<12xi32>
+  %U = memref.cast %mem : memref<12xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+  memref.dealloc %mem : memref<12xi32>
+  return
+}
+
+func.func private @store_limbs(%m : memref<12xi32>, %v0 : i32, %v1 : i32,
+    %v2 : i32, %v3 : i32, %v4 : i32, %v5 : i32, %v6 : i32, %v7 : i32,
+    %v8 : i32, %v9 : i32, %v10 : i32, %v11 : i32) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c5 = arith.constant 5 : index
+  %c6 = arith.constant 6 : index
+  %c7 = arith.constant 7 : index
+  %c8 = arith.constant 8 : index
+  %c9 = arith.constant 9 : index
+  %c10 = arith.constant 10 : index
+  %c11 = arith.constant 11 : index
+  memref.store %v0, %m[%c0] : memref<12xi32>
+  memref.store %v1, %m[%c1] : memref<12xi32>
+  memref.store %v2, %m[%c2] : memref<12xi32>
+  memref.store %v3, %m[%c3] : memref<12xi32>
+  memref.store %v4, %m[%c4] : memref<12xi32>
+  memref.store %v5, %m[%c5] : memref<12xi32>
+  memref.store %v6, %m[%c6] : memref<12xi32>
+  memref.store %v7, %m[%c7] : memref<12xi32>
+  memref.store %v8, %m[%c8] : memref<12xi32>
+  memref.store %v9, %m[%c9] : memref<12xi32>
+  memref.store %v10, %m[%c10] : memref<12xi32>
+  memref.store %v11, %m[%c11] : memref<12xi32>
+  return
+}
+
+// mont_mul(Am, Bm) with Am, Bm already in Montgomery form, fed as opaque i384
+// (bitcast i384 -> !BLS377m reinterprets bits, matching what mod_arith.constant
+// stores). Result = a*b*R % p in Montgomery form.
+func.func @test_bls377_mont_mul() {
+  %am_mem = memref.alloc() : memref<12xi32>
+  %bm_mem = memref.alloc() : memref<12xi32>
+  %am0 = arith.constant -993027604 : i32
+  %am1 = arith.constant -388498365 : i32
+  %am2 = arith.constant -1470266380 : i32
+  %am3 = arith.constant 258085974 : i32
+  %am4 = arith.constant 1271394216 : i32
+  %am5 = arith.constant -1006981957 : i32
+  %am6 = arith.constant -1774979521 : i32
+  %am7 = arith.constant 1779210631 : i32
+  %am8 = arith.constant 1700853052 : i32
+  %am9 = arith.constant 920988029 : i32
+  %am10 = arith.constant -85444264 : i32
+  %am11 = arith.constant 1398356 : i32
+  func.call @store_limbs(%am_mem, %am0, %am1, %am2, %am3, %am4, %am5, %am6,
+    %am7, %am8, %am9, %am10, %am11)
+    : (memref<12xi32>, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
+  %bm0 = arith.constant -405472615 : i32
+  %bm1 = arith.constant 857098982 : i32
+  %bm2 = arith.constant -262987786 : i32
+  %bm3 = arith.constant -1159288151 : i32
+  %bm4 = arith.constant 1476924906 : i32
+  %bm5 = arith.constant 1071475599 : i32
+  %bm6 = arith.constant -621537805 : i32
+  %bm7 = arith.constant 198586088 : i32
+  %bm8 = arith.constant -1626159698 : i32
+  %bm9 = arith.constant 1188184566 : i32
+  %bm10 = arith.constant -31640358 : i32
+  %bm11 = arith.constant 4375805 : i32
+  func.call @store_limbs(%bm_mem, %bm0, %bm1, %bm2, %bm3, %bm4, %bm5, %bm6,
+    %bm7, %bm8, %bm9, %bm10, %bm11)
+    : (memref<12xi32>, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
+
+  %ai = func.call @load_i384(%am_mem) : (memref<12xi32>) -> i384
+  %bi = func.call @load_i384(%bm_mem) : (memref<12xi32>) -> i384
+  %am = mod_arith.bitcast %ai : i384 -> !BLS377m
+  %bm = mod_arith.bitcast %bi : i384 -> !BLS377m
+  %r = mod_arith.mont_mul %am, %bm : !BLS377m
+  %v = mod_arith.bitcast %r : !BLS377m -> i384
+  func.call @print_i384(%v) : (i384) -> ()
+  memref.dealloc %am_mem : memref<12xi32>
+  memref.dealloc %bm_mem : memref<12xi32>
+  return
+}
+
+// CHECK_MONT_MUL: data =
+// CHECK_MONT_MUL-NEXT: [-2085231504, -944653634, 788851044, 435972004, -2052965250, 763951016, 195537406, 351631468, -670383268, 1389461931, -1947203231, 21569816]
+
+// from_mont(mont_mul(to_mont(a), to_mont(b))) with a, b plain residues fed as
+// opaque i384. Exercises the full to_mont -> mont_mul -> from_mont chain on the
+// runtime path; result = a*b % p in canonical (non-Montgomery) form.
+func.func @test_bls377_roundtrip() {
+  %a_mem = memref.alloc() : memref<12xi32>
+  %b_mem = memref.alloc() : memref<12xi32>
+  %z = arith.constant 0 : i32
+  %a0 = arith.constant -402653185 : i32
+  %a1 = arith.constant -1613725636 : i32
+  %a2 = arith.constant 54210108 : i32
+  func.call @store_limbs(%a_mem, %a0, %a1, %a2, %z, %z, %z, %z, %z, %z, %z, %z, %z)
+    : (memref<12xi32>, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
+  %b0 = arith.constant 2028179000 : i32
+  %b1 = arith.constant 951670155 : i32
+  %b2 = arith.constant 48186763 : i32
+  func.call @store_limbs(%b_mem, %b0, %b1, %b2, %z, %z, %z, %z, %z, %z, %z, %z, %z)
+    : (memref<12xi32>, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
+
+  %ai = func.call @load_i384(%a_mem) : (memref<12xi32>) -> i384
+  %bi = func.call @load_i384(%b_mem) : (memref<12xi32>) -> i384
+  %a = mod_arith.bitcast %ai : i384 -> !BLS377
+  %b = mod_arith.bitcast %bi : i384 -> !BLS377
+  %a_mont = mod_arith.to_mont %a : !BLS377m
+  %b_mont = mod_arith.to_mont %b : !BLS377m
+  %r_mont = mod_arith.mont_mul %a_mont, %b_mont : !BLS377m
+  %r = mod_arith.from_mont %r_mont : !BLS377
+  %v = mod_arith.bitcast %r : !BLS377 -> i384
+  func.call @print_i384(%v) : (i384) -> ()
+  memref.dealloc %a_mem : memref<12xi32>
+  memref.dealloc %b_mem : memref<12xi32>
+  return
+}
+
+// CHECK_ROUNDTRIP: data =
+// CHECK_ROUNDTRIP-NEXT: [1193046472, -1631176585, -403608459, 1030493760, 1969132180, 608202, 0, 0, 0, 0, 0, 0]

--- a/tests/Dialect/ModArith/mod_arith_gpu_cios_runner.mlir
+++ b/tests/Dialect/ModArith/mod_arith_gpu_cios_runner.mlir
@@ -18,7 +18,7 @@
 // issue #344). mont_mul operands are loaded from a memref so the op does NOT
 // constant-fold via zk_dtypes before lowering; the CIOS/wide-int arith is
 // actually emitted and executed. The same CHECK pins both the default
-// (wide-int REDC) and the target=gpu (32-bit-limb CIOS) lowerings, so a green
+// (wide-int REDC) and the limb-bits=32 (32-bit-limb CIOS) lowerings, so a green
 // run simultaneously proves the bInv fix (default path correct), proves the
 // CIOS lowering, and cross-checks the two against each other.
 //
@@ -45,7 +45,7 @@
 // RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
 // RUN: FileCheck %s -check-prefix=CHECK_MONT_MUL < %t
 
-// RUN: prime-ir-opt %s -mod-arith-to-arith=target=gpu -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN: prime-ir-opt %s -mod-arith-to-arith=limb-bits=32 -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
 // RUN:   | mlir-runner -e test_bls377_mont_mul -entry-point-result=void \
 // RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
 // RUN: FileCheck %s -check-prefix=CHECK_MONT_MUL < %t
@@ -55,7 +55,7 @@
 // RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
 // RUN: FileCheck %s -check-prefix=CHECK_ROUNDTRIP < %t
 
-// RUN: prime-ir-opt %s -mod-arith-to-arith=target=gpu -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
+// RUN: prime-ir-opt %s -mod-arith-to-arith=limb-bits=32 -convert-elementwise-to-linalg -one-shot-bufferize -convert-linalg-to-parallel-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-to-llvm -convert-vector-to-llvm \
 // RUN:   | mlir-runner -e test_bls377_roundtrip -entry-point-result=void \
 // RUN:      -shared-libs="%mlir_lib_dir/libmlir_runner_utils%shlibext" > %t
 // RUN: FileCheck %s -check-prefix=CHECK_ROUNDTRIP < %t

--- a/tests/Dialect/ModArith/mod_arith_to_arith_gpu.mlir
+++ b/tests/Dialect/ModArith/mod_arith_to_arith_gpu.mlir
@@ -13,9 +13,12 @@
 // limitations under the License.
 // ==============================================================================
 
-// RUN: prime-ir-opt -mod-arith-to-arith=target=gpu -split-input-file %s | FileCheck %s -enable-var-scope --check-prefix=GPU
-// The default (no target) RUN proves the flag actually gates: the same
-// spare-bit BLS377 case keeps the wide-int path.
+// The experimental 32-bit-limb CIOS path is opt-in (limb-bits=32):
+// RUN: prime-ir-opt -mod-arith-to-arith=limb-bits=32 -split-input-file %s | FileCheck %s -enable-var-scope --check-prefix=GPU
+// limb-bits=64 keeps the wide-int path (no regression — the 64-bit-limb
+// schoolbook is the fastest montmul on a strong-64-bit-multiply target, #337 PR3):
+// RUN: prime-ir-opt -mod-arith-to-arith=limb-bits=64 -split-input-file %s | FileCheck %s -enable-var-scope --check-prefix=CPU
+// The default (no limb-bits) RUN keeps the wide-int path:
 // RUN: prime-ir-opt -mod-arith-to-arith -split-input-file %s | FileCheck %s -enable-var-scope --check-prefix=CPU
 
 !BLS377m = !mod_arith.int<258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 : i384, true>
@@ -36,7 +39,7 @@ func.func @gpu_mont_mul_multi_limb(%a : !BLS377m, %b : !BLS377m) -> !BLS377m {
 // -----
 
 // secp256k1 base field (p > 2^255, sign bit set): CIOS gate rejects sign-bit-set
-// moduli, so even under target=gpu this falls back to the wide-int path.
+// moduli, so even under limb-bits=32 this falls back to the wide-int path.
 !Secpm = !mod_arith.int<115792089237316195423570985008687907853269984665640564039457584007908834671663 : i256, true>
 
 // GPU-LABEL: @gpu_mont_mul_sign_bit_set
@@ -135,7 +138,7 @@ func.func @gpu_square_multi_limb(%a : !BLS377m) -> !BLS377m {
 
 // BabyBear (p = 2013265921, i32, Montgomery): single-limb type never routes
 // through the 12-limb CIOS path — reduceSingleLimb is used unchanged under
-// target=gpu. The lowering uses i32 extended multiplies, not the i64 limb
+// limb-bits=32. The lowering uses i32 extended multiplies, not the i64 limb
 // accumulations of CIOS.
 !BBm = !mod_arith.int<2013265921 : i32, true>
 

--- a/tests/Dialect/ModArith/mod_arith_to_arith_gpu.mlir
+++ b/tests/Dialect/ModArith/mod_arith_to_arith_gpu.mlir
@@ -45,3 +45,88 @@ func.func @gpu_mont_mul_sign_bit_set(%a : !Secpm, %b : !Secpm) -> !Secpm {
   %r = mod_arith.mont_mul %a, %b : !Secpm
   return %r : !Secpm
 }
+
+// -----
+
+!BLS377m = !mod_arith.int<258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 : i384, true>
+
+// mont_square routes through emitMontMul(input, input): 32-bit-limb CIOS, so
+// the wide product/reduce must be gone.
+// GPU-LABEL: @gpu_mont_square_multi_limb
+// GPU: arith.muli {{.*}} : i64
+// GPU-NOT: arith.mului_extended {{.*}} : i384
+// GPU: return {{.*}} : i384
+// CPU-LABEL: @gpu_mont_square_multi_limb
+// CPU: arith.mului_extended {{.*}} : i384
+func.func @gpu_mont_square_multi_limb(%a : !BLS377m) -> !BLS377m {
+  %r = mod_arith.mont_square %a : !BLS377m
+  return %r : !BLS377m
+}
+
+// -----
+
+!BLS377m = !mod_arith.int<258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 : i384, true>
+!BLS377 = !mod_arith.int<258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 : i384>
+
+// mont_reduce routes through emitRedc: 32-bit-limb CIOS REDC, so the wide
+// mont reducer's product/reduce must be gone.
+// GPU-LABEL: @gpu_mont_reduce_multi_limb
+// GPU: arith.muli {{.*}} : i64
+// GPU-NOT: arith.mului_extended {{.*}} : i384
+// GPU: return {{.*}} : i384
+// CPU-LABEL: @gpu_mont_reduce_multi_limb
+// CPU: arith.mului_extended {{.*}} : i384
+func.func @gpu_mont_reduce_multi_limb(%lo : i384, %hi : i384) -> !BLS377 {
+  %r = mod_arith.mont_reduce %lo, %hi : i384 -> !BLS377
+  return %r : !BLS377
+}
+
+// -----
+
+!BLS377m = !mod_arith.int<258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 : i384, true>
+!BLS377 = !mod_arith.int<258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 : i384>
+
+// from_mont lowers to mont_reduce(input, 0), inheriting the CIOS REDC path.
+// GPU-LABEL: @gpu_from_mont_multi_limb
+// GPU: arith.muli {{.*}} : i64
+// GPU-NOT: arith.mului_extended {{.*}} : i384
+// GPU: return {{.*}} : i384
+// CPU-LABEL: @gpu_from_mont_multi_limb
+// CPU: arith.mului_extended {{.*}} : i384
+func.func @gpu_from_mont_multi_limb(%a : !BLS377m) -> !BLS377 {
+  %r = mod_arith.from_mont %a : !BLS377
+  return %r : !BLS377
+}
+
+// -----
+
+!BLS377m = !mod_arith.int<258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 : i384, true>
+!BLS377 = !mod_arith.int<258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 : i384>
+
+// to_mont lowers to mont_mul(input, R²), inheriting the CIOS path.
+// GPU-LABEL: @gpu_to_mont_multi_limb
+// GPU: arith.muli {{.*}} : i64
+// GPU-NOT: arith.mului_extended {{.*}} : i384
+// GPU: return {{.*}} : i384
+// CPU-LABEL: @gpu_to_mont_multi_limb
+// CPU: arith.mului_extended {{.*}} : i384
+func.func @gpu_to_mont_multi_limb(%a : !BLS377) -> !BLS377m {
+  %r = mod_arith.to_mont %a : !BLS377m
+  return %r : !BLS377m
+}
+
+// -----
+
+!BLS377m = !mod_arith.int<258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 : i384, true>
+
+// square lowers to mont_square (Montgomery type), inheriting the CIOS path.
+// GPU-LABEL: @gpu_square_multi_limb
+// GPU: arith.muli {{.*}} : i64
+// GPU-NOT: arith.mului_extended {{.*}} : i384
+// GPU: return {{.*}} : i384
+// CPU-LABEL: @gpu_square_multi_limb
+// CPU: arith.mului_extended {{.*}} : i384
+func.func @gpu_square_multi_limb(%a : !BLS377m) -> !BLS377m {
+  %r = mod_arith.square %a : !BLS377m
+  return %r : !BLS377m
+}

--- a/tests/Dialect/ModArith/mod_arith_to_arith_gpu.mlir
+++ b/tests/Dialect/ModArith/mod_arith_to_arith_gpu.mlir
@@ -130,3 +130,20 @@ func.func @gpu_square_multi_limb(%a : !BLS377m) -> !BLS377m {
   %r = mod_arith.square %a : !BLS377m
   return %r : !BLS377m
 }
+
+// -----
+
+// BabyBear (p = 2013265921, i32, Montgomery): single-limb type never routes
+// through the 12-limb CIOS path — reduceSingleLimb is used unchanged under
+// target=gpu. The lowering uses i32 extended multiplies, not the i64 limb
+// accumulations of CIOS.
+!BBm = !mod_arith.int<2013265921 : i32, true>
+
+// GPU-LABEL: @gpu_mont_mul_single_limb_babybear
+// Single-limb path: i32 extended mul present, no i64 CIOS limb products.
+// GPU: arith.mului_extended {{.*}} : i32
+// GPU-NOT: arith.muli {{.*}} : i64
+func.func @gpu_mont_mul_single_limb_babybear(%a : !BBm, %b : !BBm) -> !BBm {
+  %r = mod_arith.mont_mul %a, %b : !BBm
+  return %r : !BBm
+}

--- a/tests/Dialect/ModArith/mod_arith_to_arith_gpu.mlir
+++ b/tests/Dialect/ModArith/mod_arith_to_arith_gpu.mlir
@@ -1,0 +1,47 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// RUN: prime-ir-opt -mod-arith-to-arith=target=gpu -split-input-file %s | FileCheck %s -enable-var-scope --check-prefix=GPU
+// The default (no target) RUN proves the flag actually gates: the same
+// spare-bit BLS377 case keeps the wide-int path.
+// RUN: prime-ir-opt -mod-arith-to-arith -split-input-file %s | FileCheck %s -enable-var-scope --check-prefix=CPU
+
+!BLS377m = !mod_arith.int<258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 : i384, true>
+
+// GPU-LABEL: @gpu_mont_mul_multi_limb
+// 32-bit-limb CIOS: limb products are (i64)a32*b32 accumulations; the wide
+// product/reduce of the cpu path must be gone.
+// GPU: arith.muli {{.*}} : i64
+// GPU-NOT: arith.mului_extended {{.*}} : i384
+// GPU: return {{.*}} : i384
+// CPU-LABEL: @gpu_mont_mul_multi_limb
+// CPU: arith.mului_extended {{.*}} : i384
+func.func @gpu_mont_mul_multi_limb(%a : !BLS377m, %b : !BLS377m) -> !BLS377m {
+  %r = mod_arith.mont_mul %a, %b : !BLS377m
+  return %r : !BLS377m
+}
+
+// -----
+
+// secp256k1 base field (p > 2^255, sign bit set): CIOS gate rejects sign-bit-set
+// moduli, so even under target=gpu this falls back to the wide-int path.
+!Secpm = !mod_arith.int<115792089237316195423570985008687907853269984665640564039457584007908834671663 : i256, true>
+
+// GPU-LABEL: @gpu_mont_mul_sign_bit_set
+// GPU: arith.mului_extended {{.*}} : i256
+func.func @gpu_mont_mul_sign_bit_set(%a : !Secpm, %b : !Secpm) -> !Secpm {
+  %r = mod_arith.mont_mul %a, %b : !Secpm
+  return %r : !Secpm
+}

--- a/tests/Dialect/ModArith/mod_arith_to_arith_gpu_lazy.mlir
+++ b/tests/Dialect/ModArith/mod_arith_to_arith_gpu_lazy.mlir
@@ -13,7 +13,7 @@
 // limitations under the License.
 // ==============================================================================
 
-// Lazy-reduction contract under target=gpu, multi-limb CIOS path.
+// Lazy-reduction contract under limb-bits=32, multi-limb CIOS path.
 //
 // BLS12-377 (p is 377-bit in i384, spare bit clear): setLazyRedcRange accepts
 // it because 2p < 2^384. The CIOS path applies: multi-limb, sign bit clear.
@@ -28,8 +28,8 @@
 // pair (getCanonicalFromExtended(., 2)).  Lazy elides the pair for non-final
 // results, so the count delta is 1 per elided intermediate.
 
-// RUN: prime-ir-opt '-mod-arith-to-arith=target=gpu lazy-reduction=true' -split-input-file %s | FileCheck %s -enable-var-scope --check-prefix=LAZY
-// RUN: prime-ir-opt -mod-arith-to-arith=target=gpu -split-input-file %s | FileCheck %s -enable-var-scope --check-prefix=EAGER
+// RUN: prime-ir-opt '-mod-arith-to-arith=limb-bits=32 lazy-reduction=true' -split-input-file %s | FileCheck %s -enable-var-scope --check-prefix=LAZY
+// RUN: prime-ir-opt -mod-arith-to-arith=limb-bits=32 -split-input-file %s | FileCheck %s -enable-var-scope --check-prefix=EAGER
 
 !Fpm = !mod_arith.int<258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 : i384, true>
 

--- a/tests/Dialect/ModArith/mod_arith_to_arith_gpu_lazy.mlir
+++ b/tests/Dialect/ModArith/mod_arith_to_arith_gpu_lazy.mlir
@@ -1,0 +1,55 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// Lazy-reduction contract under target=gpu, multi-limb CIOS path.
+//
+// BLS12-377 (p is 377-bit in i384, spare bit clear): setLazyRedcRange accepts
+// it because 2p < 2^384. The CIOS path applies: multi-limb, sign bit clear.
+//
+// Invariant under lazy+gpu vs eager+gpu for a chained mont_mul:
+//   eager: 2 arith.minui — one after each CIOS REDC to canonicalise [0,2p)->[0,p)
+//   lazy:  1 arith.minui — the intermediate result feeds the second multiply
+//          without the final conditional subtraction; only the boundary
+//          reduction at return is emitted.
+//
+// Each canonical CIOS REDC tail emits exactly one arith.subi + arith.minui
+// pair (getCanonicalFromExtended(., 2)).  Lazy elides the pair for non-final
+// results, so the count delta is 1 per elided intermediate.
+
+// RUN: prime-ir-opt '-mod-arith-to-arith=target=gpu lazy-reduction=true' -split-input-file %s | FileCheck %s -enable-var-scope --check-prefix=LAZY
+// RUN: prime-ir-opt -mod-arith-to-arith=target=gpu -split-input-file %s | FileCheck %s -enable-var-scope --check-prefix=EAGER
+
+!Fpm = !mod_arith.int<258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 : i384, true>
+
+// LAZY-LABEL: @gpu_cios_lazy_mont_mul_chain
+// CIOS path: 32-bit limb products via i64 multiplies.
+// LAZY: arith.muli {{.*}} : i64
+// LAZY-NOT: arith.mului_extended {{.*}} : i384
+// Intermediate result feeds the second multiply without a canonical reduction:
+// exactly one arith.minui total (the boundary reduction at return).
+// LAZY-COUNT-1: arith.minui
+// LAZY-NOT: arith.minui
+// LAZY: return
+
+// EAGER-LABEL: @gpu_cios_lazy_mont_mul_chain
+// Eager: two arith.minui, one after each CIOS REDC.
+// EAGER-COUNT-2: arith.minui
+// EAGER-NOT: arith.minui
+// EAGER: return
+func.func @gpu_cios_lazy_mont_mul_chain(%a : !Fpm, %b : !Fpm, %c : !Fpm) -> !Fpm {
+  %t = mod_arith.mont_mul %a, %b : !Fpm
+  %r = mod_arith.mont_mul %t, %c : !Fpm
+  return %r : !Fpm
+}


### PR DESCRIPTION
## Description

Montgomery multiply lowering is target-conditioned because the optimal limb
width tracks the native multiplier: NVIDIA has no 64-bit IMAD and `IMAD.WIDE`
is 32×32→64, while CPUs have `MULX` 64×64→128 — so one strategy can't serve
both. `target=gpu` now lowers multi-limb Montgomery ops via a 32-bit-limb CIOS
schedule whose inner step (`(i64)a·b + acc`) selects a single `IMAD.WIDE.U32`;
the CPU path (wide-int, native 64-bit mul) is unchanged. Eligibility is
multi-limb + spare-bit + storage-width%64==0; sign-bit-set and single-limb
moduli keep the existing path. Rationale and the PR1 profiling that motivates
it are on #337.

`fix(mod_arith): reduce b against full-width modulus` is a prerequisite, not
part of the perf change: the CIOS runtime cross-check exposed that `bReduced`
truncated the modulus to 65 bits, so `bInv` — and therefore the default
`reduceMultiLimb` montmul — was wrong at runtime for moduli with bit 64 clear
(BLS12-377). It stayed latent because the runner tests feed constants and
constant-fold via the zk_dtypes evaluator, never executing the lowered REDC.
The new cross-check uses memref-loaded (non-constant) operands so the arith
actually runs, and fails on the default path without the fix.

IMAD.WIDE selection was confirmed on the pinned toolchain (`llc` 23 → `ptxas`
12.9, sm_120) before building the emitter; the emitter schedule was
independently simulated over BLS12-377/BN254/min-width inputs.

Follow-ups (separate): zkx one-line `target=gpu` opt-in + pin bump; the PR3
throughput / MSM-NTT measurement.

## Related Issues/PRs

Part of #337
Fixes #344

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline
