### PR TITLE
build: bump zk_dtypes to ec4bf76af408

### DIFF
--- a/third_party/zk_dtypes/workspace.bzl
+++ b/third_party/zk_dtypes/workspace.bzl
@@ -17,8 +17,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def repo():
-    ZK_DTYPES_COMMIT = "61b007aa315731a392a6c14f9f626c01381eeb38"
-    ZK_DTYPES_SHA256 = "909ec2feea97f2fc8e86bd3abed914d807eb7058ec0456359c9e3ec24c1ac6dd"
+    ZK_DTYPES_COMMIT = "ec4bf76af408bd1aa864177bd9c5fdef58804e2d"
+    ZK_DTYPES_SHA256 = "c27e21c6748626dc787413d9ea5c064c4ebf7ebda141c93c2f0df5b30cc22234"
     http_archive(
         name = "zk_dtypes",
         sha256 = ZK_DTYPES_SHA256,


### PR DESCRIPTION
Automated pin bump of `zk_dtypes` to [`ec4bf76af408`](https://github.com/fractalyze/zk_dtypes/commit/ec4bf76af408bd1aa864177bd9c5fdef58804e2d).