### PR TITLE
fix: convert scf.index_switch in structural type conversion

### DIFF
--- a/prime_ir/Utils/BUILD.bazel
+++ b/prime_ir/Utils/BUILD.bazel
@@ -131,6 +131,7 @@ prime_ir_cc_library(
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:FuncTransforms",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:SCFTransforms",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",

--- a/prime_ir/Utils/ConversionUtils.cpp
+++ b/prime_ir/Utils/ConversionUtils.cpp
@@ -24,6 +24,7 @@ limitations under the License.
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Func/Transforms/FuncConversions.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/Patterns.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -186,6 +187,47 @@ LogicalResult convertAnyOperand(const TypeConverter *typeConverter,
   return success();
 }
 
+namespace {
+// populateSCFStructuralTypeConversionsAndLegality covers scf.for/if/while but
+// not scf.index_switch, so an index_switch carrying converted-away result types
+// (e.g. field.pf -> mod_arith.int) is left unconverted while its body converts,
+// stranding an unresolved materialization at its yields. Convert it the way
+// upstream's ConvertIfOpTypes converts scf.if: clone with converted result
+// types and inline the original regions so the framework recurses into them
+// (the index arg and case attribute are unaffected by the type converter).
+class ConvertIndexSwitchOpTypes
+    : public OpConversionPattern<scf::IndexSwitchOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(scf::IndexSwitchOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type> newResultTypes;
+    if (failed(
+            typeConverter->convertTypes(op.getResultTypes(), newResultTypes)))
+      return rewriter.notifyMatchFailure(op, "could not convert result types");
+
+    auto newOp = scf::IndexSwitchOp::create(rewriter, op.getLoc(),
+                                            newResultTypes, adaptor.getArg(),
+                                            op.getCases(), op.getNumCases());
+
+    // Inline the original regions so the conversion framework keeps converting
+    // the ops (and yields) inside them, rather than cloning them out of its
+    // worklist.
+    rewriter.inlineRegionBefore(op.getDefaultRegion(), newOp.getDefaultRegion(),
+                                newOp.getDefaultRegion().end());
+    for (unsigned i = 0, e = op.getNumCases(); i < e; ++i)
+      rewriter.inlineRegionBefore(op.getCaseRegions()[i],
+                                  newOp.getCaseRegions()[i],
+                                  newOp.getCaseRegions()[i].end());
+
+    rewriter.replaceOp(op, newOp.getResults());
+    return success();
+  }
+};
+} // namespace
+
 void addStructuralConversionPatterns(TypeConverter &typeConverter,
                                      RewritePatternSet &patterns,
                                      ConversionTarget &target) {
@@ -214,6 +256,23 @@ void addStructuralConversionPatterns(TypeConverter &typeConverter,
 
   scf::populateSCFStructuralTypeConversionsAndLegality(typeConverter, patterns,
                                                        target);
+  // Upstream's SCF structural conversion omits scf.index_switch; add it so a
+  // converted-away result type (e.g. field → mod_arith) is rewritten with the
+  // op rather than left for an unresolvable materialization at its yields.
+  patterns.add<ConvertIndexSwitchOpTypes>(typeConverter, patterns.getContext());
+  target.addDynamicallyLegalOp<scf::IndexSwitchOp>(
+      [&](scf::IndexSwitchOp op) { return typeConverter.isLegal(op); });
+  // The upstream populate marks index_switch-parented yields legal (it only
+  // recognizes for/if/while), so the already-registered yield conversion never
+  // fires on them. addDynamicallyLegalOp overwrites, so re-register the whole
+  // predicate with index_switch added — keep the for/if/while arm in sync with
+  // upstream's populateSCFStructuralTypeConversionTarget.
+  target.addDynamicallyLegalOp<scf::YieldOp>([&](scf::YieldOp op) {
+    if (!isa<scf::ForOp, scf::IfOp, scf::WhileOp, scf::IndexSwitchOp>(
+            op->getParentOp()))
+      return true;
+    return typeConverter.isLegal(op.getOperandTypes());
+  });
 }
 
 bool hasConstantOperand(Operation *op) {

--- a/tests/Dialect/Field/scf_index_switch_to_mod_arith.mlir
+++ b/tests/Dialect/Field/scf_index_switch_to_mod_arith.mlir
@@ -1,0 +1,30 @@
+// RUN: prime-ir-opt -field-to-mod-arith -split-input-file %s | FileCheck %s -enable-var-scope
+
+// Upstream's SCF structural type conversion (populateSCFStructuralTypeConversions)
+// covers scf.for/if/while but NOT scf.index_switch. Without the supplementary
+// pattern in addStructuralConversionPatterns, a field-typed index_switch is left
+// unconverted while its body's field ops lower to mod_arith, and the pass fails
+// to legalize an unresolved materialization at the yields. This pins that an
+// index_switch carrying a prime-field result lowers to mod_arith with the op.
+
+!PF = !field.pf<97:i32>
+
+// CHECK-LABEL: @lower_index_switch
+// CHECK-SAME:  (%[[SEL:.*]]: index, %[[A:.*]]: [[T:.*]], %[[B:.*]]: [[T]]) -> [[T]]
+func.func @lower_index_switch(%sel: index, %a: !PF, %b: !PF) -> !PF {
+  // CHECK:      %[[R:.*]] = scf.index_switch %[[SEL]] -> [[T]]
+  // CHECK:        %[[ADD:.*]] = mod_arith.add %[[A]], %[[B]] : [[T]]
+  // CHECK:        scf.yield %[[ADD]] : [[T]]
+  // CHECK:      default
+  // CHECK:        scf.yield %[[A]] : [[T]]
+  // CHECK:      return %[[R]] : [[T]]
+  %res = scf.index_switch %sel -> !PF
+  case 0 {
+    %s = field.add %a, %b : !PF
+    scf.yield %s : !PF
+  }
+  default {
+    scf.yield %a : !PF
+  }
+  return %res : !PF
+}


### PR DESCRIPTION
## What

`addStructuralConversionPatterns` relies on MLIR's
`populateSCFStructuralTypeConversionsAndLegality`, which converts `scf.for`,
`scf.if`, and `scf.while` result types but **not** `scf.index_switch`. So an
`index_switch` carrying a field-typed result is left unconverted while its body
ops convert (e.g. `field.pf` → `mod_arith.int`), and the pass fails to legalize
an unresolved materialization stranded at its yields.

This adds a `ConvertIndexSwitchOpTypes` structural pattern (mirroring upstream's
`ConvertIfOpTypes`: clone with converted result types, inline the original
regions so the framework recurses into them) and extends the `scf.yield`
legality to `index_switch` parents.

## Why

A register-resident GPU emitter (zkx `constraint_eval` loop-form) uses
`scf.index_switch` for per-instruction operand fetch and field-op dispatch. With
a base-field regfile, `field-to-mod-arith` hit exactly this gap. The fix is
general — any `field-to-mod-arith` (or other structural) conversion over an
`index_switch` benefits.

## Test

`tests/Dialect/Field/scf_index_switch_to_mod_arith.mlir` — an `index_switch`
returning a prime-field result lowers to `mod_arith` with the op (failed to
legalize before this change). Full `//tests/Dialect/Field:all` green (50/50).