### PR TITLE
feat(field): general monic modulus through type, folding, and codegen

### DIFF
--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/ExtensionFieldCodeGen.cpp
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/ExtensionFieldCodeGen.cpp
@@ -21,5 +21,6 @@ namespace mlir::prime_ir::field {
 template class ExtensionFieldCodeGen<2, PrimeFieldCodeGen>;
 template class ExtensionFieldCodeGen<3, PrimeFieldCodeGen>;
 template class ExtensionFieldCodeGen<4, PrimeFieldCodeGen>;
+template class ExtensionFieldCodeGen<3, PrimeFieldCodeGen, true>;
 
 } // namespace mlir::prime_ir::field

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/ExtensionFieldCodeGen.h
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/ExtensionFieldCodeGen.h
@@ -35,8 +35,14 @@ limitations under the License.
 
 namespace mlir::prime_ir::field {
 
-// Forward declaration
-template <size_t N, typename BaseFieldT = PrimeFieldCodeGen>
+// Forward declaration. GeneralModulus selects the general-monic-modulus
+// variant (uᴺ ≡ Σⱼ mⱼ·uʲ, a DenseIntElementsAttr non-residue on a prime
+// base): it exposes ModulusLowCoeffs(), which zk_dtypes' operation mixins
+// detect to route reduction/inverse through the general fold. The binomial
+// variant must not expose it, or every binomial lowering would emit the
+// general fold's extra multiplies.
+template <size_t N, typename BaseFieldT = PrimeFieldCodeGen,
+          bool GeneralModulus = false>
 class ExtensionFieldCodeGen;
 
 // Helper to select the appropriate base operation class.
@@ -52,9 +58,10 @@ struct ExtensionFieldOperationBase {
 
 namespace zk_dtypes {
 
-template <size_t N, typename BaseFieldT>
+template <size_t N, typename BaseFieldT, bool GeneralModulus>
 class ExtensionFieldOperationTraits<
-    mlir::prime_ir::field::ExtensionFieldCodeGen<N, BaseFieldT>> {
+    mlir::prime_ir::field::ExtensionFieldCodeGen<N, BaseFieldT,
+                                                 GeneralModulus>> {
 public:
   using BaseField = BaseFieldT;
   static constexpr size_t kDegree = N;
@@ -67,14 +74,20 @@ namespace mlir::prime_ir::field {
 // NOTE(chokobole): This class is not used directly. It is used to generate
 // MLIR operations that implement extension field arithmetic. User should use
 // FieldCodeGen instead.
-template <size_t N, typename BaseFieldT>
+template <size_t N, typename BaseFieldT, bool GeneralModulus>
 class ExtensionFieldCodeGen
     : public ExtensionFieldOperationBase<
-          N, BaseFieldT, ExtensionFieldCodeGen<N, BaseFieldT>>::Type,
-      public VandermondeMatrix<ExtensionFieldCodeGen<N, BaseFieldT>>,
-      public FrobeniusCoeffs<ExtensionFieldCodeGen<N, BaseFieldT>, N> {
+          N, BaseFieldT,
+          ExtensionFieldCodeGen<N, BaseFieldT, GeneralModulus>>::Type,
+      public VandermondeMatrix<
+          ExtensionFieldCodeGen<N, BaseFieldT, GeneralModulus>>,
+      public FrobeniusCoeffs<
+          ExtensionFieldCodeGen<N, BaseFieldT, GeneralModulus>, N> {
   using Base = typename ExtensionFieldOperationBase<
-      N, BaseFieldT, ExtensionFieldCodeGen<N, BaseFieldT>>::Type;
+      N, BaseFieldT,
+      ExtensionFieldCodeGen<N, BaseFieldT, GeneralModulus>>::Type;
+  static_assert(!GeneralModulus || std::is_same_v<BaseFieldT, PrimeFieldCodeGen>,
+                "general-modulus extension fields must have a prime base");
 
 public:
   // Bring base class operators into scope. Without these, the derived class's
@@ -84,15 +97,34 @@ public:
   using Base::operator-;
   // TODO(junbeomlee): Remove these using declarations after refactoring
   // zk_dtypes to not define these methods in QuarticExtensionFieldOperation.
-  using VandermondeMatrix<
-      ExtensionFieldCodeGen<N, BaseFieldT>>::GetVandermondeInverseMatrix;
-  using FrobeniusCoeffs<ExtensionFieldCodeGen<N, BaseFieldT>,
+  using VandermondeMatrix<ExtensionFieldCodeGen<
+      N, BaseFieldT, GeneralModulus>>::GetVandermondeInverseMatrix;
+  using FrobeniusCoeffs<ExtensionFieldCodeGen<N, BaseFieldT, GeneralModulus>,
                         N>::GetFrobeniusCoeffs;
 
   ExtensionFieldCodeGen() = default;
+  template <bool G = GeneralModulus, std::enable_if_t<!G> * = nullptr>
   ExtensionFieldCodeGen(Value value, Value nonResidue)
       : value(value), nonResidue(nonResidue) {}
+  // General-modulus variant: one base-field Value per low coefficient of
+  // uᴺ ≡ Σⱼ mⱼ·uʲ (from ExtensionFieldType::createModulusLowCoeffValues).
+  template <bool G = GeneralModulus, std::enable_if_t<G> * = nullptr>
+  ExtensionFieldCodeGen(Value value, SmallVector<Value, 4> modulusLowCoeffs)
+      : value(value), modulusLowCoeffs(std::move(modulusLowCoeffs)) {}
   ~ExtensionFieldCodeGen() = default;
+
+  // Present only on the general-modulus variant; zk_dtypes' operation mixins
+  // detect this member (it must stay public — the detection trait is not a
+  // friend) and route through the general fold.
+  template <bool G = GeneralModulus, std::enable_if_t<G> * = nullptr>
+  std::array<BaseFieldT, N> ModulusLowCoeffs() const {
+    assert(modulusLowCoeffs.size() == N);
+    std::array<BaseFieldT, N> m;
+    for (size_t i = 0; i < N; ++i) {
+      m[i] = createBaseFieldCodeGen(modulusLowCoeffs[i]);
+    }
+    return m;
+  }
 
   operator Value() const { return value; }
 
@@ -142,7 +174,7 @@ public:
     std::array<BaseFieldT, N> coeffs;
     coeffs[0] = baseConst;
     for (size_t i = 1; i < N; ++i) {
-      coeffs[i] = NonResidue().CreateConst(0);
+      coeffs[i] = baseHandle().CreateConst(0);
     }
     return FromCoeffs(coeffs);
   }
@@ -176,10 +208,21 @@ public:
       coeffs.push_back(static_cast<Value>(values[i]));
     }
     ImplicitLocOpBuilder *b = BuilderContext::GetInstance().Top();
-    return {fromCoeffs(*b, value.getType(), coeffs), nonResidue};
+    Value composed = fromCoeffs(*b, value.getType(), coeffs);
+    if constexpr (GeneralModulus) {
+      return {composed, modulusLowCoeffs};
+    } else {
+      return {composed, nonResidue};
+    }
   }
 
-  BaseFieldT NonResidue() const { return createBaseFieldCodeGen(nonResidue); }
+  // Binomial-only: a general-modulus field has no scalar ξ, and gating the
+  // accessor turns any stray binomial-path call into a compile error instead
+  // of arithmetic on a null Value.
+  template <bool G = GeneralModulus, std::enable_if_t<!G> * = nullptr>
+  BaseFieldT NonResidue() const {
+    return createBaseFieldCodeGen(nonResidue);
+  }
 
   // Limb-aware algorithm selection for quartic extensions.
   // ToomCook's naive Vandermonde 7×7 matrix multiply generates ~30+ non-trivial
@@ -213,17 +256,27 @@ public:
   // Delegates to BaseFieldT::CreateConst() which handles the type-specific
   // logic.
   BaseFieldT createConstBaseField(int64_t x) const {
-    return NonResidue().CreateConst(x);
+    return baseHandle().CreateConst(x);
   }
 
   // Create a rational constant (numerator/denominator) in the base field.
   // Delegates to BaseFieldT::CreateRationalConst() which computes num/denom
   // at compile-time and creates a single constant op.
   BaseFieldT createRationalConstBaseField(int64_t num, int64_t denom) const {
-    return NonResidue().CreateRationalConst(num, denom);
+    return baseHandle().CreateRationalConst(num, denom);
   }
 
 private:
+  // A base-field element usable as a constant-creation handle: the scalar
+  // non-residue for binomial fields, the first modulus coefficient otherwise.
+  BaseFieldT baseHandle() const {
+    if constexpr (GeneralModulus) {
+      return createBaseFieldCodeGen(modulusLowCoeffs[0]);
+    } else {
+      return createBaseFieldCodeGen(nonResidue);
+    }
+  }
+
   BaseFieldT createBaseFieldCodeGen(Value v) const {
     if constexpr (std::is_same_v<BaseFieldT, PrimeFieldCodeGen>) {
       return PrimeFieldCodeGen(v);
@@ -238,13 +291,18 @@ private:
   }
 
   Value value;
+  // Binomial: the scalar ξ constant. General modulus: empty.
   Value nonResidue;
+  // General modulus: one constant per low coefficient of uᴺ ≡ Σⱼ mⱼ·uʲ.
+  // Binomial: empty.
+  SmallVector<Value, 4> modulusLowCoeffs;
 };
 
 // Explicit instantiations for non-tower extension fields
 extern template class ExtensionFieldCodeGen<2, PrimeFieldCodeGen>;
 extern template class ExtensionFieldCodeGen<3, PrimeFieldCodeGen>;
 extern template class ExtensionFieldCodeGen<4, PrimeFieldCodeGen>;
+extern template class ExtensionFieldCodeGen<3, PrimeFieldCodeGen, true>;
 
 // Type aliases for non-tower extension fields (backward compatible)
 using QuadraticExtensionFieldCodeGen =
@@ -252,6 +310,10 @@ using QuadraticExtensionFieldCodeGen =
 using CubicExtensionFieldCodeGen = ExtensionFieldCodeGen<3, PrimeFieldCodeGen>;
 using QuarticExtensionFieldCodeGen =
     ExtensionFieldCodeGen<4, PrimeFieldCodeGen>;
+// General-monic-modulus cubic (e.g. pil2-stark's x³ - x - 1): the general
+// fold + matrix inverse instead of the ξ closed forms.
+using CubicGeneralModulusExtensionFieldCodeGen =
+    ExtensionFieldCodeGen<3, PrimeFieldCodeGen, true>;
 
 // Type aliases for tower extension fields
 // Tower over quadratic: e.g., Fp4 = (Fp2)^2, Fp6 = (Fp2)^3

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/ExtensionFieldCodeGen.h
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/ExtensionFieldCodeGen.h
@@ -86,7 +86,8 @@ class ExtensionFieldCodeGen
   using Base = typename ExtensionFieldOperationBase<
       N, BaseFieldT,
       ExtensionFieldCodeGen<N, BaseFieldT, GeneralModulus>>::Type;
-  static_assert(!GeneralModulus || std::is_same_v<BaseFieldT, PrimeFieldCodeGen>,
+  static_assert(!GeneralModulus ||
+                    std::is_same_v<BaseFieldT, PrimeFieldCodeGen>,
                 "general-modulus extension fields must have a prime base");
 
 public:

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldCodeGen.cpp
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/FieldCodeGen.cpp
@@ -29,6 +29,18 @@ FieldCodeGen::FieldCodeGen(Type type, Value value,
 
   ImplicitLocOpBuilder *b = BuilderContext::GetInstance().Top();
   auto efType = cast<ExtensionFieldType>(type);
+
+  // A dense non-residue on a prime base is the general-monic-modulus
+  // encoding; the tower-signature dispatch below would otherwise pick the
+  // binomial variant, whose lowering misreads the attribute.
+  if (efType.hasGeneralModulus()) {
+    assert(efType.getDegree() == 3 &&
+           "general-modulus lowering is cubic-only for now");
+    codeGen = CubicGeneralModulusExtensionFieldCodeGen(
+        value, efType.createModulusLowCoeffValues(*b));
+    return;
+  }
+
   Value nonResidue = efType.createNonResidueValue(*b);
 
   auto sig = getTowerSignature(efType);
@@ -70,8 +82,9 @@ FieldCodeGen applyBinaryOp(const FieldCodeGen::CodeGenType &a,
 template <typename T>
 struct IsExtensionFieldCodeGen : std::false_type {};
 
-template <size_t N, typename B>
-struct IsExtensionFieldCodeGen<ExtensionFieldCodeGen<N, B>> : std::true_type {
+template <size_t N, typename B, bool G>
+struct IsExtensionFieldCodeGen<ExtensionFieldCodeGen<N, B, G>>
+    : std::true_type {
   using BaseFieldT = B;
 };
 

--- a/prime_ir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.h
+++ b/prime_ir/Dialect/Field/Conversions/FieldToModArith/PrimeFieldCodeGen.h
@@ -38,7 +38,7 @@ class ExtensionFieldOperation;
 namespace mlir::prime_ir::field {
 
 class FieldCodeGen;
-template <size_t N, typename BaseFieldT>
+template <size_t N, typename BaseFieldT, bool GeneralModulus>
 class ExtensionFieldCodeGen;
 
 // NOTE(chokobole): This class is not used directly. It is used to generate
@@ -62,7 +62,7 @@ public:
 
 private:
   friend class FieldCodeGen;
-  template <size_t, typename>
+  template <size_t, typename, bool>
   friend class ExtensionFieldCodeGen;
   template <typename>
   friend class zk_dtypes::QuadraticExtensionFieldOperation;

--- a/prime_ir/Dialect/Field/IR/ExtensionFieldOperation.cpp
+++ b/prime_ir/Dialect/Field/IR/ExtensionFieldOperation.cpp
@@ -21,10 +21,14 @@ namespace mlir::prime_ir::field {
 template class ExtensionFieldOperation<2, PrimeFieldOperation>;
 template class ExtensionFieldOperation<3, PrimeFieldOperation>;
 template class ExtensionFieldOperation<4, PrimeFieldOperation>;
+template class ExtensionFieldOperation<3, PrimeFieldOperation, true>;
 
 template raw_ostream &
 operator<<(raw_ostream &os,
            const ExtensionFieldOperation<2, PrimeFieldOperation> &op);
+template raw_ostream &
+operator<<(raw_ostream &os,
+           const ExtensionFieldOperation<3, PrimeFieldOperation, true> &op);
 template raw_ostream &
 operator<<(raw_ostream &os,
            const ExtensionFieldOperation<3, PrimeFieldOperation> &op);

--- a/prime_ir/Dialect/Field/IR/ExtensionFieldOperation.h
+++ b/prime_ir/Dialect/Field/IR/ExtensionFieldOperation.h
@@ -31,8 +31,15 @@
 
 namespace mlir::prime_ir::field {
 
-// Forward declaration with default base field type
-template <size_t N, typename BaseFieldT = PrimeFieldOperation>
+// Forward declaration with default base field type. GeneralModulus selects
+// the general-monic-modulus variant (uᴺ ≡ Σⱼ mⱼ·uʲ, encoded as a
+// DenseIntElementsAttr non-residue on a prime base): it exposes
+// ModulusLowCoeffs(), which zk_dtypes' operation mixins detect to route
+// reduction/inverse through the general fold. The default (binomial) variant
+// must not expose it, or every binomial field would silently take the
+// general path.
+template <size_t N, typename BaseFieldT = PrimeFieldOperation,
+          bool GeneralModulus = false>
 class ExtensionFieldOperation;
 
 } // namespace mlir::prime_ir::field
@@ -40,9 +47,10 @@ class ExtensionFieldOperation;
 namespace zk_dtypes {
 
 // Traits specialization: supports both prime field base and tower extensions
-template <size_t N, typename BaseFieldT>
-class ExtensionFieldOperationTraits<
-    mlir::prime_ir::field::ExtensionFieldOperation<N, BaseFieldT>> {
+template <size_t N, typename BaseFieldT, bool GeneralModulus>
+class ExtensionFieldOperationTraits<mlir::prime_ir::field::
+                                        ExtensionFieldOperation<
+                                            N, BaseFieldT, GeneralModulus>> {
 public:
   using BaseField = BaseFieldT;
   static constexpr size_t kDegree = N;
@@ -65,8 +73,8 @@ struct BaseFieldBitWidth<PrimeFieldOperation> {
   }
 };
 
-template <size_t M, typename InnerBaseT>
-struct BaseFieldBitWidth<ExtensionFieldOperation<M, InnerBaseT>> {
+template <size_t M, typename InnerBaseT, bool G>
+struct BaseFieldBitWidth<ExtensionFieldOperation<M, InnerBaseT, G>> {
   static unsigned get(ExtensionFieldType efType) {
     // For tower extensions, get the bit width from the underlying prime field
     return efType.getBasePrimeField().getTypeSizeInBits();
@@ -94,11 +102,16 @@ public:
 template <typename ExtF, bool IsPrime>
 struct ZkDtypeToExtensionFieldOpImpl;
 
-// Specialization for when BaseField is prime field (non-tower)
+// Specialization for when BaseField is prime field (non-tower). A zk_dtypes
+// type registered with a general monic modulus (it exposes
+// ModulusLowCoeffs()) maps to the general-modulus operation variant.
 template <typename ExtF>
 struct ZkDtypeToExtensionFieldOpImpl<ExtF, true> {
   static constexpr size_t N = ExtF::Config::kDegreeOverBaseField;
-  using type = ExtensionFieldOperation<N, PrimeFieldOperation>;
+  using type =
+      ExtensionFieldOperation<N, PrimeFieldOperation,
+                              zk_dtypes::internal::HasModulusLowCoeffs<
+                                  ExtF>::value>;
 };
 
 // Specialization for when BaseField is extension field (tower)
@@ -198,21 +211,42 @@ ExtensionFieldType convertExtFieldType(ExtensionFieldType ef) {
 // Extension field operation class for compile-time evaluation.
 // Inherits from zk_dtypes CRTP operations for Square/Inverse algorithms.
 // Supports tower extensions via the BaseFieldT template parameter.
-template <size_t N, typename BaseFieldT>
+template <size_t N, typename BaseFieldT, bool GeneralModulus>
 class ExtensionFieldOperation
     : public ExtensionFieldOperationSelector<N>::template Type<
-          ExtensionFieldOperation<N, BaseFieldT>>,
-      public VandermondeMatrix<ExtensionFieldOperation<N, BaseFieldT>> {
+          ExtensionFieldOperation<N, BaseFieldT, GeneralModulus>>,
+      public VandermondeMatrix<
+          ExtensionFieldOperation<N, BaseFieldT, GeneralModulus>> {
   using CRTPBase = typename ExtensionFieldOperationSelector<N>::template Type<
-      ExtensionFieldOperation<N, BaseFieldT>>;
+      ExtensionFieldOperation<N, BaseFieldT, GeneralModulus>>;
 
 public:
   // Override zk_dtypes::VandermondeMatrix::GetVandermondeInverseMatrix to avoid
   // static caching conflicts between Montgomery and standard domains.
-  using VandermondeMatrix<
-      ExtensionFieldOperation<N, BaseFieldT>>::GetVandermondeInverseMatrix;
+  using VandermondeMatrix<ExtensionFieldOperation<
+      N, BaseFieldT, GeneralModulus>>::GetVandermondeInverseMatrix;
   static constexpr bool kIsTower =
       !std::is_same_v<BaseFieldT, PrimeFieldOperation>;
+  // The general-modulus encoding lives on a prime base; a tower over a
+  // general-modulus field is future work.
+  static_assert(!GeneralModulus || !kIsTower,
+                "general-modulus extension fields must have a prime base");
+
+  // Present only on the general-modulus variant: the low coefficients of
+  // uᴺ ≡ Σⱼ mⱼ·uʲ, read off the type's DenseIntElementsAttr non-residue.
+  // zk_dtypes' operation mixins detect this member to route through the
+  // general fold instead of the ξ closed forms — it must stay public, or the
+  // detection trait (not a friend) would silently evaluate false.
+  template <bool G = GeneralModulus, std::enable_if_t<G> * = nullptr>
+  std::array<BaseFieldT, N> ModulusLowCoeffs() const {
+    auto denseAttr = cast<DenseIntElementsAttr>(efType.getNonResidue());
+    std::array<BaseFieldT, N> m;
+    size_t i = 0;
+    for (const APInt &c : denseAttr.getValues<APInt>()) {
+      m[i++] = createBaseFieldOpUnchecked(c, efType);
+    }
+    return m;
+  }
 
   ExtensionFieldOperation() = default;
 
@@ -297,15 +331,31 @@ public:
 
     if constexpr (detail::IsPrimeField<BaseF>::value) {
       // Non-tower: base is prime field
-      IntegerAttr nonResidue =
-          convertToIntegerAttr(context, ExtF::Config::kNonResidue.value());
       auto modulusBits = llvm::bit_ceil(BaseF::Config::kModulusBits);
       IntegerAttr modulus = IntegerAttr::get(
           IntegerType::get(context, modulusBits),
           convertToAPInt(BaseF::Config::kModulus, modulusBits));
       PrimeFieldType pfType =
           PrimeFieldType::get(context, modulus, ExtF::kUseMontgomery);
-      return ExtensionFieldType::get(context, N, pfType, nonResidue);
+      if constexpr (zk_dtypes::internal::HasModulusLowCoeffs<ExtF>::value) {
+        // General monic modulus: encode the low coefficients of
+        // uᴺ ≡ Σⱼ mⱼ·uʲ as a DenseIntElementsAttr (the prime-base dense
+        // encoding ExtensionFieldType reserves for this).
+        SmallVector<APInt> mCoeffs;
+        for (size_t i = 0; i < N; ++i) {
+          mCoeffs.push_back(
+              convertToAPInt(ExtF::Config::kModulusLowCoeffs[i].value()));
+        }
+        auto modulusLowCoeffs = DenseIntElementsAttr::get(
+            RankedTensorType::get({static_cast<int64_t>(N)},
+                                  pfType.getStorageType()),
+            mCoeffs);
+        return ExtensionFieldType::get(context, N, pfType, modulusLowCoeffs);
+      } else {
+        IntegerAttr nonResidue =
+            convertToIntegerAttr(context, ExtF::Config::kNonResidue.value());
+        return ExtensionFieldType::get(context, N, pfType, nonResidue);
+      }
     } else {
       // Tower: base is extension field
       // For tower extensions, non-residue is an element in the base extension
@@ -596,9 +646,9 @@ private:
   template <typename>
   friend class VandermondeMatrix;
 
-  template <size_t N2, typename B2>
-  friend raw_ostream &operator<<(raw_ostream &os,
-                                 const ExtensionFieldOperation<N2, B2> &op);
+  template <size_t N2, typename B2, bool G2>
+  friend raw_ostream &operator<<(
+      raw_ostream &os, const ExtensionFieldOperation<N2, B2, G2> &op);
 
   const std::array<BaseFieldT, N> &ToCoeffs() const { return coeffs; }
 
@@ -766,9 +816,9 @@ private:
   ExtensionFieldType efType;
 };
 
-template <size_t N, typename BaseFieldT>
+template <size_t N, typename BaseFieldT, bool G>
 raw_ostream &operator<<(raw_ostream &os,
-                        const ExtensionFieldOperation<N, BaseFieldT> &op) {
+                        const ExtensionFieldOperation<N, BaseFieldT, G> &op) {
   llvm::interleaveComma(op.coeffs, os, [&](const BaseFieldT &c) { os << c; });
   return os;
 }
@@ -777,6 +827,7 @@ raw_ostream &operator<<(raw_ostream &os,
 extern template class ExtensionFieldOperation<2, PrimeFieldOperation>;
 extern template class ExtensionFieldOperation<3, PrimeFieldOperation>;
 extern template class ExtensionFieldOperation<4, PrimeFieldOperation>;
+extern template class ExtensionFieldOperation<3, PrimeFieldOperation, true>;
 
 extern template raw_ostream &
 operator<<(raw_ostream &os,
@@ -787,6 +838,9 @@ operator<<(raw_ostream &os,
 extern template raw_ostream &
 operator<<(raw_ostream &os,
            const ExtensionFieldOperation<4, PrimeFieldOperation> &op);
+extern template raw_ostream &
+operator<<(raw_ostream &os,
+           const ExtensionFieldOperation<3, PrimeFieldOperation, true> &op);
 
 // Type aliases for non-tower extension fields (backward compatible)
 using QuadraticExtensionFieldOperation =
@@ -795,6 +849,11 @@ using CubicExtensionFieldOperation =
     ExtensionFieldOperation<3, PrimeFieldOperation>;
 using QuarticExtensionFieldOperation =
     ExtensionFieldOperation<4, PrimeFieldOperation>;
+// General-monic-modulus cubic (e.g. pil2-stark's x³ - x - 1 Goldilocks
+// extension): same shape, general fold + matrix inverse instead of the ξ
+// closed forms.
+using CubicGeneralModulusExtensionFieldOperation =
+    ExtensionFieldOperation<3, PrimeFieldOperation, true>;
 
 // Type aliases for tower extension fields
 // Tower over quadratic: e.g., Fp4 = (Fp2)^2, Fp6 = (Fp2)^3

--- a/prime_ir/Dialect/Field/IR/ExtensionFieldOperation.h
+++ b/prime_ir/Dialect/Field/IR/ExtensionFieldOperation.h
@@ -48,9 +48,9 @@ namespace zk_dtypes {
 
 // Traits specialization: supports both prime field base and tower extensions
 template <size_t N, typename BaseFieldT, bool GeneralModulus>
-class ExtensionFieldOperationTraits<mlir::prime_ir::field::
-                                        ExtensionFieldOperation<
-                                            N, BaseFieldT, GeneralModulus>> {
+class ExtensionFieldOperationTraits<
+    mlir::prime_ir::field::ExtensionFieldOperation<N, BaseFieldT,
+                                                   GeneralModulus>> {
 public:
   using BaseField = BaseFieldT;
   static constexpr size_t kDegree = N;
@@ -108,10 +108,9 @@ struct ZkDtypeToExtensionFieldOpImpl;
 template <typename ExtF>
 struct ZkDtypeToExtensionFieldOpImpl<ExtF, true> {
   static constexpr size_t N = ExtF::Config::kDegreeOverBaseField;
-  using type =
-      ExtensionFieldOperation<N, PrimeFieldOperation,
-                              zk_dtypes::internal::HasModulusLowCoeffs<
-                                  ExtF>::value>;
+  using type = ExtensionFieldOperation<
+      N, PrimeFieldOperation,
+      zk_dtypes::internal::HasModulusLowCoeffs<ExtF>::value>;
 };
 
 // Specialization for when BaseField is extension field (tower)
@@ -647,8 +646,8 @@ private:
   friend class VandermondeMatrix;
 
   template <size_t N2, typename B2, bool G2>
-  friend raw_ostream &operator<<(
-      raw_ostream &os, const ExtensionFieldOperation<N2, B2, G2> &op);
+  friend raw_ostream &operator<<(raw_ostream &os,
+                                 const ExtensionFieldOperation<N2, B2, G2> &op);
 
   const std::array<BaseFieldT, N> &ToCoeffs() const { return coeffs; }
 

--- a/prime_ir/Dialect/Field/IR/FieldOperation.cpp
+++ b/prime_ir/Dialect/Field/IR/FieldOperation.cpp
@@ -85,8 +85,8 @@ R applyBinaryOp(const FieldOperation::OperationType &a,
 template <typename T>
 struct IsExtensionFieldOp : std::false_type {};
 
-template <size_t N, typename B>
-struct IsExtensionFieldOp<ExtensionFieldOperation<N, B>> : std::true_type {
+template <size_t N, typename B, bool G>
+struct IsExtensionFieldOp<ExtensionFieldOperation<N, B, G>> : std::true_type {
   using BaseFieldT = B;
 };
 

--- a/prime_ir/Dialect/Field/IR/FieldOperation.h
+++ b/prime_ir/Dialect/Field/IR/FieldOperation.h
@@ -110,8 +110,11 @@ public:
     if constexpr (F::ExtensionDegree() == 1) {
       return PrimeFieldOperation::fromZkDtype(context, f);
     } else {
-      constexpr size_t N = F::Config::kDegreeOverBaseField;
-      return ExtensionFieldOperation<N>::fromZkDtype(context, f);
+      // ZkDtypeToExtensionFieldOp resolves tower structure AND the
+      // general-modulus variant (a modulus-registered zk_dtypes type must
+      // land on the variant whose arithmetic reads the dense modulus).
+      using OpT = typename detail::ZkDtypeToExtensionFieldOp<F>::type;
+      return OpT::fromZkDtype(context, f);
     }
   }
 
@@ -173,6 +176,16 @@ private:
 
   template <typename T>
   void createExtFieldOp(T &&value, ExtensionFieldType efType) {
+    // A dense non-residue on a prime base is the general-monic-modulus
+    // encoding; the tower-signature dispatch below would otherwise pick the
+    // binomial variant, whose arithmetic misreads the attribute.
+    if (efType.hasGeneralModulus()) {
+      assert(efType.getDegree() == 3 &&
+             "general-modulus arithmetic is cubic-only for now");
+      operation = CubicGeneralModulusExtensionFieldOperation(
+          std::forward<T>(value), efType);
+      return;
+    }
     auto sig = getTowerSignature(efType);
 #define CREATE_EXT_FIELD_OP(unused_sig, TypeName)                              \
   operation = TypeName(std::forward<T>(value), efType);
@@ -183,6 +196,13 @@ private:
 
   template <typename T>
   void createRawExtFieldOp(T &&value, ExtensionFieldType efType) {
+    if (efType.hasGeneralModulus()) {
+      assert(efType.getDegree() == 3 &&
+             "general-modulus arithmetic is cubic-only for now");
+      operation = CubicGeneralModulusExtensionFieldOperation::fromUnchecked(
+          std::forward<T>(value), efType);
+      return;
+    }
     auto sig = getTowerSignature(efType);
 #define CREATE_RAW_EXT_FIELD_OP(unused_sig, TypeName)                          \
   operation = TypeName::fromUnchecked(std::forward<T>(value), efType);

--- a/prime_ir/Dialect/Field/IR/FieldTypes.cpp
+++ b/prime_ir/Dialect/Field/IR/FieldTypes.cpp
@@ -404,6 +404,22 @@ ExtensionFieldType::verify(function_ref<InFlightDiagnostic()> emitError,
     return success();
   }
 
+  // A DenseIntElementsAttr on a prime base encodes a general monic modulus
+  // uᴺ ≡ Σⱼ mⱼ·uʲ (e.g. pil2-stark's x³ - x - 1 as [1, 1, 0]) rather than a
+  // binomial non-residue. The binomial power test below does not apply, and
+  // irreducibility of a general modulus has no comparably cheap check — it is
+  // the registrant's responsibility (the zk_dtypes dtype this mirrors is
+  // golden-tested against its reference implementation).
+  if (auto denseAttr = dyn_cast<DenseIntElementsAttr>(nonResidue)) {
+    if (denseAttr.getNumElements() != static_cast<int64_t>(degree)) {
+      return emitError() << "modulus low-coefficient count ("
+                         << denseAttr.getNumElements()
+                         << ") must equal the extension degree (" << degree
+                         << ")";
+    }
+    return success();
+  }
+
   // For direct extensions over prime fields, validate that nonResidue is
   // actually a non-residue: nonResidue^((p - 1) / n) ≢ 1 (mod p)
   auto pfType = cast<PrimeFieldType>(baseField);
@@ -454,12 +470,32 @@ Type ExtensionFieldType::parse(AsmParser &parser) {
     return nullptr;
   }
 
-  // Parse non-residue
+  // Parse non-residue: a scalar IntegerAttr (binomial uᴺ - ξ), or on a prime
+  // base a DenseIntElementsAttr of the general monic modulus's low
+  // coefficients (uᴺ ≡ Σⱼ mⱼ·uʲ).
   if (failed(parser.parseComma())) {
     return nullptr;
   }
-  IntegerAttr nonResidue;
-  if (failed(parser.parseAttribute(nonResidue))) {
+  Attribute nonResidueAttr;
+  if (failed(parser.parseAttribute(nonResidueAttr))) {
+    return nullptr;
+  }
+  if (auto denseAttr = dyn_cast<DenseIntElementsAttr>(nonResidueAttr)) {
+    if (auto pfType = dyn_cast<PrimeFieldType>(baseFieldType);
+        pfType && pfType.getIsMontgomery()) {
+      nonResidueAttr = mod_arith::getAttrAsMontgomeryForm(
+          pfType.getModulus(), cast<DenseIntElementsAttr>(nonResidueAttr));
+    }
+    if (failed(parser.parseGreater())) {
+      return nullptr;
+    }
+    return ExtensionFieldType::get(parser.getContext(), degree, baseFieldType,
+                                   nonResidueAttr);
+  }
+  IntegerAttr nonResidue = dyn_cast<IntegerAttr>(nonResidueAttr);
+  if (!nonResidue) {
+    parser.emitError(parser.getCurrentLocation(),
+                     "non-residue must be an integer or dense-int attribute");
     return nullptr;
   }
 
@@ -492,8 +528,15 @@ void ExtensionFieldType::print(AsmPrinter &printer) const {
 
   if (auto pfType = dyn_cast<PrimeFieldType>(baseField)) {
     if (pfType.getIsMontgomery()) {
-      nonResidue = mod_arith::getAttrAsStandardForm(
-          pfType.getModulus(), cast<IntegerAttr>(nonResidue));
+      // Scalar = binomial non-residue; dense = general monic modulus low
+      // coefficients (prime base only).
+      if (auto intAttr = dyn_cast<IntegerAttr>(nonResidue)) {
+        nonResidue =
+            mod_arith::getAttrAsStandardForm(pfType.getModulus(), intAttr);
+      } else {
+        nonResidue = mod_arith::getAttrAsStandardForm(
+            pfType.getModulus(), cast<DenseIntElementsAttr>(nonResidue));
+      }
     }
   } else {
     auto efType = cast<ExtensionFieldType>(baseField);
@@ -669,6 +712,28 @@ Value ExtensionFieldType::createNonResidueValue(
 
   return ConstantOp::materialize(builder, nonResidueAttr, baseEfType,
                                  builder.getLoc());
+}
+
+bool ExtensionFieldType::hasGeneralModulus() const {
+  return isa<PrimeFieldType>(getBaseField()) &&
+         isa<DenseIntElementsAttr>(getNonResidue());
+}
+
+SmallVector<Value> ExtensionFieldType::createModulusLowCoeffValues(
+    ImplicitLocOpBuilder &builder) const {
+  // General-monic-modulus counterpart of createNonResidueValue: one mod_arith
+  // constant per low coefficient of uᴺ ≡ Σⱼ mⱼ·uʲ. Prime base only — a tower
+  // over a general-modulus field is future work.
+  assert(hasGeneralModulus());
+  auto pfType = cast<PrimeFieldType>(getBaseField());
+  auto denseAttr = cast<DenseIntElementsAttr>(getNonResidue());
+  SmallVector<Value> coeffs;
+  for (const APInt &c : denseAttr.getValues<APInt>()) {
+    coeffs.push_back(mod_arith::ConstantOp::create(
+        builder, convertPrimeFieldType(pfType),
+        IntegerAttr::get(pfType.getStorageType(), c)));
+  }
+  return coeffs;
 }
 
 Value ExtensionFieldType::buildStructFromCoeffs(

--- a/prime_ir/Dialect/Field/IR/FieldTypes.td
+++ b/prime_ir/Dialect/Field/IR/FieldTypes.td
@@ -197,7 +197,12 @@ def Field_ExtensionFieldType : Field_Type<"ExtensionField", "ef", [
   let parameters = (ins
     "unsigned": $degree,
     "Type": $baseField,  // Can be PrimeFieldType or ExtensionFieldType
-    "Attribute": $nonResidue  // IntegerAttr for simple, DenseIntElementsAttr for tower
+    // IntegerAttr: binomial non-residue ξ (u^N = ξ).
+    // DenseIntElementsAttr on an extension base: tower non-residue element.
+    // DenseIntElementsAttr on a prime base: the low coefficients of a general
+    // monic modulus u^N = Σⱼ mⱼ·uʲ (e.g. pil2-stark's x³ - x - 1 as
+    // dense<[1, 1, 0]>) — see createModulusLowCoeffValues.
+    "Attribute": $nonResidue
   );
   let extraClassDeclaration = [{
     // Returns the underlying prime field at the base of the tower.
@@ -222,6 +227,16 @@ def Field_ExtensionFieldType : Field_Type<"ExtensionField", "ef", [
 
     // Creates a Value representing the non-residue constant in the base field.
     Value createNonResidueValue(ImplicitLocOpBuilder &builder) const;
+
+    // Returns true if the non-residue attribute encodes a general monic
+    // modulus (dense low coefficients on a prime base) rather than a
+    // binomial non-residue.
+    bool hasGeneralModulus() const;
+
+    // Creates one base-field constant per low coefficient of the general
+    // monic modulus u^N = Σⱼ mⱼ·uʲ. Only valid when hasGeneralModulus().
+    SmallVector<Value> createModulusLowCoeffValues(
+        ImplicitLocOpBuilder &builder) const;
 
     Value buildStructFromCoeffs(ImplicitLocOpBuilder &builder,
                                 Type structType,

--- a/prime_ir/Dialect/Field/IR/PrimeFieldOperation.h
+++ b/prime_ir/Dialect/Field/IR/PrimeFieldOperation.h
@@ -202,7 +202,7 @@ public:
 private:
   friend class FieldOperation;
   // PascalCase methods (zk_dtypes compatible)
-  template <size_t, typename>
+  template <size_t, typename, bool>
   friend class ExtensionFieldOperation;
   template <typename>
   friend class zk_dtypes::QuadraticExtensionFieldOperation;

--- a/prime_ir/Dialect/Field/IR/TowerFieldConfig.h
+++ b/prime_ir/Dialect/Field/IR/TowerFieldConfig.h
@@ -101,6 +101,8 @@ inline SmallVector<unsigned, 4> getTowerSignature(ExtensionFieldType efType) {
                Quadratic##NON_TOWER_SUFFIX,                            \
                Cubic##NON_TOWER_SUFFIX,                                \
                Quartic##NON_TOWER_SUFFIX,                              \
+               /* General monic modulus (dense non-residue, prime base) */ \
+               CubicGeneralModulus##NON_TOWER_SUFFIX,                  \
                /* Depth-1 tower extension fields */                    \
                TowerQuadraticOverQuadratic##TOWER_SUFFIX,              \
                TowerCubicOverQuadratic##TOWER_SUFFIX,                  \

--- a/tests/Dialect/Field/BUILD.bazel
+++ b/tests/Dialect/Field/BUILD.bazel
@@ -78,7 +78,6 @@ prime_ir_cc_test(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@zk_dtypes//zk_dtypes:babybearx4",
-        "@zk_dtypes//zk_dtypes:goldilocks3_pil",
         "@zk_dtypes//zk_dtypes:goldilocksx3",
         "@zk_dtypes//zk_dtypes:mersenne31x2",
         "@zk_dtypes//zk_dtypes:mersenne31x2x2",

--- a/tests/Dialect/Field/BUILD.bazel
+++ b/tests/Dialect/Field/BUILD.bazel
@@ -78,6 +78,7 @@ prime_ir_cc_test(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@zk_dtypes//zk_dtypes:babybearx4",
+        "@zk_dtypes//zk_dtypes:goldilocks3_pil",
         "@zk_dtypes//zk_dtypes:goldilocksx3",
         "@zk_dtypes//zk_dtypes:mersenne31x2",
         "@zk_dtypes//zk_dtypes:mersenne31x2x2",

--- a/tests/Dialect/Field/ExtensionFieldOperationTest.cpp
+++ b/tests/Dialect/Field/ExtensionFieldOperationTest.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include "prime_ir/Dialect/Field/IR/FieldDialect.h"
 #include "prime_ir/Utils/ZkDtypes.h"
 #include "zk_dtypes/include/field/babybear/babybearx4.h"
+#include "zk_dtypes/include/field/goldilocks/goldilocks3_pil.h"
 #include "zk_dtypes/include/field/goldilocks/goldilocksx3.h"
 #include "zk_dtypes/include/field/mersenne31/mersenne31x2.h"
 #include "zk_dtypes/include/field/mersenne31/mersenne31x2x2.h"
@@ -97,6 +98,9 @@ using ExtensionFieldTypes = testing::Types<
     zk_dtypes::Mersenne31X2,
     // degree = 3
     zk_dtypes::GoldilocksX3,
+    // degree = 3, general monic modulus (x^3 - x - 1, pil2-stark's
+    // Goldilocks3): folds through the general-modulus operation variant
+    zk_dtypes::Goldilocks3Pil,
     // degree = 4
     zk_dtypes::BabybearX4,
     // degree = 2 x 2

--- a/tests/Dialect/Field/ExtensionFieldOperationTest.cpp
+++ b/tests/Dialect/Field/ExtensionFieldOperationTest.cpp
@@ -19,7 +19,6 @@ limitations under the License.
 #include "prime_ir/Dialect/Field/IR/FieldDialect.h"
 #include "prime_ir/Utils/ZkDtypes.h"
 #include "zk_dtypes/include/field/babybear/babybearx4.h"
-#include "zk_dtypes/include/field/goldilocks/goldilocks3_pil.h"
 #include "zk_dtypes/include/field/goldilocks/goldilocksx3.h"
 #include "zk_dtypes/include/field/mersenne31/mersenne31x2.h"
 #include "zk_dtypes/include/field/mersenne31/mersenne31x2x2.h"
@@ -96,11 +95,10 @@ MLIRContext ExtensionFieldOperationTest<F>::context;
 using ExtensionFieldTypes = testing::Types<
     // degree = 2
     zk_dtypes::Mersenne31X2,
-    // degree = 3
-    zk_dtypes::GoldilocksX3,
     // degree = 3, general monic modulus (x^3 - x - 1, pil2-stark's
-    // Goldilocks3): folds through the general-modulus operation variant
-    zk_dtypes::Goldilocks3Pil,
+    // Goldilocks3 since zk_dtypes#135): folds through the general-modulus
+    // operation variant
+    zk_dtypes::GoldilocksX3,
     // degree = 4
     zk_dtypes::BabybearX4,
     // degree = 2 x 2

--- a/tests/Dialect/Field/general_modulus_ext_field_to_mod_arith.mlir
+++ b/tests/Dialect/Field/general_modulus_ext_field_to_mod_arith.mlir
@@ -9,7 +9,7 @@
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific Language governing permissions and
+// See the License for the specific language governing permissions and
 // limitations under the License.
 // ==============================================================================
 

--- a/tests/Dialect/Field/general_modulus_ext_field_to_mod_arith.mlir
+++ b/tests/Dialect/Field/general_modulus_ext_field_to_mod_arith.mlir
@@ -1,0 +1,84 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific Language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// RUN: prime-ir-opt -field-to-mod-arith %s | FileCheck %s
+
+// General monic modulus u^3 = 1 + u (x^3 - x - 1, irreducible over F13 —
+// no roots mod 13), encoded as dense low coefficients on a prime base.
+// The pil2-stark Goldilocks3 convention at test size.
+!PF = !field.pf<13:i32>
+!TF = !field.ef<3x!PF, dense<[1, 1, 0]> : tensor<3xi32>>
+
+// Add/sub never touch the modulus: same shape as the binomial lowering.
+// CHECK-LABEL: @test_lower_add
+func.func @test_lower_add(%arg0: !TF, %arg1: !TF) -> !TF {
+    // CHECK-COUNT-2: field.ext_to_coeffs
+    // CHECK-COUNT-3: mod_arith.add
+    // CHECK: field.ext_from_coeffs
+    %0 = field.add %arg0, %arg1 : !TF
+    return %0 : !TF
+}
+
+// CHECK-LABEL: @test_lower_mul
+func.func @test_lower_mul(%arg0: !TF, %arg1: !TF) -> !TF {
+    // The modulus low coefficients materialize as constants (1, 1, 0)...
+    // CHECK-DAG: mod_arith.constant 1 : !z13_i32
+    // CHECK-DAG: mod_arith.constant 0 : !z13_i32
+    // CHECK-COUNT-2: field.ext_to_coeffs
+    // ...and the Karatsuba product folds every overflow coefficient through
+    // them (6 product muls + 2 overflow slots x 3 modulus muls).
+    // CHECK-COUNT-12: mod_arith.mul
+    // CHECK: field.ext_from_coeffs
+    %0 = field.mul %arg0, %arg1 : !TF
+    return %0 : !TF
+}
+
+// CHECK-LABEL: @test_lower_square
+func.func @test_lower_square(%arg0: !TF) -> !TF {
+    // The general modulus routes Square through Karatsuba's generic fold
+    // (CH-SQR2 is binomial-only): 3 coefficient squares + cross/fold muls.
+    // CHECK: field.ext_to_coeffs
+    // CHECK-COUNT-3: mod_arith.square
+    // CHECK: field.ext_from_coeffs
+    %0 = field.square %arg0 : !TF
+    return %0 : !TF
+}
+
+// CHECK-LABEL: @test_lower_inverse
+func.func @test_lower_inverse(%arg0: !TF) -> !TF {
+    // Multiplication-by-x matrix inverse: build x*u and x*u^2 columns
+    // (shift + modulus fold), first-row cofactors, Laplace determinant,
+    // one base inverse, then scale the cofactors.
+    // CHECK: field.ext_to_coeffs
+    // CHECK: mod_arith.inverse
+    // CHECK-COUNT-3: mod_arith.mul
+    // CHECK: field.ext_from_coeffs
+    %inv = field.inverse %arg0 : !TF
+    return %inv : !TF
+}
+
+// The Montgomery variant lowers through the same path; the dense modulus
+// coefficients are stored (and printed) in standard form regardless.
+!PFm = !field.pf<13:i32, true>
+!TFm = !field.ef<3x!PFm, dense<[1, 1, 0]> : tensor<3xi32>>
+
+// CHECK-LABEL: @test_lower_mul_mont
+func.func @test_lower_mul_mont(%arg0: !TFm, %arg1: !TFm) -> !TFm {
+    // CHECK-COUNT-2: field.ext_to_coeffs
+    // CHECK-COUNT-12: mod_arith.mul
+    // CHECK: field.ext_from_coeffs
+    %0 = field.mul %arg0, %arg1 : !TFm
+    return %0 : !TFm
+}


### PR DESCRIPTION
## Description

pil2-stark's Goldilocks cubic extension is x³ − x − 1 — a trinomial, unrepresentable in the binomial uᴺ = ξ that `ExtensionFieldType` and every operation path assumed. zk_dtypes grew a general-modulus registration (fractalyze/zk_dtypes#134, `Goldilocks3Pil`); this PR carries the same design through prime-ir so the dtype folds and lowers correctly, keeping eager (zk_dtypes) and compiled (lowered kernels) arithmetic in lockstep.

Design notes a reviewer can't get from the diff:

- **Encoding**: a `DenseIntElementsAttr` non-residue on a **prime** base means "modulus low coefficients" (the tower encoding is distinguishable by base type), so the type's parameter list and all existing IR forms stay untouched. Irreducibility of a general modulus has no cheap verifier check; the zk_dtypes dtype it mirrors is golden-tested against pil2-proofman.
- **Why a template variant, not a runtime branch**: zk_dtypes routes by compile-time detection of `ModulusLowCoeffs()`. One class exposing it would drag every binomial field through the general fold and change their emitted kernels; the `GeneralModulus` variant keeps binomial lowering byte-identical (existing FileCheck tests pin this). The gated `NonResidue()` turns stray binomial-path calls on a modulus field into compile errors.
- Two traps recorded in comments: the detection trait is not a friend (so `ModulusLowCoeffs()` must be public), and member `static_assert`s fire under explicit instantiation (so constructor variants gate by `enable_if`).
- Frobenius / pairing codegen stay binomial-only by the missing-member contract inherited from zk_dtypes.

**Build/test caveats**: zk_dtypes#134+#135 merged and the pin already points at ec4bf76 (the trinomial goldilocksx3), so this is ready. Verified with `--repo_env=CC=gcc`: the system clang-21 21.1.8-6ubuntu1 (2026-06-07 apt) segfaults deterministically on upstream `mlir/lib/IR/BuiltinDialectBytecode.cpp`, unrelated to this change. Six FileCheck tests (`cubic/quartic_ext_field_to_mod_arith`, `phi_m_limb_known_modulus`, `field_to_mod_arith_and_canonicalize`, EC canonicalize) fail identically **with the diff stashed** on base ba092859 — pre-existing, not introduced here.

## Related Issues/PRs

Depends on fractalyze/zk_dtypes#134. Part of fractalyze/zk_dtypes#133's sequenced goldilocksx3 swap (step 2 of the plan recorded there).

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline