### PR TITLE
perf(field): add reassociate-field-add pass for rank-ordered add trees

### DIFF
--- a/prime_ir/Dialect/Field/Transforms/BUILD.bazel
+++ b/prime_ir/Dialect/Field/Transforms/BUILD.bazel
@@ -61,3 +61,33 @@ gentbl_cc_library(
         "@llvm-project//mlir:PassBaseTdFiles",
     ],
 )
+
+prime_ir_cc_library(
+    name = "ReassociateFieldAdd",
+    srcs = ["ReassociateFieldAdd.cpp"],
+    hdrs = ["ReassociateFieldAdd.h"],
+    deps = [
+        ":reassociate_field_add_inc_gen",
+        "//prime_ir/Dialect/Field/IR:Field",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+gentbl_cc_library(
+    name = "reassociate_field_add_inc_gen",
+    tbl_outs = {
+        "ReassociateFieldAdd.h.inc": [
+            "-gen-pass-decls",
+            "-name=ReassociateFieldAdd",
+        ],
+    },
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "ReassociateFieldAdd.td",
+    deps = [
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)

--- a/prime_ir/Dialect/Field/Transforms/ReassociateFieldAdd.cpp
+++ b/prime_ir/Dialect/Field/Transforms/ReassociateFieldAdd.cpp
@@ -1,0 +1,193 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "prime_ir/Dialect/Field/Transforms/ReassociateFieldAdd.h"
+
+#include <limits>
+#include <queue>
+#include <vector>
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "mlir/IR/PatternMatch.h"
+#include "prime_ir/Dialect/Field/IR/FieldOps.h"
+
+namespace mlir::prime_ir::field {
+
+#define GEN_PASS_DEF_REASSOCIATEFIELDADD
+#include "prime_ir/Dialect/Field/Transforms/ReassociateFieldAdd.h.inc"
+
+namespace {
+
+// Marks a value whose depth computation is in progress on the explicit DFS
+// stack. Encountering it as an operand means a def-use cycle (possible only
+// in graph regions); the cycle edge is treated as depth 0.
+constexpr unsigned kVisiting = std::numeric_limits<unsigned>::max();
+
+// A field.add whose operands and result all share one type. Mixed-type adds
+// (extension field + base field) change the element type along the chain,
+// so they act as chain boundaries.
+bool isUniformAdd(AddOp add) {
+  if (!add)
+    return false;
+  Type type = add.getOutput().getType();
+  return add.getLhs().getType() == type && add.getRhs().getType() == type;
+}
+
+// SSA depth of the DAG defining `v`: block arguments and zero-operand ops
+// (constants) have depth 0, an op result is 1 + the maximum operand depth.
+// This is the rank used for tree placement — a deep operand is "late" and
+// should fold into the tree last. Iterative so emitter-generated chains
+// thousands of ops deep cannot overflow the C++ stack.
+unsigned getDepth(Value v, DenseMap<Value, unsigned> &memo) {
+  SmallVector<Value> stack{v};
+  while (!stack.empty()) {
+    Value cur = stack.back();
+    auto it = memo.find(cur);
+    if (it != memo.end() && it->second != kVisiting) {
+      stack.pop_back();
+      continue;
+    }
+    Operation *def = cur.getDefiningOp();
+    if (!def || def->getNumOperands() == 0) {
+      memo[cur] = 0;
+      stack.pop_back();
+      continue;
+    }
+    bool operandsReady = true;
+    unsigned maxOperandDepth = 0;
+    for (Value operand : def->getOperands()) {
+      auto operandIt = memo.find(operand);
+      if (operandIt == memo.end()) {
+        stack.push_back(operand);
+        operandsReady = false;
+      } else if (operandIt->second != kVisiting) {
+        maxOperandDepth = std::max(maxOperandDepth, operandIt->second);
+      }
+    }
+    if (operandsReady) {
+      memo[cur] = maxOperandDepth + 1;
+      stack.pop_back();
+    } else {
+      memo[cur] = kVisiting;
+    }
+  }
+  return memo.lookup(v);
+}
+
+// A tree node during reconstruction: `rank` is the depth at which the value
+// is ready, `seq` makes heap ordering deterministic among equal ranks.
+struct Node {
+  Value value;
+  unsigned rank;
+  unsigned seq;
+};
+
+struct NodeGreater {
+  bool operator()(const Node &a, const Node &b) const {
+    return a.rank > b.rank || (a.rank == b.rank && a.seq > b.seq);
+  }
+};
+
+// Rewrites the maximal add-tree rooted at `root` into a rank-ordered
+// balanced tree. Returns false if the tree is too small to profit.
+// `depthMemo` is shared across chains so common upstream DAGs are ranked
+// once per function.
+bool reassociateChain(AddOp root, IRRewriter &rewriter,
+                      DenseMap<Value, unsigned> &depthMemo) {
+  // Collect the leaves of the maximal tree of single-use, same-block,
+  // uniform adds under `root`. `interior` is pre-order (parents first).
+  SmallVector<Value> leaves;
+  SmallVector<Operation *> interior{root};
+  SmallVector<Value> worklist{root.getRhs(), root.getLhs()};
+  while (!worklist.empty()) {
+    Value v = worklist.pop_back_val();
+    auto add = dyn_cast_or_null<AddOp>(v.getDefiningOp());
+    if (isUniformAdd(add) && v.hasOneUse() &&
+        add->getBlock() == root->getBlock()) {
+      interior.push_back(add);
+      worklist.push_back(add.getRhs());
+      worklist.push_back(add.getLhs());
+    } else {
+      leaves.push_back(v);
+    }
+  }
+  // A 2-leaf "chain" is a single add; nothing to rebalance.
+  if (leaves.size() < 3)
+    return false;
+
+  // Rank every leaf, then rebuild Huffman-style: repeatedly combine the two
+  // lowest-rank nodes, the combined sum becoming ready one level later.
+  // Equal-rank leaves pair up into a balanced tree; a late operand (high
+  // rank) is only combined once the rest of the sum has caught up to it,
+  // which keeps it off the critical path.
+  std::priority_queue<Node, std::vector<Node>, NodeGreater> heap;
+  unsigned seq = 0;
+  for (Value leaf : leaves) {
+    heap.push({leaf, getDepth(leaf, depthMemo), seq++});
+  }
+  rewriter.setInsertionPoint(root);
+  while (heap.size() > 1) {
+    Node a = heap.top();
+    heap.pop();
+    Node b = heap.top();
+    heap.pop();
+    auto add = AddOp::create(rewriter, root.getLoc(), a.value, b.value);
+    heap.push({add.getOutput(), std::max(a.rank, b.rank) + 1, seq++});
+  }
+  // Drop memo entries for the values about to be erased: a later allocation
+  // could reuse their storage, and a stale hit would return a bogus depth.
+  for (Operation *op : interior)
+    depthMemo.erase(op->getResult(0));
+  rewriter.replaceOp(root, heap.top().value);
+  // The old interior adds are now dead; pre-order erases users before defs.
+  for (Operation *op : ArrayRef(interior).drop_front())
+    rewriter.eraseOp(op);
+  return true;
+}
+
+} // namespace
+
+struct ReassociateFieldAdd
+    : impl::ReassociateFieldAddBase<ReassociateFieldAdd> {
+  using ReassociateFieldAddBase::ReassociateFieldAddBase;
+
+  void runOnOperation() override {
+    // Collect chain roots first: rewriting invalidates interior ops, and a
+    // walk must not visit erased ops.
+    SmallVector<AddOp> roots;
+    getOperation()->walk([&](AddOp op) {
+      if (!isUniformAdd(op))
+        return;
+      // An add consumed as the single use of a uniform add in the same
+      // block is interior to that user's tree, not a root.
+      if (op.getOutput().hasOneUse()) {
+        auto user = dyn_cast<AddOp>(*op.getOutput().getUsers().begin());
+        if (isUniformAdd(user) && user->getBlock() == op->getBlock())
+          return;
+      }
+      roots.push_back(op);
+    });
+
+    IRRewriter rewriter(&getContext());
+    DenseMap<Value, unsigned> depthMemo;
+    for (AddOp root : roots) {
+      if (reassociateChain(root, rewriter, depthMemo))
+        ++numReassociated;
+    }
+  }
+};
+
+} // namespace mlir::prime_ir::field

--- a/prime_ir/Dialect/Field/Transforms/ReassociateFieldAdd.h
+++ b/prime_ir/Dialect/Field/Transforms/ReassociateFieldAdd.h
@@ -1,0 +1,35 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef PRIME_IR_DIALECT_FIELD_TRANSFORMS_REASSOCIATEFIELDADD_H_
+#define PRIME_IR_DIALECT_FIELD_TRANSFORMS_REASSOCIATEFIELDADD_H_
+
+// IWYU pragma: begin_keep
+// Headers needed for ReassociateFieldAdd.h.inc
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/Pass.h"
+// IWYU pragma: end_keep
+
+namespace mlir::prime_ir::field {
+
+#define GEN_PASS_DECL
+#include "prime_ir/Dialect/Field/Transforms/ReassociateFieldAdd.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "prime_ir/Dialect/Field/Transforms/ReassociateFieldAdd.h.inc" // NOLINT(build/include)
+
+} // namespace mlir::prime_ir::field
+
+#endif // PRIME_IR_DIALECT_FIELD_TRANSFORMS_REASSOCIATEFIELDADD_H_

--- a/prime_ir/Dialect/Field/Transforms/ReassociateFieldAdd.td
+++ b/prime_ir/Dialect/Field/Transforms/ReassociateFieldAdd.td
@@ -1,0 +1,65 @@
+/* Copyright 2026 The PrimeIR Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef PRIME_IR_DIALECT_FIELD_TRANSFORMS_REASSOCIATEFIELDADD_TD_
+#define PRIME_IR_DIALECT_FIELD_TRANSFORMS_REASSOCIATEFIELDADD_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def ReassociateFieldAdd : Pass<"reassociate-field-add", "func::FuncOp"> {
+  let summary = "Rebalance serial field.add chains into rank-ordered trees";
+  let description = [{
+    Field addition is associative and commutative, so a serial reduction
+    chain
+
+      %s1 = field.add %a, %b
+      %s2 = field.add %s1, %c
+      %s3 = field.add %s2, %d
+
+    can be rewritten as a balanced tree
+
+      %t1 = field.add %a, %b
+      %t2 = field.add %c, %d
+      %s3 = field.add %t1, %t2
+
+    without changing a single output value. Only the dependency shape
+    changes: the serial chain has depth n-1 while the tree has depth
+    ceil(log2(n)), which matters because the later `field -> mod_arith ->
+    arith` lowering interleaves canonicalization ops between the adds, so
+    LLVM's `-reassociate` cannot see the associativity post-lowering.
+
+    Operands are placed in the tree by *rank* (SSA depth of the defining
+    chain), LLVM-reassociate style: trees are built by repeatedly combining
+    the two lowest-rank nodes, so a late-arriving operand (e.g. a value at
+    the end of a long multiply chain) folds into the tree last instead of
+    serializing the whole sum behind it.
+
+    The pass only touches maximal chains of same-type `field.add` ops whose
+    intermediate results have a single use; multi-use intermediates and
+    mixed-type adds (extension field + base field) are treated as chain
+    boundaries. The rewrite is count-neutral: n-1 adds before and after.
+
+    This is deliberately a standalone pass rather than a canonicalization
+    pattern: reassociation patterns fight constant-folding canonicalization
+    patterns in a greedy driver, and chain detection wants a single cheap
+    walk, not fixpoint iteration.
+  }];
+  let statistics = [
+    Statistic<"numReassociated", "num-reassociated",
+              "Number of field.add chains rebalanced">,
+  ];
+}
+
+#endif // PRIME_IR_DIALECT_FIELD_TRANSFORMS_REASSOCIATEFIELDADD_TD_

--- a/tests/Dialect/Field/reassociate_add.mlir
+++ b/tests/Dialect/Field/reassociate_add.mlir
@@ -1,0 +1,154 @@
+// Copyright 2026 The PrimeIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ==============================================================================
+
+// RUN: prime-ir-opt -reassociate-field-add %s | FileCheck %s -enable-var-scope
+
+!PF = !field.pf<17:i32>
+!QF = !field.ef<2x!PF, 6:i32>
+
+//===----------------------------------------------------------------------===//
+// Serial chain -> balanced tree
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @serial_chain_to_balanced_tree
+func.func @serial_chain_to_balanced_tree(
+    %a: !PF, %b: !PF, %c: !PF, %d: !PF,
+    %e: !PF, %f: !PF, %g: !PF, %h: !PF) -> !PF {
+  // CHECK: %[[S0:.*]] = field.add %arg0, %arg1
+  // CHECK: %[[S1:.*]] = field.add %arg2, %arg3
+  // CHECK: %[[S2:.*]] = field.add %arg4, %arg5
+  // CHECK: %[[S3:.*]] = field.add %arg6, %arg7
+  // CHECK: %[[S4:.*]] = field.add %[[S0]], %[[S1]]
+  // CHECK: %[[S5:.*]] = field.add %[[S2]], %[[S3]]
+  // CHECK: %[[S6:.*]] = field.add %[[S4]], %[[S5]]
+  // CHECK: return %[[S6]]
+  %0 = field.add %a, %b : !PF
+  %1 = field.add %0, %c : !PF
+  %2 = field.add %1, %d : !PF
+  %3 = field.add %2, %e : !PF
+  %4 = field.add %3, %f : !PF
+  %5 = field.add %4, %g : !PF
+  %6 = field.add %5, %h : !PF
+  return %6 : !PF
+}
+
+//===----------------------------------------------------------------------===//
+// Rank ordering: the operand at the end of a multiply chain is the deepest,
+// so it must fold into the tree last (rightmost operand of the final add),
+// keeping it off the critical path of the other adds.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @rank_orders_deep_operand_last
+func.func @rank_orders_deep_operand_last(
+    %a: !PF, %b: !PF, %c: !PF, %d: !PF, %x: !PF) -> !PF {
+  // CHECK: %[[M1:.*]] = field.mul %arg4, %arg4
+  // CHECK: %[[M2:.*]] = field.mul %[[M1]], %arg4
+  // CHECK: %[[M3:.*]] = field.mul %[[M2]], %arg4
+  // CHECK: %[[S0:.*]] = field.add %arg0, %arg1
+  // CHECK: %[[S1:.*]] = field.add %arg2, %arg3
+  // CHECK: %[[S2:.*]] = field.add %[[S0]], %[[S1]]
+  // CHECK: %[[S3:.*]] = field.add %[[S2]], %[[M3]]
+  // CHECK: return %[[S3]]
+  %m1 = field.mul %x, %x : !PF
+  %m2 = field.mul %m1, %x : !PF
+  %m3 = field.mul %m2, %x : !PF
+  %0 = field.add %m3, %a : !PF
+  %1 = field.add %0, %b : !PF
+  %2 = field.add %1, %c : !PF
+  %3 = field.add %2, %d : !PF
+  return %3 : !PF
+}
+
+//===----------------------------------------------------------------------===//
+// Extension-field chains rebalance the same way.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @ext_field_chain
+func.func @ext_field_chain(%a: !QF, %b: !QF, %c: !QF, %d: !QF) -> !QF {
+  // CHECK: %[[S0:.*]] = field.add %arg0, %arg1
+  // CHECK: %[[S1:.*]] = field.add %arg2, %arg3
+  // CHECK: %[[S2:.*]] = field.add %[[S0]], %[[S1]]
+  // CHECK: return %[[S2]]
+  %0 = field.add %a, %b : !QF
+  %1 = field.add %0, %c : !QF
+  %2 = field.add %1, %d : !QF
+  return %2 : !QF
+}
+
+//===----------------------------------------------------------------------===//
+// Tensor (elementwise) chains are field-like containers and rebalance too.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @tensor_elementwise_chain
+func.func @tensor_elementwise_chain(
+    %a: tensor<2x!PF>, %b: tensor<2x!PF>,
+    %c: tensor<2x!PF>, %d: tensor<2x!PF>) -> tensor<2x!PF> {
+  // CHECK: %[[S0:.*]] = field.add %arg0, %arg1
+  // CHECK: %[[S1:.*]] = field.add %arg2, %arg3
+  // CHECK: %[[S2:.*]] = field.add %[[S0]], %[[S1]]
+  // CHECK: return %[[S2]]
+  %0 = field.add %a, %b : tensor<2x!PF>
+  %1 = field.add %0, %c : tensor<2x!PF>
+  %2 = field.add %1, %d : tensor<2x!PF>
+  return %2 : tensor<2x!PF>
+}
+
+//===----------------------------------------------------------------------===//
+// A single add is not a chain; it must be left untouched.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @single_add_untouched
+func.func @single_add_untouched(%a: !PF, %b: !PF) -> !PF {
+  // CHECK: %[[S:.*]] = field.add %arg0, %arg1
+  // CHECK: return %[[S]]
+  %0 = field.add %a, %b : !PF
+  return %0 : !PF
+}
+
+//===----------------------------------------------------------------------===//
+// A multi-use intermediate is a chain boundary: collapsing it into the
+// outer sum would duplicate work, so both adds stay as written.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @multi_use_intermediate_untouched
+func.func @multi_use_intermediate_untouched(
+    %a: !PF, %b: !PF, %c: !PF) -> (!PF, !PF) {
+  // CHECK: %[[S0:.*]] = field.add %arg0, %arg1
+  // CHECK: %[[S1:.*]] = field.add %[[S0]], %arg2
+  // CHECK: return %[[S0]], %[[S1]]
+  %0 = field.add %a, %b : !PF
+  %1 = field.add %0, %c : !PF
+  return %0, %1 : !PF, !PF
+}
+
+//===----------------------------------------------------------------------===//
+// A mixed-type add (extension field + base field) is a chain boundary, but
+// the uniform sub-chain feeding it still rebalances.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @mixed_type_add_is_boundary
+func.func @mixed_type_add_is_boundary(
+    %a: !PF, %b: !PF, %c: !PF, %d: !PF, %e: !QF) -> !QF {
+  // CHECK: %[[S0:.*]] = field.add %arg0, %arg1
+  // CHECK: %[[S1:.*]] = field.add %arg2, %arg3
+  // CHECK: %[[S2:.*]] = field.add %[[S0]], %[[S1]]
+  // CHECK: %[[R:.*]] = field.add %arg4, %[[S2]] : !field.ef<{{.*}}>, !pf
+  // CHECK: return %[[R]]
+  %0 = field.add %a, %b : !PF
+  %1 = field.add %0, %c : !PF
+  %2 = field.add %1, %d : !PF
+  %3 = field.add %e, %2 : !QF, !PF
+  return %3 : !QF
+}

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -54,6 +54,7 @@ prime_ir_cc_binary(
         "//prime_ir/Dialect/Field/Pipelines:Passes",
         "//prime_ir/Dialect/Field/Transforms:BufferizableOpInterfaceImpl",
         "//prime_ir/Dialect/Field/Transforms:FoldFieldLinalgContraction",
+        "//prime_ir/Dialect/Field/Transforms:ReassociateFieldAdd",
         "//prime_ir/Dialect/ModArith/Conversions/ModArithToArith",
         "//prime_ir/Dialect/ModArith/IR:ModArith",
         "//prime_ir/Dialect/ModArith/Transforms:BufferizableOpInterfaceImpl",

--- a/tools/prime-ir-opt.cpp
+++ b/tools/prime-ir-opt.cpp
@@ -33,6 +33,7 @@ limitations under the License.
 #include "prime_ir/Dialect/Field/Pipelines/Passes.h"
 #include "prime_ir/Dialect/Field/Transforms/BufferizableOpInterfaceImpl.h"
 #include "prime_ir/Dialect/Field/Transforms/FoldFieldLinalgContraction.h"
+#include "prime_ir/Dialect/Field/Transforms/ReassociateFieldAdd.h"
 #include "prime_ir/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.h"
 #include "prime_ir/Dialect/ModArith/IR/ModArithDialect.h"
 #include "prime_ir/Dialect/ModArith/Transforms/BufferizableOpInterfaceImpl.h"
@@ -76,6 +77,7 @@ int main(int argc, char **argv) {
   mlir::prime_ir::elliptic_curve::registerEllipticCurveToLLVMPasses();
   mlir::prime_ir::tensor_ext::registerTensorExtToTensorPasses();
   mlir::prime_ir::field::registerFoldFieldLinalgContractionPasses();
+  mlir::prime_ir::field::registerReassociateFieldAddPasses();
 
   mlir::prime_ir::field::registerFieldPipelines();
 


### PR DESCRIPTION
## Description

PR1 of the two-PR plan on #358: the dialect-level home for what zkx's Poseidon2 emitter currently hand-schedules (zkx#620/#625's balanced add trees). Associativity of `field.add` is only visible at this level — after `field → mod_arith → arith` lowering, canonicalization ops sit between the adds and LLVM's `-reassociate` cannot re-tree them.

Reviewer context the diff doesn't show:

- Ranks are SSA depths and the tree is built by repeatedly combining the two lowest-rank nodes (the combined sum is ready one level later). Equal-rank operands pair into a balanced tree; a late operand — an S-box output at the end of a multiply chain — folds in last. That rank ordering is what subsumes the zkx#620 hand schedule; naive rebalancing would put the late operand back on the critical path.
- Standalone pass, not canonicalization patterns: reassociation under a greedy driver fights constant-folding patterns (cf. the #343 reassoc-cycle fix), and chain detection wants one cheap walk.
- Mixed-type adds (ef + base pf) and multi-use intermediates are chain boundaries; the rewrite is count-neutral (n−1 adds before and after) and byte-identical by mod-p associativity.
- Per the infra-with-consumer rule, the consumer validation lands with PR2 in zkx (pass wired into the CPU pipeline, emitter trees reverted to serial emission, Poseidon2 byte-match + merkle 65K no-regression vs the 46.0 ns/perm zkx#625 baseline).

Not in scope (recorded in #358): the M₄ 11-add multi-output schedule stays emitter-side — it re-derives different shared partials per output, which a single-chain rewrite cannot discover.

Note: `//tests/Dialect/Field:phi_m_limb_known_modulus` fails on main independently of this change (stale alias CHECKs after the ntt64 zk_dtypes pin bumps).

## Related Issues/PRs

Part of #358 (PR2 in zkx completes the acceptance criteria; do not close on merge)

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline